### PR TITLE
feat: Release radar groupings

### DIFF
--- a/lambdas/common/release_radar_dynamo.py
+++ b/lambdas/common/release_radar_dynamo.py
@@ -6,16 +6,17 @@ Database operations for release radar history table.
 Table Structure:
 - PK: email (string)
 - SK: weekKey (string) - format "YYYY-WW" (e.g., "2025-02")
-- releases: list of release objects
+- releases: list of release objects (flat, ordered by releaseDate desc)
+- groupedReleases: releases grouped by artist, ordered by releaseDate desc
 - stats: { artistCount, releaseCount, trackCount, albumCount, singleCount }
 - playlistId: string
 - startDate: string "YYYY-MM-DD" (Saturday)
-- endDate: string "YYYY-MM-DD" (Friday)
+- endDate: string "YYYY-MM-DD" (Thursday)
 - createdAt: ISO timestamp
 
-Week Definition: Saturday 00:00:00 to Friday 23:59:59
-- Cron runs Saturday morning to process the week that just ended (last Sat - yesterday Fri)
-- This captures all "New Music Friday" releases
+Week Definition: Saturday 00:00:00 to Thursday 23:59:59
+- Cron runs Saturday morning to process the week that just ended (last Sat - yesterday Thu)
+- Friday releases are excluded from the capture window (cutoff is Thursday)
 """
 
 from datetime import datetime, timezone, timedelta
@@ -77,47 +78,52 @@ def get_week_key(target_date: datetime = None) -> str:
 
 def get_previous_week_key() -> str:
     """
-    Get the week key for the PREVIOUS week (the one that just ended Friday).
-    
+    Get the week key for the PREVIOUS week (the one that just ended Thursday).
+
     Used by the cron job which runs Saturday morning to process
-    the week that ended Friday night.
-    
+    the week that ended Thursday night (Friday releases are excluded).
+
     Returns:
-        Week key for last Saturday-Friday
+        Week key for last Saturday-Thursday
     """
-    # Go back 1 day to get into the previous week (from Saturday -> Friday)
+    # Go back 1 day from Saturday to land in Friday, which still belongs to
+    # the previous week (Saturday-Thursday window).
     yesterday = datetime.now() - timedelta(days=1)
     return get_week_key(yesterday)
 
 
 def get_week_date_range(week_key: str) -> tuple[datetime, datetime]:
     """
-    Get the Saturday-Friday date range for a week key.
-    
+    Get the Saturday-Thursday date range for a week key.
+
+    Friday releases are intentionally excluded from the capture window
+    to avoid double-counting releases that land on Spotify's New Music Friday
+    cutoff of the following week.
+
     Args:
         week_key: Week key in "YYYY-WW" format
-        
+
     Returns:
         Tuple of (start_date, end_date) as datetime objects
         start_date = Saturday 00:00:00
-        end_date = Friday 23:59:59
+        end_date = Thursday 23:59:59
     """
     year, week = map(int, week_key.split('-'))
-    
+
     # Find Monday of that ISO week
     jan_4 = datetime(year, 1, 4)  # Jan 4 is always in week 1
     start_of_week_1 = jan_4 - timedelta(days=jan_4.weekday())  # Monday of week 1
     monday_of_week = start_of_week_1 + timedelta(weeks=week - 1)
-    
+
     # Our week starts on Saturday (5 days after Monday)
     saturday = monday_of_week + timedelta(days=5)
     saturday = saturday.replace(hour=0, minute=0, second=0, microsecond=0)
-    
-    # Friday is 6 days after Saturday
-    friday = saturday + timedelta(days=6)
-    friday = friday.replace(hour=23, minute=59, second=59, microsecond=999999)
-    
-    return saturday, friday
+
+    # Cutoff is Thursday (5 days after Saturday) — Friday excluded
+    thursday = saturday + timedelta(days=5)
+    thursday = thursday.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+    return saturday, thursday
 
 
 def get_current_week_date_range() -> tuple[datetime, datetime]:
@@ -145,6 +151,64 @@ def format_week_display(week_key: str) -> str:
 
 
 # ============================================
+# Release Grouping Helpers
+# ============================================
+
+def group_releases_by_artist(releases: list) -> list:
+    """
+    Group a flat list of releases by artist, ordering releases within each
+    artist group by release date (newest first) and ordering the artist
+    groups themselves by their most-recent release date.
+
+    Args:
+        releases: Flat list of release objects (each has artistId, artistName,
+                  releaseDate, albumName, albumType, etc.)
+
+    Returns:
+        List of artist group dicts, each shaped as::
+
+            {
+                "artistId":   str,
+                "artistName": str,
+                "releases":   [release, ...],   # newest first
+            }
+
+        The outer list is ordered by the newest releaseDate within each
+        artist group (most-recently-active artist first).
+    """
+    artist_map: dict[str, dict] = {}
+
+    for release in releases:
+        artist_id = release.get('artistId') or 'unknown'
+        artist_name = release.get('artistName') or 'Unknown Artist'
+
+        if artist_id not in artist_map:
+            artist_map[artist_id] = {
+                'artistId': artist_id,
+                'artistName': artist_name,
+                'releases': [],
+            }
+
+        artist_map[artist_id]['releases'].append(release)
+
+    # Sort releases within each artist group by releaseDate descending
+    for group in artist_map.values():
+        group['releases'].sort(
+            key=lambda r: r.get('releaseDate') or '',
+            reverse=True,
+        )
+
+    # Sort artist groups by the newest release date in each group
+    grouped = sorted(
+        artist_map.values(),
+        key=lambda g: g['releases'][0].get('releaseDate') or '' if g['releases'] else '',
+        reverse=True,
+    )
+
+    return grouped
+
+
+# ============================================
 # Save Release Radar Week
 # ============================================
 
@@ -156,67 +220,83 @@ def save_release_radar_week(
 ) -> dict:
     """
     Save a week's release radar data to the history table.
-    
+
+    Persists both a flat, date-ordered ``releases`` list and a
+    ``groupedReleases`` list (artist → sorted releases) for use by
+    frontend and email consumers.
+
     Args:
         email: User's email (partition key)
         week_key: Format "YYYY-WW" (sort key)
-        releases: List of release objects
+        releases: Flat list of release objects, ordered by releaseDate desc
         playlist_id: Optional Spotify playlist ID
-        
+
     Returns:
         The saved item
     """
     try:
         log.info(f"Saving release radar week for {email} - {week_key}")
-        
+
         table = dynamodb.Table(RELEASE_RADAR_HISTORY_TABLE_NAME)
-        
+
         # Get date range for this week
         start_date, end_date = get_week_date_range(week_key)
-        
+
+        # Ensure flat list is ordered by releaseDate descending
+        sorted_releases = sorted(
+            releases,
+            key=lambda r: r.get('releaseDate') or '',
+            reverse=True,
+        )
+
         # Calculate stats
         unique_artists = set()
         album_count = 0
         single_count = 0
         total_tracks = 0
-        
-        for r in releases:
+
+        for r in sorted_releases:
             artist_id = r.get('artistId')
             if artist_id:
                 unique_artists.add(artist_id)
-            
+
             album_type = (r.get('albumType') or r.get('album_type') or '').lower()
             if album_type == 'album':
                 album_count += 1
             elif album_type == 'single':
                 single_count += 1
-            
+
             total_tracks += r.get('totalTracks') or r.get('total_tracks') or 1
-        
+
         stats = {
             'artistCount': len(unique_artists),
-            'releaseCount': len(releases),
+            'releaseCount': len(sorted_releases),
             'trackCount': total_tracks,
             'albumCount': album_count,
-            'singleCount': single_count
+            'singleCount': single_count,
         }
-        
+
+        # Build artist-grouped structure
+        grouped_releases = group_releases_by_artist(sorted_releases)
+
         item = {
             'email': email,
             'weekKey': week_key,
-            'releases': releases,
+            'releases': sorted_releases,
+            'groupedReleases': grouped_releases,
             'stats': stats,
             'playlistId': playlist_id,
             'startDate': start_date.strftime('%Y-%m-%d'),
             'endDate': end_date.strftime('%Y-%m-%d'),
-            'createdAt': _get_timestamp()
+            'createdAt': _get_timestamp(),
         }
-        
+
         table.put_item(Item=item)
-        
-        log.info(f"Saved release radar for {email} - {week_key}: {len(releases)} releases")
+
+        log.info(f"Saved release radar for {email} - {week_key}: {len(sorted_releases)} releases "
+                 f"across {len(grouped_releases)} artists")
         return item
-        
+
     except Exception as err:
         log.error(f"Save release radar week failed: {err}")
         raise DynamoDBError(

--- a/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
+++ b/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
@@ -4,14 +4,17 @@ XOMIFY Weekly Release Radar Cron Job
 Processes release radar for all enrolled users.
 
 Schedule: Runs every Saturday morning (~2 AM Eastern)
-Week Definition: Saturday 00:00:00 to Friday 23:59:59
+Week Definition: Saturday 00:00:00 to Thursday 23:59:59
+
+Friday releases are excluded from the capture window so that New Music
+Friday drops are not double-counted across weekly boundaries.
 
 Flow:
-1. Get the PREVIOUS week (last Saturday through yesterday Friday)
+1. Get the PREVIOUS week (last Saturday through last Thursday)
 2. For each enrolled user:
    a. Get all followed artists
-   b. Fetch releases from that week
-   c. Save to DynamoDB history
+   b. Fetch releases from that week (Sat-Thu, Friday excluded)
+   c. Save to DynamoDB history (flat list + artist-grouped structure)
    d. Create/update Spotify playlist
 3. Email sender runs 15 min later
 """
@@ -55,7 +58,7 @@ async def release_radar_cron_job(event) -> tuple[list, list]:
     start_date, end_date = get_week_date_range(week_key)
     
     log.info(f"Processing week: {week_key}")
-    log.info(f"Date range: {start_date.strftime('%Y-%m-%d')} (Sat) to {end_date.strftime('%Y-%m-%d')} (Fri)")
+    log.info(f"Date range: {start_date.strftime('%Y-%m-%d')} (Sat) to {end_date.strftime('%Y-%m-%d')} (Thu) — Friday excluded")
     log.info(f"Display: {format_week_display(week_key)}")
     
     # Get active users
@@ -213,15 +216,20 @@ async def fetch_releases_for_week(
 ) -> list:
     """
     Fetch all releases from followed artists within the week.
-    
+
+    The date window is Saturday 00:00 → Thursday 23:59 (Friday excluded).
+    Results are returned as a flat list ordered by releaseDate descending
+    (newest first). Grouping by artist is performed later in
+    ``save_release_radar_week``.
+
     Args:
         spotify: Spotify client
         artist_ids: List of artist IDs to check
-        start_date: Saturday start of week
-        end_date: Friday end of week
-        
+        start_date: Saturday start of week (00:00:00)
+        end_date: Thursday end of week (23:59:59) — Friday excluded
+
     Returns:
-        List of normalized release objects
+        List of normalized release objects, sorted by releaseDate descending
     """
     releases = []
     seen_ids = set()

--- a/tests/test_release_radar_dynamo.py
+++ b/tests/test_release_radar_dynamo.py
@@ -1,0 +1,129 @@
+"""
+Tests for release_radar_dynamo helpers:
+- group_releases_by_artist
+- get_week_date_range (Thursday cutoff)
+"""
+
+import pytest
+from datetime import datetime
+from lambdas.common.release_radar_dynamo import (
+    group_releases_by_artist,
+    get_week_date_range,
+    get_week_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# group_releases_by_artist
+# ---------------------------------------------------------------------------
+
+def _make_release(artist_id, artist_name, album_name, release_date, album_type="single"):
+    return {
+        "artistId": artist_id,
+        "artistName": artist_name,
+        "albumId": f"{artist_id}-{album_name}",
+        "albumName": album_name,
+        "albumType": album_type,
+        "releaseDate": release_date,
+        "totalTracks": 1,
+    }
+
+
+class TestGroupReleasesByArtist:
+
+    def test_empty_list_returns_empty(self):
+        assert group_releases_by_artist([]) == []
+
+    def test_single_release_single_artist(self):
+        releases = [_make_release("a1", "Artist One", "Album A", "2025-01-10")]
+        grouped = group_releases_by_artist(releases)
+        assert len(grouped) == 1
+        assert grouped[0]["artistId"] == "a1"
+        assert grouped[0]["artistName"] == "Artist One"
+        assert len(grouped[0]["releases"]) == 1
+
+    def test_multiple_releases_same_artist_grouped(self):
+        releases = [
+            _make_release("a1", "Artist One", "Single B", "2025-01-08"),
+            _make_release("a1", "Artist One", "Album A", "2025-01-10", "album"),
+        ]
+        grouped = group_releases_by_artist(releases)
+        assert len(grouped) == 1
+        assert grouped[0]["artistId"] == "a1"
+        # Inner releases sorted newest first
+        assert grouped[0]["releases"][0]["albumName"] == "Album A"
+        assert grouped[0]["releases"][1]["albumName"] == "Single B"
+
+    def test_multiple_artists_ordered_by_newest_release(self):
+        releases = [
+            _make_release("a2", "Artist Two", "Old Single", "2025-01-05"),
+            _make_release("a1", "Artist One", "New Album", "2025-01-12", "album"),
+            _make_release("a3", "Artist Three", "Mid Single", "2025-01-09"),
+        ]
+        grouped = group_releases_by_artist(releases)
+        assert len(grouped) == 3
+        # Outer list should be newest-first
+        assert grouped[0]["artistId"] == "a1"   # 2025-01-12
+        assert grouped[1]["artistId"] == "a3"   # 2025-01-09
+        assert grouped[2]["artistId"] == "a2"   # 2025-01-05
+
+    def test_inner_releases_sorted_newest_first(self):
+        releases = [
+            _make_release("a1", "Artist One", "Older", "2025-01-01"),
+            _make_release("a1", "Artist One", "Newer", "2025-01-10"),
+            _make_release("a1", "Artist One", "Middle", "2025-01-05"),
+        ]
+        grouped = group_releases_by_artist(releases)
+        dates = [r["releaseDate"] for r in grouped[0]["releases"]]
+        assert dates == sorted(dates, reverse=True)
+
+    def test_missing_artist_id_grouped_under_unknown(self):
+        releases = [
+            {"albumName": "Mystery", "releaseDate": "2025-01-01"},
+        ]
+        grouped = group_releases_by_artist(releases)
+        assert len(grouped) == 1
+        assert grouped[0]["artistId"] == "unknown"
+
+    def test_deduplication_across_same_artist(self):
+        """Two releases from same artist should be in one group, not two."""
+        releases = [
+            _make_release("a1", "Artist One", "EP1", "2025-01-07"),
+            _make_release("a1", "Artist One", "EP2", "2025-01-03"),
+        ]
+        grouped = group_releases_by_artist(releases)
+        assert len(grouped) == 1
+        assert len(grouped[0]["releases"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_week_date_range — Thursday cutoff
+# ---------------------------------------------------------------------------
+
+class TestWeekDateRange:
+
+    def test_end_date_is_thursday_not_friday(self):
+        """Week should end on Thursday, not Friday."""
+        week_key = get_week_key(datetime(2025, 1, 18))  # A Saturday
+        start, end = get_week_date_range(week_key)
+        # End should be Thursday (weekday 3)
+        assert end.weekday() == 3, f"Expected Thursday (3), got weekday {end.weekday()}"
+
+    def test_start_date_is_saturday(self):
+        week_key = get_week_key(datetime(2025, 1, 18))
+        start, end = get_week_date_range(week_key)
+        assert start.weekday() == 5, f"Expected Saturday (5), got weekday {start.weekday()}"
+
+    def test_window_is_six_days(self):
+        """Saturday to Thursday is 5 full days apart (6 days inclusive)."""
+        week_key = get_week_key(datetime(2025, 2, 1))
+        start, end = get_week_date_range(week_key)
+        delta = (end.date() - start.date()).days
+        assert delta == 5, f"Expected 5-day gap (Sat→Thu), got {delta}"
+
+    def test_friday_is_excluded_from_range(self):
+        """A release on the Friday after Saturday should not fall in the range."""
+        week_key = get_week_key(datetime(2025, 1, 18))  # Saturday 2025-01-18
+        start, end = get_week_date_range(week_key)
+        friday = start.replace(hour=12) + __import__('datetime').timedelta(days=6)
+        assert not (start <= friday <= end), "Friday should be outside the week range"


### PR DESCRIPTION
Closes #105

## What changed

### 1. Group releases by artist
Added `group_releases_by_artist()` helper in `lambdas/common/release_radar_dynamo.py`.

- Releases are grouped under their artist; each artist group holds a list of that artist's releases sorted newest-first
- Artist groups themselves are ordered by each artist's most-recent release date (most active artist first)
- The grouped structure (`groupedReleases`) is saved alongside the existing flat `releases` list in DynamoDB, so both consumers (frontend, email) can use whichever suits them

### 2. Order by release time
The flat `releases` list is now explicitly sorted by `releaseDate` descending inside `save_release_radar_week()` before being persisted, making the ordering guarantee explicit at the storage layer (not just at fetch time).

### 3. Update cutoff date — remove Friday releases
`get_week_date_range()` previously returned Saturday → **Friday**. It now returns Saturday → **Thursday**.

Friday releases are excluded from the capture window to avoid double-counting releases that straddle Spotify's New Music Friday weekly boundary. Updated all docstrings and log messages accordingly.

## Tests
Added `tests/test_release_radar_dynamo.py` with 11 new passing tests covering:
- `group_releases_by_artist`: grouping, inner/outer ordering, edge cases (missing artist ID, deduplication)
- `get_week_date_range`: Thursday end date, Saturday start, Friday exclusion, 5-day window