### PR TITLE
feat: release radar groupings — artist/album + date ordering + cutoff fix

### DIFF
--- a/lambdas/common/release_radar_dynamo.py
+++ b/lambdas/common/release_radar_dynamo.py
@@ -10,12 +10,12 @@ Table Structure:
 - stats: { artistCount, releaseCount, trackCount, albumCount, singleCount }
 - playlistId: string
 - startDate: string "YYYY-MM-DD" (Saturday)
-- endDate: string "YYYY-MM-DD" (Friday)
+- endDate: string "YYYY-MM-DD" (Thursday)
 - createdAt: ISO timestamp
 
-Week Definition: Saturday 00:00:00 to Friday 23:59:59
-- Cron runs Saturday morning to process the week that just ended (last Sat - yesterday Fri)
-- This captures all "New Music Friday" releases
+Week Definition: Saturday 00:00:00 to Thursday 23:59:59
+- Cron runs Saturday morning to process the week that just ended (last Sat - yesterday Thu)
+- Friday is excluded to avoid capturing back-dated "last Friday" releases
 """
 
 from datetime import datetime, timezone, timedelta
@@ -77,13 +77,14 @@ def get_week_key(target_date: datetime = None) -> str:
 
 def get_previous_week_key() -> str:
     """
-    Get the week key for the PREVIOUS week (the one that just ended Friday).
-    
+    Get the week key for the PREVIOUS week (the one that just ended Thursday).
+
     Used by the cron job which runs Saturday morning to process
-    the week that ended Friday night.
-    
+    the week that ended Thursday night.  Going back one day from Saturday
+    lands on Friday, which still maps to the previous Saturday's week key.
+
     Returns:
-        Week key for last Saturday-Friday
+        Week key for last Saturday-Thursday
     """
     # Go back 1 day to get into the previous week (from Saturday -> Friday)
     yesterday = datetime.now() - timedelta(days=1)
@@ -92,15 +93,18 @@ def get_previous_week_key() -> str:
 
 def get_week_date_range(week_key: str) -> tuple[datetime, datetime]:
     """
-    Get the Saturday-Friday date range for a week key.
-    
+    Get the Saturday-Thursday date range for a week key.
+
+    Friday is excluded so that back-dated "New Music Friday" releases
+    from the prior week are not included in the current week's radar.
+
     Args:
         week_key: Week key in "YYYY-WW" format
-        
+
     Returns:
         Tuple of (start_date, end_date) as datetime objects
         start_date = Saturday 00:00:00
-        end_date = Friday 23:59:59
+        end_date = Thursday 23:59:59
     """
     year, week = map(int, week_key.split('-'))
     
@@ -113,11 +117,12 @@ def get_week_date_range(week_key: str) -> tuple[datetime, datetime]:
     saturday = monday_of_week + timedelta(days=5)
     saturday = saturday.replace(hour=0, minute=0, second=0, microsecond=0)
     
-    # Friday is 6 days after Saturday
-    friday = saturday + timedelta(days=6)
-    friday = friday.replace(hour=23, minute=59, second=59, microsecond=999999)
-    
-    return saturday, friday
+    # Thursday is 5 days after Saturday (exclude Friday to avoid including
+    # "last Friday" releases that Spotify sometimes back-dates into the prior week)
+    thursday = saturday + timedelta(days=5)
+    thursday = thursday.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+    return saturday, thursday
 
 
 def get_current_week_date_range() -> tuple[datetime, datetime]:

--- a/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
+++ b/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
@@ -4,10 +4,11 @@ XOMIFY Weekly Release Radar Cron Job
 Processes release radar for all enrolled users.
 
 Schedule: Runs every Saturday morning (~2 AM Eastern)
-Week Definition: Saturday 00:00:00 to Friday 23:59:59
+Week Definition: Saturday 00:00:00 to Thursday 23:59:59
+(Friday excluded to avoid back-dated "New Music Friday" releases)
 
 Flow:
-1. Get the PREVIOUS week (last Saturday through yesterday Friday)
+1. Get the PREVIOUS week (last Saturday through last Thursday)
 2. For each enrolled user:
    a. Get all followed artists
    b. Fetch releases from that week
@@ -55,7 +56,7 @@ async def release_radar_cron_job(event) -> tuple[list, list]:
     start_date, end_date = get_week_date_range(week_key)
     
     log.info(f"Processing week: {week_key}")
-    log.info(f"Date range: {start_date.strftime('%Y-%m-%d')} (Sat) to {end_date.strftime('%Y-%m-%d')} (Fri)")
+    log.info(f"Date range: {start_date.strftime('%Y-%m-%d')} (Sat) to {end_date.strftime('%Y-%m-%d')} (Thu)")
     log.info(f"Display: {format_week_display(week_key)}")
     
     # Get active users

--- a/lambdas/release_radar_history/handler.py
+++ b/lambdas/release_radar_history/handler.py
@@ -2,6 +2,8 @@
 GET /release-radar/history - Get user's release radar history
 """
 
+from collections import defaultdict
+
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
@@ -16,6 +18,82 @@ log = get_logger(__file__)
 HANDLER = 'release_radar_history'
 
 
+def group_releases(releases: list) -> list:
+    """
+    Group a flat releases list into an artist -> albums structure.
+
+    Releases stored in DynamoDB are album-level objects with fields:
+        albumId, albumName, albumType, artistId, artistName,
+        releaseDate, totalTracks, imageUrl, spotifyUrl, uri
+
+    Returns:
+        List of artist objects sorted alphabetically by artist name.
+        Each artist contains an ``albums`` list sorted by releaseDate descending.
+
+    Example output::
+
+        [
+            {
+                "artistName": "Taylor Swift",
+                "artistId": "06HL4z0CvFAxyc27GXpf02",
+                "albums": [
+                    {
+                        "name": "The Tortured Poets Department",
+                        "id": "5H7ixXZfsNMGbIE5OBSpcb",
+                        "releaseDate": "2024-04-19",
+                        "type": "album",
+                        "uri": "spotify:album:5H7ixXZfsNMGbIE5OBSpcb",
+                        "imageUrl": "https://i.scdn.co/image/...",
+                        "totalTracks": 31,
+                        "spotifyUrl": "https://open.spotify.com/album/..."
+                    }
+                ]
+            }
+        ]
+    """
+    artist_map: dict = defaultdict(lambda: {"name": "", "id": "", "albums": {}})
+
+    for release in releases:
+        artist_id = release.get('artistId') or release.get('artist_id', '')
+        artist_name = release.get('artistName') or release.get('artist_name', 'Unknown Artist')
+        album_id = release.get('albumId') or release.get('album_id', '')
+        album_name = release.get('albumName') or release.get('album_name', 'Unknown Album')
+        release_date = release.get('releaseDate') or release.get('release_date', '')
+
+        artist_map[artist_id]['name'] = artist_name
+        artist_map[artist_id]['id'] = artist_id
+
+        if album_id not in artist_map[artist_id]['albums']:
+            artist_map[artist_id]['albums'][album_id] = {
+                'name': album_name,
+                'id': album_id,
+                'releaseDate': release_date,
+                'type': release.get('albumType') or release.get('album_type', 'album'),
+                'uri': release.get('uri', ''),
+                'imageUrl': release.get('imageUrl') or release.get('image_url', ''),
+                'totalTracks': release.get('totalTracks') or release.get('total_tracks', 1),
+                'spotifyUrl': release.get('spotifyUrl') or release.get('spotify_url', ''),
+            }
+
+    # Build sorted output: artists alphabetical, albums newest-first
+    grouped = []
+    for artist_id, artist_data in sorted(
+        artist_map.items(), key=lambda kv: kv[1]['name'].lower()
+    ):
+        albums = sorted(
+            artist_data['albums'].values(),
+            key=lambda a: a['releaseDate'],
+            reverse=True,
+        )
+        grouped.append({
+            'artistName': artist_data['name'],
+            'artistId': artist_data['id'],
+            'albums': albums,
+        })
+
+    return grouped
+
+
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
@@ -26,9 +104,20 @@ def handler(event, context):
 
     weeks = get_user_release_radar_history(email, limit=limit)
 
-    # Add display name to each week
+    # Enrich each week with display name, sorted flat list, and grouped structure
     for week in weeks:
         week['weekDisplay'] = format_week_display(week.get('weekKey', ''))
+        releases = week.get('releases', [])
+
+        # Sort flat list by releaseDate descending (newest first)
+        week['releases'] = sorted(
+            releases,
+            key=lambda r: r.get('releaseDate') or r.get('release_date', ''),
+            reverse=True,
+        )
+
+        # Add grouped structure (backwards-compatible new field)
+        week['releasesGrouped'] = group_releases(releases)
 
     # Get current week info
     current_week = get_week_key()


### PR DESCRIPTION
## Summary
Implements groupings for release radar as requested in #105.

## Changes
- **Group by artist/album**: New `releasesGrouped` field in API response with structure: `[{artistName, artistId, albums: [{name, id, releaseDate, type, uri, imageUrl, totalTracks}]}]`
- **Order by release time**: Albums sorted by `releaseDate` desc within each artist, artists sorted alphabetically
- **Cutoff fix**: Week window changed from Saturday–Friday to Saturday–Thursday to exclude back-dated "New Music Friday" releases
- **Backwards compatible**: Original flat `releases[]` array preserved and also sorted by releaseDate desc

## Files Changed
- `lambdas/release_radar_history/handler.py` — added `group_releases()` helper, added `releasesGrouped` to response, sorted flat list
- `lambdas/common/release_radar_dynamo.py` — updated `get_week_date_range()` end date from Friday→Thursday
- `lambdas/cron_release_radar/weekly_release_radar_aiohttp.py` — updated docstring/log to reflect Thursday cutoff

Closes #105