### PR TITLE
feat(backend-shares): add shares + invites handlers and common helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,31 @@ Returns user data including enrollment status.
 **POST** `/user/user-table`
 Update user enrollments or refresh token.
 
+### Shares Service (`/shares`)
+
+**POST** `/shares/create`
+Create a new track share. Body: `{ email, trackId, trackUri, trackName, artistName, albumName, albumArtUrl, caption?, moodTag?, genreTags? }`. `moodTag` must be one of `hype|chill|sad|party|focus|discovery`; `caption` max 140 chars; `genreTags` max 3.
+
+**GET** `/shares/feed?email={email}&groupId={optional}&limit={<=100}&before={isoCursor}`
+Merged feed of shares from the requester and their accepted friends, newest first. Returns `{ shares: [...], nextBefore }`.
+
+**DELETE** `/shares/delete?email={email}&shareId={shareId}`
+Delete a share. Returns 204 on success, 401 if the requester is not the owner, 404 if the share does not exist.
+
+**GET** `/shares/user?email={email}&targetEmail={target}&limit={<=100}&before={isoCursor}`
+List shares authored by `targetEmail`, newest first.
+
+**POST** `/shares/react`
+Toggle or set a reaction on a share (see sub-feature #4 for full schema).
+
+### Invites Service (`/invites`)
+
+**POST** `/invites/create`
+Body: `{ email }`. Issues an 8-char base32 invite code. Max 10 outstanding invites per sender (returns 429 if exceeded). Returns `{ inviteCode, inviteUrl, expiresAt, createdAt }`.
+
+**POST** `/invites/accept`
+Body: `{ email, inviteCode }`. Consumes an invite atomically and auto-creates an accepted friendship with the sender. Returns 410 if the invite is expired or already consumed, 409 if the two users are already friends, 400 on self-invite.
+
 ## Environment Setup
 
 ### AWS SSM Parameters Required

--- a/lambdas/common/constants.py
+++ b/lambdas/common/constants.py
@@ -29,6 +29,10 @@ SHARES_TABLE_NAME = os.environ.get('SHARES_TABLE_NAME', '')
 SHARE_INTERACTIONS_TABLE_NAME = os.environ.get('SHARE_INTERACTIONS_TABLE_NAME', '')
 INVITES_TABLE_NAME = os.environ.get('INVITES_TABLE_NAME', '')
 
+# Shares GSI + invite URL template (backend-shares sub-feature)
+SHARES_EMAIL_INDEX = os.environ.get('SHARES_EMAIL_INDEX', 'email-createdAt-index')
+INVITE_URL_TEMPLATE = os.environ.get('INVITE_URL_TEMPLATE', 'https://xomify.app/invite/{code}')
+
 # Email Service
 FROM_EMAIL = os.environ.get('FROM_EMAIL', 'noreply@xomify.xomware.com')
 XOMIFY_URL = "https://xomify.xomware.com"

--- a/lambdas/common/friendships_dynamo.py
+++ b/lambdas/common/friendships_dynamo.py
@@ -192,3 +192,66 @@ def delete_friends(email: str, request_email: str):
             function="reject_friend_request",
             table=FRIENDSHIPS_TABLE_NAME
         )
+
+
+# ============================================
+# Create Accepted Friendship (from invite flow)
+# ============================================
+def create_accepted_friendship(sender_email: str, recipient_email: str):
+    """
+    Write both directional friendship rows in a single transaction with
+    status='accepted' and matching createdAt + acceptedAt timestamps.
+
+    Guarded by attribute_not_exists on both puts so a retry after a partial
+    prior write does not overwrite existing rows (caller should fall back to
+    the existing pending/accept flow if the transaction fails with
+    ConditionalCheckFailedException).
+    """
+    try:
+        client = boto3.client("dynamodb")
+        ts = _get_timestamp()
+
+        client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": FRIENDSHIPS_TABLE_NAME,
+                        "Item": {
+                            "email": {"S": sender_email},
+                            "friendEmail": {"S": recipient_email},
+                            "status": {"S": "accepted"},
+                            "direction": {"S": "outgoing"},
+                            "createdAt": {"S": ts},
+                            "acceptedAt": {"S": ts},
+                        },
+                        "ConditionExpression": "attribute_not_exists(email) AND attribute_not_exists(friendEmail)",
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": FRIENDSHIPS_TABLE_NAME,
+                        "Item": {
+                            "email": {"S": recipient_email},
+                            "friendEmail": {"S": sender_email},
+                            "status": {"S": "accepted"},
+                            "direction": {"S": "incoming"},
+                            "createdAt": {"S": ts},
+                            "acceptedAt": {"S": ts},
+                        },
+                        "ConditionExpression": "attribute_not_exists(email) AND attribute_not_exists(friendEmail)",
+                    }
+                },
+            ]
+        )
+        log.info(
+            f"Accepted friendship created between {sender_email} and {recipient_email}"
+        )
+        return True
+
+    except Exception as err:
+        log.error(f"Create Accepted Friendship error: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="create_accepted_friendship",
+            table=FRIENDSHIPS_TABLE_NAME,
+        )

--- a/lambdas/common/invites_dynamo.py
+++ b/lambdas/common/invites_dynamo.py
@@ -1,22 +1,29 @@
 """
 XOMIFY Invites DynamoDB Helpers
 ===============================
-Database operations for Invites table.
+Database operations for the xomify-invites table.
 
 Table Structure:
-- PK: inviteCode (string, uuid4)
+- PK: inviteCode (string, 8-char base32)
 
 Attributes:
-- email: string (issuer)
-- createdAt: timestamp
-- expiresAt: timestamp
-- status: "pending" | "accepted" | "expired"
-- usedBy: string (optional, set on accept)
+- senderEmail: string
+- createdAt: ISO8601 UTC timestamp
+- expiresAt: ISO8601 UTC timestamp (30 days after createdAt by default)
+- consumedAt: ISO8601 UTC timestamp or absent
+- consumedBy: string (consumer email) or absent
 """
 
+from __future__ import annotations
+
+import base64
+import os
 from datetime import datetime, timezone, timedelta
-from uuid import uuid4
+from typing import Any, Optional
+
 import boto3
+from boto3.dynamodb.conditions import Attr
+from botocore.exceptions import ClientError
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import DynamoDBError
@@ -26,110 +33,180 @@ log = get_logger(__file__)
 
 dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
-INVITE_TTL_DAYS = 7
+INVITE_TTL_DAYS = 30
+INVITE_CODE_LEN = 8
+MAX_OUTSTANDING_INVITES_PER_SENDER = 10
 
 
-def _get_timestamp() -> str:
-    """Get current UTC timestamp."""
-    return datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
-def _get_expiry_timestamp(days: int = INVITE_TTL_DAYS) -> str:
-    """Get UTC timestamp N days from now."""
-    return (datetime.now(timezone.utc) + timedelta(days=days)).strftime('%Y-%m-%d %H:%M:%S')
+def _iso_future(days: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(days=days)).isoformat()
+
+
+def generate_invite_code() -> str:
+    """Generate an 8-char uppercase base32 invite code."""
+    # 5 random bytes -> 8 chars of base32 (no padding needed)
+    return base64.b32encode(os.urandom(5)).decode("ascii")[:INVITE_CODE_LEN].upper()
 
 
 # ============================================
 # Create Invite
 # ============================================
-def create_invite(email: str) -> dict:
+def create_invite(
+    sender_email: str,
+    invite_code: str,
+    ttl_days: int = INVITE_TTL_DAYS,
+) -> dict[str, Any]:
+    """PutItem with attribute_not_exists(inviteCode) — raises on collision."""
     try:
         table = dynamodb.Table(INVITES_TABLE_NAME)
-
-        invite_code = str(uuid4())
-        created_at = _get_timestamp()
-        expires_at = _get_expiry_timestamp()
+        created_at = _iso_now()
+        expires_at = _iso_future(ttl_days)
 
         item = {
             "inviteCode": invite_code,
-            "email": email,
+            "senderEmail": sender_email,
             "createdAt": created_at,
             "expiresAt": expires_at,
-            "status": "pending"
         }
 
-        table.put_item(Item=item)
-        log.info(f"Invite {invite_code} created by {email}")
+        table.put_item(
+            Item=item,
+            ConditionExpression="attribute_not_exists(inviteCode)",
+        )
+        log.info(f"Invite {invite_code} created by {sender_email}")
         return item
 
+    except ClientError as err:
+        # Surface collision so callers can retry with a new code
+        if err.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise
+        log.error(f"Create Invite failed: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="create_invite",
+            table=INVITES_TABLE_NAME,
+        )
     except Exception as err:
         log.error(f"Create Invite failed: {err}")
         raise DynamoDBError(
             message=str(err),
             function="create_invite",
-            table=INVITES_TABLE_NAME
+            table=INVITES_TABLE_NAME,
         )
 
 
 # ============================================
 # Get Invite
 # ============================================
-def get_invite(invite_code: str):
+def get_invite(invite_code: str) -> Optional[dict[str, Any]]:
     try:
         table = dynamodb.Table(INVITES_TABLE_NAME)
         response = table.get_item(Key={"inviteCode": invite_code})
         return response.get("Item")
-
     except Exception as err:
         log.error(f"Get Invite failed: {err}")
         raise DynamoDBError(
             message=str(err),
             function="get_invite",
-            table=INVITES_TABLE_NAME
+            table=INVITES_TABLE_NAME,
         )
 
 
 # ============================================
-# Mark Invite Accepted
+# Consume Invite (atomic)
 # ============================================
-def mark_invite_accepted(invite_code: str, used_by: str):
+def consume_invite(invite_code: str, recipient_email: str) -> dict[str, Any]:
+    """
+    Atomic update: set consumedAt + consumedBy only when the invite is still
+    unconsumed and unexpired. Raises ClientError (ConditionalCheckFailedException)
+    if the invite was already consumed or expired — caller maps to 410.
+    """
     try:
         table = dynamodb.Table(INVITES_TABLE_NAME)
+        now_iso = _iso_now()
 
-        table.update_item(
+        response = table.update_item(
             Key={"inviteCode": invite_code},
-            UpdateExpression="SET #status = :accepted, usedBy = :usedBy, acceptedAt = :ts",
-            ExpressionAttributeNames={
-                "#status": "status"
-            },
+            UpdateExpression="SET consumedAt = :now, consumedBy = :email",
+            ConditionExpression="attribute_not_exists(consumedAt) AND expiresAt > :now",
             ExpressionAttributeValues={
-                ":accepted": "accepted",
-                ":usedBy": used_by,
-                ":ts": _get_timestamp()
-            }
+                ":now": now_iso,
+                ":email": recipient_email,
+            },
+            ReturnValues="ALL_NEW",
         )
-        log.info(f"Invite {invite_code} accepted by {used_by}")
-        return True
+        log.info(f"Invite {invite_code} consumed by {recipient_email}")
+        return response.get("Attributes", {})
 
-    except Exception as err:
-        log.error(f"Mark Invite Accepted failed: {err}")
+    except ClientError as err:
+        if err.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise
+        log.error(f"Consume Invite failed: {err}")
         raise DynamoDBError(
             message=str(err),
-            function="mark_invite_accepted",
-            table=INVITES_TABLE_NAME
+            function="consume_invite",
+            table=INVITES_TABLE_NAME,
+        )
+    except Exception as err:
+        log.error(f"Consume Invite failed: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="consume_invite",
+            table=INVITES_TABLE_NAME,
         )
 
 
 # ============================================
-# Is Invite Expired
+# List Invites By Sender
 # ============================================
-def is_invite_expired(invite: dict) -> bool:
-    expires_at = invite.get("expiresAt")
-    if not expires_at:
-        return False
+def list_invites_by_sender(
+    sender_email: str,
+    active_only: bool = True,
+) -> list[dict[str, Any]]:
+    """
+    Return invites issued by a sender. Uses Scan + FilterExpression because the
+    invites table has no sender GSI in v1 (flagged for follow-up once traffic grows).
+
+    Args:
+        sender_email: sender to match
+        active_only: when True, return only invites that are neither consumed nor expired
+    """
     try:
-        expires_dt = datetime.strptime(expires_at, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
-        return datetime.now(timezone.utc) > expires_dt
+        table = dynamodb.Table(INVITES_TABLE_NAME)
+        now_iso = _iso_now()
+
+        filter_expr = Attr("senderEmail").eq(sender_email)
+        if active_only:
+            filter_expr = (
+                filter_expr
+                & Attr("consumedAt").not_exists()
+                & Attr("expiresAt").gt(now_iso)
+            )
+
+        items: list[dict[str, Any]] = []
+        scan_kwargs: dict[str, Any] = {"FilterExpression": filter_expr}
+        while True:
+            response = table.scan(**scan_kwargs)
+            items.extend(response.get("Items", []))
+            if "LastEvaluatedKey" not in response:
+                break
+            scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+
+        return items
+
     except Exception as err:
-        log.warning(f"Could not parse expiresAt {expires_at}: {err}")
-        return False
+        log.error(f"List Invites By Sender failed: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="list_invites_by_sender",
+            table=INVITES_TABLE_NAME,
+        )
+
+
+def count_outstanding_invites_for_sender(sender_email: str) -> int:
+    """Rate-limit helper — count of non-consumed, non-expired invites for a sender."""
+    return len(list_invites_by_sender(sender_email, active_only=True))

--- a/lambdas/common/shares_dynamo.py
+++ b/lambdas/common/shares_dynamo.py
@@ -1,115 +1,225 @@
 """
 XOMIFY Shares DynamoDB Helpers
 ==============================
-Database operations for Shares table.
+Database operations for the xomify-shares table.
 
 Table Structure:
 - PK: shareId (string)
-- GSI: email-createdAt-index (PK: email, SK: createdAt)
+- GSI: email-createdAt-index (PK=email, SK=createdAt) PROJECTION_ALL
 
 Attributes:
 - shareId: string (uuid4)
 - email: string (author)
-- type: "wrapped" | "release_radar" | "track" | "playlist"
-- payload: dict (type-specific data)
-- caption: string (optional)
-- createdAt: timestamp
+- trackId / trackUri / trackName / artistName / albumName / albumArtUrl: denormalized Spotify metadata
+- caption: string, optional, max 140 chars
+- moodTag: string, optional, one of hype|chill|sad|party|focus|discovery
+- genreTags: list[str], optional, max 3
+- createdAt: ISO8601 UTC timestamp
+- sharedAt: mirror of createdAt (kept for downstream compatibility)
 """
 
+from __future__ import annotations
+
+import concurrent.futures
 from datetime import datetime, timezone
+from typing import Any, Optional
 from uuid import uuid4
+
 import boto3
 from boto3.dynamodb.conditions import Key
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import DynamoDBError
-from lambdas.common.constants import SHARES_TABLE_NAME
+from lambdas.common.constants import SHARES_TABLE_NAME, SHARES_EMAIL_INDEX
 
 log = get_logger(__file__)
 
 dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
 
-def _get_timestamp() -> str:
-    """Get current UTC timestamp."""
-    return datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+def _iso_now() -> str:
+    """Get current UTC timestamp in ISO8601 format."""
+    return datetime.now(timezone.utc).isoformat()
 
 
 # ============================================
 # Create Share
 # ============================================
-def create_share(email: str, share_type: str, payload: dict, caption: str | None = None) -> str:
+def create_share(
+    email: str,
+    track_id: str,
+    track_uri: str,
+    track_name: str,
+    artist_name: str,
+    album_name: str,
+    album_art_url: str,
+    caption: Optional[str] = None,
+    mood_tag: Optional[str] = None,
+    genre_tags: Optional[list[str]] = None,
+) -> dict[str, str]:
+    """Create a share row; returns {shareId, createdAt}."""
     try:
         table = dynamodb.Table(SHARES_TABLE_NAME)
 
         share_id = str(uuid4())
-        timestamp = _get_timestamp()
+        created_at = _iso_now()
 
-        item = {
+        item: dict[str, Any] = {
             "shareId": share_id,
             "email": email,
-            "type": share_type,
-            "payload": payload,
-            "createdAt": timestamp
+            "trackId": track_id,
+            "trackUri": track_uri,
+            "trackName": track_name,
+            "artistName": artist_name,
+            "albumName": album_name,
+            "albumArtUrl": album_art_url,
+            "createdAt": created_at,
+            "sharedAt": created_at,
         }
 
-        if caption:
+        if caption is not None:
             item["caption"] = caption
+        if mood_tag is not None:
+            item["moodTag"] = mood_tag
+        if genre_tags is not None:
+            item["genreTags"] = genre_tags
 
         table.put_item(Item=item)
-        log.info(f"Share {share_id} created by {email} (type={share_type})")
-        return share_id
+        log.info(f"Share {share_id} created by {email} (track={track_id})")
+        return {"shareId": share_id, "createdAt": created_at}
 
     except Exception as err:
         log.error(f"Create Share failed: {err}")
         raise DynamoDBError(
             message=str(err),
             function="create_share",
-            table=SHARES_TABLE_NAME
-        )
-
-
-# ============================================
-# List Shares For User (via GSI)
-# ============================================
-def list_shares_for_user(email: str, limit: int = 20):
-    """
-    Queries the email-createdAt-index GSI to get a user's shares
-    ordered by createdAt desc (newest first).
-    """
-    try:
-        table = dynamodb.Table(SHARES_TABLE_NAME)
-        response = table.query(
-            IndexName="email-createdAt-index",
-            KeyConditionExpression=Key("email").eq(email),
-            ScanIndexForward=False,  # newest first
-            Limit=limit
-        )
-
-        return response["Items"]
-
-    except Exception as err:
-        log.error(f"List Shares For User failed: {err}")
-        raise DynamoDBError(
-            message=str(err),
-            function="list_shares_for_user",
-            table=SHARES_TABLE_NAME
+            table=SHARES_TABLE_NAME,
         )
 
 
 # ============================================
 # Get Share
 # ============================================
-def get_share(share_id: str):
+def get_share(share_id: str) -> Optional[dict[str, Any]]:
+    """Fetch a share by primary key. Returns None on miss."""
     try:
         table = dynamodb.Table(SHARES_TABLE_NAME)
         response = table.get_item(Key={"shareId": share_id})
         return response.get("Item")
-
     except Exception as err:
         log.error(f"Get Share failed: {err}")
         raise DynamoDBError(
             message=str(err),
             function="get_share",
-            table=SHARES_TABLE_NAME
+            table=SHARES_TABLE_NAME,
         )
+
+
+# ============================================
+# Delete Share
+# ============================================
+def delete_share(share_id: str) -> bool:
+    """Delete a share by primary key."""
+    try:
+        table = dynamodb.Table(SHARES_TABLE_NAME)
+        table.delete_item(Key={"shareId": share_id})
+        log.info(f"Share {share_id} deleted")
+        return True
+    except Exception as err:
+        log.error(f"Delete Share failed: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="delete_share",
+            table=SHARES_TABLE_NAME,
+        )
+
+
+# ============================================
+# List Shares For User (via GSI)
+# ============================================
+def list_shares_for_user(
+    email: str,
+    limit: int = 50,
+    before: Optional[str] = None,
+) -> tuple[list[dict[str, Any]], Optional[str]]:
+    """
+    Query email-createdAt-index GSI for a single author's shares, newest first.
+
+    Args:
+        email: author email to query
+        limit: page size (caller should cap)
+        before: ISO8601 createdAt cursor — only items strictly older than this are returned
+                (implemented via ExclusiveStartKey)
+
+    Returns:
+        (items, next_before) — next_before is the createdAt of the last item if a page
+        boundary was reached, else None.
+    """
+    try:
+        table = dynamodb.Table(SHARES_TABLE_NAME)
+
+        query_kwargs: dict[str, Any] = {
+            "IndexName": SHARES_EMAIL_INDEX,
+            "KeyConditionExpression": Key("email").eq(email),
+            "ScanIndexForward": False,
+            "Limit": limit,
+        }
+
+        if before:
+            # ExclusiveStartKey needs all GSI + base-table keys
+            query_kwargs["ExclusiveStartKey"] = {
+                "email": email,
+                "createdAt": before,
+            }
+
+        response = table.query(**query_kwargs)
+        items = response.get("Items", [])
+
+        last_key = response.get("LastEvaluatedKey")
+        next_before = last_key["createdAt"] if last_key and "createdAt" in last_key else None
+
+        return items, next_before
+
+    except Exception as err:
+        log.error(f"List Shares For User failed: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="list_shares_for_user",
+            table=SHARES_TABLE_NAME,
+        )
+
+
+# ============================================
+# Fan-out Feed Query
+# ============================================
+def query_feed_for_emails(
+    emails: list[str],
+    limit: int = 50,
+    before: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """
+    Fan-out across authors in parallel, merge-sort by createdAt desc, return top `limit`.
+
+    `before` applies to every per-email query (filters older than cursor).
+    """
+    if not emails:
+        return []
+
+    all_items: list[dict[str, Any]] = []
+
+    def _fetch(author_email: str) -> list[dict[str, Any]]:
+        try:
+            items, _ = list_shares_for_user(author_email, limit=limit, before=before)
+            return items
+        except Exception as err:
+            log.warning(f"Feed fan-out failed for {author_email}: {err}")
+            return []
+
+    # ThreadPoolExecutor caps at 10 per plan
+    max_workers = min(10, max(1, len(emails)))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
+        for result in ex.map(_fetch, emails):
+            all_items.extend(result)
+
+    all_items.sort(key=lambda s: s.get("createdAt", ""), reverse=True)
+    return all_items[:limit]

--- a/lambdas/invites_accept/handler.py
+++ b/lambdas/invites_accept/handler.py
@@ -1,23 +1,50 @@
 """
-POST /invites/accept - Accept an invite code and auto-friend the issuer
+POST /invites/accept - Consume an invite code and auto-friend the sender.
 """
 
+from datetime import datetime, timezone
+
+from botocore.exceptions import ClientError
+
 from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors, NotFoundError, ValidationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
-from lambdas.common.invites_dynamo import (
-    get_invite,
-    is_invite_expired,
-    mark_invite_accepted,
+from lambdas.common.errors import (
+    handle_errors,
+    NotFoundError,
+    ValidationError,
+    XomifyError,
+    DynamoDBError,
 )
+from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.invites_dynamo import get_invite, consume_invite
 from lambdas.common.friendships_dynamo import (
-    send_friend_request,
-    accept_friend_request,
+    list_all_friends_for_user,
+    create_accepted_friendship,
 )
 
 log = get_logger(__file__)
 
 HANDLER = 'invites_accept'
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        # fromisoformat accepts the isoformat() output produced by _iso_now()
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError:
+        return None
+
+
+def _is_already_friends(email: str, other_email: str) -> bool:
+    friends = list_all_friends_for_user(email)
+    for f in friends:
+        if f.get('friendEmail') == other_email and f.get('status') == 'accepted':
+            return True
+    return False
 
 
 @handle_errors(HANDLER)
@@ -28,7 +55,7 @@ def handler(event, context):
     email = body.get('email')
     invite_code = body.get('inviteCode')
 
-    log.info(f"User {email} attempting to accept invite {invite_code}")
+    log.info(f"User {email} accepting invite {invite_code}")
 
     invite = get_invite(invite_code)
     if not invite:
@@ -36,55 +63,83 @@ def handler(event, context):
             message=f"Invite code {invite_code} not found",
             handler=HANDLER,
             function='handler',
-            resource='invite'
+            resource='invite',
         )
 
-    status = invite.get('status')
-    if status != 'pending':
+    sender_email = invite.get('senderEmail')
+    if not sender_email:
         raise ValidationError(
-            message=f"Invite is not pending (current status: {status})",
+            message="Invite is missing senderEmail",
             handler=HANDLER,
             function='handler',
-            field='status'
+            field='senderEmail',
         )
 
-    if is_invite_expired(invite):
-        raise ValidationError(
-            message="Invite has expired",
-            handler=HANDLER,
-            function='handler',
-            field='expiresAt'
-        )
-
-    issuer_email = invite.get('email')
-    if not issuer_email:
-        raise ValidationError(
-            message="Invite is missing issuer email",
-            handler=HANDLER,
-            function='handler',
-            field='email'
-        )
-
-    if issuer_email == email:
+    if sender_email == email:
         raise ValidationError(
             message="You cannot accept your own invite",
             handler=HANDLER,
             function='handler',
-            field='email'
+            field='email',
         )
 
-    # Mark invite accepted
-    mark_invite_accepted(invite_code, email)
+    # 410 Gone: already consumed
+    if invite.get('consumedAt'):
+        raise XomifyError(
+            message="Invite has already been consumed",
+            handler=HANDLER,
+            function='handler',
+            status=410,
+            details={"error_code": "INVITE_CONSUMED"},
+        )
 
-    # Auto-friend: issuer sends request, acceptor accepts, resulting in immediate friendship
-    log.info(f"Auto-friending {issuer_email} and {email} via invite {invite_code}")
-    send_friend_request(issuer_email, email)
-    accept_friend_request(email, issuer_email)
+    # 410 Gone: expired
+    expires_at = _parse_iso(invite.get('expiresAt'))
+    if expires_at is None or expires_at < datetime.now(timezone.utc):
+        raise XomifyError(
+            message="Invite has expired",
+            handler=HANDLER,
+            function='handler',
+            status=410,
+            details={"error_code": "INVITE_EXPIRED"},
+        )
 
-    log.info(f"Invite {invite_code} accepted and friendship established")
+    # 409 Conflict: already friends
+    if _is_already_friends(email, sender_email):
+        raise XomifyError(
+            message=f"You are already friends with {sender_email}",
+            handler=HANDLER,
+            function='handler',
+            status=409,
+            details={"error_code": "ALREADY_FRIENDS"},
+        )
+
+    # Atomic consume — guards against concurrent accepts
+    try:
+        consume_invite(invite_code, email)
+    except ClientError as err:
+        code = err.response.get("Error", {}).get("Code")
+        if code == "ConditionalCheckFailedException":
+            raise XomifyError(
+                message="Invite is no longer available",
+                handler=HANDLER,
+                function='handler',
+                status=410,
+                details={"error_code": "INVITE_UNAVAILABLE"},
+            )
+        raise DynamoDBError(
+            message=str(err),
+            handler=HANDLER,
+            function='consume_invite',
+        )
+
+    # Establish accepted friendship in one transaction
+    create_accepted_friendship(sender_email, email)
+
+    log.info(f"Invite {invite_code} accepted; {sender_email} <-> {email} now friends")
 
     return success_response({
-        'success': True,
+        'ok': True,
+        'senderEmail': sender_email,
         'inviteCode': invite_code,
-        'friendEmail': issuer_email
     })

--- a/lambdas/invites_create/handler.py
+++ b/lambdas/invites_create/handler.py
@@ -1,16 +1,26 @@
 """
-POST /invites/create - Create a new invite link
+POST /invites/create - Issue a new invite code for a sender (rate-limited).
 """
 
+from botocore.exceptions import ClientError
+
 from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors
+from lambdas.common.errors import handle_errors, ValidationError, XomifyError
 from lambdas.common.utility_helpers import success_response, parse_body, require_fields
-from lambdas.common.invites_dynamo import create_invite
-from lambdas.common.constants import XOMIFY_URL
+from lambdas.common.invites_dynamo import (
+    create_invite,
+    generate_invite_code,
+    count_outstanding_invites_for_sender,
+    MAX_OUTSTANDING_INVITES_PER_SENDER,
+)
+from lambdas.common.constants import INVITE_URL_TEMPLATE
 
 log = get_logger(__file__)
 
 HANDLER = 'invites_create'
+
+# How many distinct codes to try before giving up on collision retries.
+COLLISION_RETRY_LIMIT = 2
 
 
 @handle_errors(HANDLER)
@@ -18,18 +28,51 @@ def handler(event, context):
     body = parse_body(event)
     require_fields(body, 'email')
 
-    email = body.get('email')
+    sender_email = body.get('email')
 
-    log.info(f"User {email} creating invite")
-    invite = create_invite(email)
-    invite_code = invite.get('inviteCode')
-    share_url = f"{XOMIFY_URL}/invite/{invite_code}"
+    # Rate limit — max 10 outstanding invites per sender
+    outstanding = count_outstanding_invites_for_sender(sender_email)
+    log.info(f"{sender_email} has {outstanding} outstanding invites")
+    if outstanding >= MAX_OUTSTANDING_INVITES_PER_SENDER:
+        raise XomifyError(
+            message=f"Max {MAX_OUTSTANDING_INVITES_PER_SENDER} outstanding invites",
+            handler=HANDLER,
+            function='handler',
+            status=429,
+            details={"field": "rateLimit"},
+        )
 
-    log.info(f"Invite {invite_code} issued for {email}")
+    last_err: Exception | None = None
+    item = None
+    for attempt in range(COLLISION_RETRY_LIMIT + 1):
+        code = generate_invite_code()
+        try:
+            item = create_invite(sender_email, code)
+            break
+        except ClientError as err:
+            if err.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                log.warning(f"Invite code collision on attempt {attempt + 1}: {code}")
+                last_err = err
+                continue
+            raise
+
+    if item is None:
+        log.error(f"Exhausted {COLLISION_RETRY_LIMIT + 1} invite code attempts")
+        raise ValidationError(
+            message="Could not allocate a unique invite code, try again",
+            handler=HANDLER,
+            function='handler',
+            field='inviteCode',
+        )
+
+    invite_code = item['inviteCode']
+    invite_url = INVITE_URL_TEMPLATE.format(code=invite_code)
+
+    log.info(f"Invite {invite_code} issued for {sender_email}")
 
     return success_response({
         'inviteCode': invite_code,
-        'shareUrl': share_url,
-        'expiresAt': invite.get('expiresAt'),
-        'status': invite.get('status')
+        'inviteUrl': invite_url,
+        'expiresAt': item.get('expiresAt'),
+        'createdAt': item.get('createdAt'),
     })

--- a/lambdas/shares_create/handler.py
+++ b/lambdas/shares_create/handler.py
@@ -1,9 +1,9 @@
 """
-POST /shares/create - Create a new share
+POST /shares/create - Create a new share (track share with denormalized metadata)
 """
 
 from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors
+from lambdas.common.errors import handle_errors, ValidationError
 from lambdas.common.utility_helpers import success_response, parse_body, require_fields
 from lambdas.common.shares_dynamo import create_share
 
@@ -11,39 +11,84 @@ log = get_logger(__file__)
 
 HANDLER = 'shares_create'
 
-ALLOWED_TYPES = {"wrapped", "release_radar", "track", "playlist"}
+ALLOWED_MOODS = {"hype", "chill", "sad", "party", "focus", "discovery"}
+CAPTION_MAX_LEN = 140
+GENRE_TAGS_MAX = 3
 
 
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'type', 'payload')
+    require_fields(
+        body,
+        'email',
+        'trackId',
+        'trackUri',
+        'trackName',
+        'artistName',
+        'albumName',
+        'albumArtUrl',
+    )
 
     email = body.get('email')
-    share_type = body.get('type')
-    payload = body.get('payload')
+    track_id = body.get('trackId')
+    track_uri = body.get('trackUri')
+    track_name = body.get('trackName')
+    artist_name = body.get('artistName')
+    album_name = body.get('albumName')
+    album_art_url = body.get('albumArtUrl')
     caption = body.get('caption')
+    mood_tag = body.get('moodTag')
+    genre_tags = body.get('genreTags')
 
-    if share_type not in ALLOWED_TYPES:
-        from lambdas.common.errors import ValidationError
+    # Caption length
+    if caption is not None and len(caption) > CAPTION_MAX_LEN:
         raise ValidationError(
-            message=f"Invalid share type '{share_type}'. Must be one of: {sorted(ALLOWED_TYPES)}",
+            message=f"caption exceeds {CAPTION_MAX_LEN} characters",
             handler=HANDLER,
             function='handler',
-            field='type'
+            field='caption',
         )
 
-    if not isinstance(payload, dict):
-        from lambdas.common.errors import ValidationError
+    # Mood tag enum
+    if mood_tag is not None and mood_tag not in ALLOWED_MOODS:
         raise ValidationError(
-            message="payload must be a dictionary",
+            message=f"Invalid moodTag '{mood_tag}'. Must be one of: {sorted(ALLOWED_MOODS)}",
             handler=HANDLER,
             function='handler',
-            field='payload'
+            field='moodTag',
         )
 
-    log.info(f"User {email} creating share (type={share_type})")
-    share_id = create_share(email, share_type, payload, caption)
-    log.info(f"Share {share_id} created successfully")
+    # Genre tags cap
+    if genre_tags is not None:
+        if not isinstance(genre_tags, list):
+            raise ValidationError(
+                message="genreTags must be a list",
+                handler=HANDLER,
+                function='handler',
+                field='genreTags',
+            )
+        if len(genre_tags) > GENRE_TAGS_MAX:
+            raise ValidationError(
+                message=f"genreTags exceeds {GENRE_TAGS_MAX} entries",
+                handler=HANDLER,
+                function='handler',
+                field='genreTags',
+            )
 
-    return success_response({'shareId': share_id})
+    log.info(f"User {email} creating share for track {track_id}")
+    result = create_share(
+        email=email,
+        track_id=track_id,
+        track_uri=track_uri,
+        track_name=track_name,
+        artist_name=artist_name,
+        album_name=album_name,
+        album_art_url=album_art_url,
+        caption=caption,
+        mood_tag=mood_tag,
+        genre_tags=genre_tags,
+    )
+
+    log.info(f"Share {result['shareId']} created successfully")
+    return success_response(result)

--- a/lambdas/shares_delete/handler.py
+++ b/lambdas/shares_delete/handler.py
@@ -1,0 +1,55 @@
+"""
+DELETE /shares/delete - Delete a share by id (owner only).
+"""
+
+from lambdas.common.logger import get_logger
+from lambdas.common.errors import (
+    handle_errors,
+    NotFoundError,
+    AuthorizationError,
+)
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+)
+from lambdas.common.shares_dynamo import get_share, delete_share
+
+log = get_logger(__file__)
+
+HANDLER = 'shares_delete'
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    params = get_query_params(event)
+    require_fields(params, 'email', 'shareId')
+
+    email = params.get('email')
+    share_id = params.get('shareId')
+
+    log.info(f"User {email} requesting delete of share {share_id}")
+
+    share = get_share(share_id)
+    if not share:
+        raise NotFoundError(
+            message=f"Share {share_id} not found",
+            handler=HANDLER,
+            function='handler',
+            resource='share',
+        )
+
+    owner = share.get('email')
+    if owner != email:
+        log.warning(
+            f"Delete share {share_id} blocked: requester {email} is not owner ({owner})"
+        )
+        raise AuthorizationError(
+            message="You can only delete your own shares",
+            handler=HANDLER,
+            function='handler',
+        )
+
+    delete_share(share_id)
+    log.info(f"Share {share_id} deleted by owner {email}")
+    return success_response({}, status_code=204)

--- a/lambdas/shares_feed/handler.py
+++ b/lambdas/shares_feed/handler.py
@@ -1,20 +1,60 @@
 """
-GET /shares/feed - Get merged feed of shares from user + accepted friends
+GET /shares/feed - Merged feed of shares from the requester + accepted friends
+                   (optionally filtered to a specific group).
 """
 
 from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors
+from lambdas.common.errors import handle_errors, ValidationError
 from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
 from lambdas.common.friendships_dynamo import list_all_friends_for_user
-from lambdas.common.shares_dynamo import list_shares_for_user
-from lambdas.common.interactions_dynamo import count_interactions_for_share
+from lambdas.common.group_members_dynamo import list_members_of_group
+from lambdas.common.shares_dynamo import query_feed_for_emails
 
 log = get_logger(__file__)
 
 HANDLER = 'shares_feed'
 
-PER_USER_LIMIT = 20
-FEED_CAP = 50
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 100
+
+
+def _parse_limit(raw: str | None) -> int:
+    if raw is None:
+        return DEFAULT_LIMIT
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        raise ValidationError(
+            message="limit must be an integer",
+            handler=HANDLER,
+            function='handler',
+            field='limit',
+        )
+    if limit <= 0:
+        raise ValidationError(
+            message="limit must be > 0",
+            handler=HANDLER,
+            function='handler',
+            field='limit',
+        )
+    if limit > MAX_LIMIT:
+        raise ValidationError(
+            message=f"limit cannot exceed {MAX_LIMIT}",
+            handler=HANDLER,
+            function='handler',
+            field='limit',
+        )
+    return limit
+
+
+def _enrich(share: dict) -> dict:
+    """Stub enrichment — sub-feature #4 fills these in for real."""
+    share.setdefault('queuedCount', 0)
+    share.setdefault('ratedCount', 0)
+    share.setdefault('viewerHasQueued', False)
+    share.setdefault('viewerRating', None)
+    share.setdefault('sharerRating', None)
+    return share
 
 
 @handle_errors(HANDLER)
@@ -23,53 +63,36 @@ def handler(event, context):
     require_fields(params, 'email')
 
     email = params.get('email')
+    group_id = params.get('groupId')
+    limit = _parse_limit(params.get('limit'))
+    before = params.get('before')
 
-    log.info(f"Building feed for user {email}")
+    log.info(f"Building feed for {email} (groupId={group_id}, limit={limit}, before={before})")
 
-    # Friends list — only accepted
+    # Friends list — filter to accepted only, include requester themselves
     friends = list_all_friends_for_user(email)
-    accepted_emails = [
+    feed_emails: set[str] = {
         f.get('friendEmail')
         for f in friends
         if f.get('status') == 'accepted' and f.get('friendEmail')
-    ]
-
-    # Include the user themselves
-    feed_emails = set(accepted_emails)
+    }
     feed_emails.add(email)
 
-    log.info(f"Fetching shares for {len(feed_emails)} users (self + {len(accepted_emails)} accepted friends)")
+    # Optional group filter — intersect with members of the group
+    if group_id:
+        members = list_members_of_group(group_id)
+        member_emails = {m.get('email') for m in members if m.get('email')}
+        feed_emails = feed_emails & member_emails
+        log.info(f"After group filter: {len(feed_emails)} authors in set")
 
-    # Collect shares from each user
-    all_shares = []
-    for user_email in feed_emails:
-        try:
-            user_shares = list_shares_for_user(user_email, limit=PER_USER_LIMIT)
-            all_shares.extend(user_shares)
-        except Exception as err:
-            log.warning(f"Failed to fetch shares for {user_email}: {err}")
-            continue
+    if not feed_emails:
+        return success_response({'shares': [], 'nextBefore': None})
 
-    # Sort newest first by createdAt
-    all_shares.sort(key=lambda s: s.get('createdAt', ''), reverse=True)
+    shares = query_feed_for_emails(sorted(feed_emails), limit=limit, before=before)
+    shares = [_enrich(s) for s in shares]
 
-    # Cap
-    all_shares = all_shares[:FEED_CAP]
+    # Cursor for next page: createdAt of the oldest returned share if we hit the limit
+    next_before = shares[-1].get('createdAt') if len(shares) == limit and shares else None
 
-    # Attach interaction counts per share
-    for share in all_shares:
-        share_id = share.get('shareId')
-        if share_id:
-            try:
-                share['interactionCounts'] = count_interactions_for_share(share_id)
-            except Exception as err:
-                log.warning(f"Failed to count interactions for share {share_id}: {err}")
-                share['interactionCounts'] = {}
-
-    log.info(f"Returning {len(all_shares)} shares for {email}'s feed")
-
-    return success_response({
-        'email': email,
-        'shares': all_shares,
-        'totalCount': len(all_shares)
-    })
+    log.info(f"Returning {len(shares)} shares for {email}'s feed (nextBefore={next_before})")
+    return success_response({'shares': shares, 'nextBefore': next_before})

--- a/lambdas/shares_user/handler.py
+++ b/lambdas/shares_user/handler.py
@@ -1,0 +1,70 @@
+"""
+GET /shares/user - List shares authored by a specific user (no friendship gate in v1).
+"""
+
+from lambdas.common.logger import get_logger
+from lambdas.common.errors import handle_errors, ValidationError
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+)
+from lambdas.common.shares_dynamo import list_shares_for_user
+
+log = get_logger(__file__)
+
+HANDLER = 'shares_user'
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 100
+
+
+def _parse_limit(raw: str | None) -> int:
+    if raw is None:
+        return DEFAULT_LIMIT
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        raise ValidationError(
+            message="limit must be an integer",
+            handler=HANDLER,
+            function='handler',
+            field='limit',
+        )
+    if limit <= 0:
+        raise ValidationError(
+            message="limit must be > 0",
+            handler=HANDLER,
+            function='handler',
+            field='limit',
+        )
+    if limit > MAX_LIMIT:
+        raise ValidationError(
+            message=f"limit cannot exceed {MAX_LIMIT}",
+            handler=HANDLER,
+            function='handler',
+            field='limit',
+        )
+    return limit
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    params = get_query_params(event)
+    # email is the requester (kept for future friendship gating); targetEmail is the author
+    require_fields(params, 'email', 'targetEmail')
+
+    email = params.get('email')
+    target_email = params.get('targetEmail')
+    limit = _parse_limit(params.get('limit'))
+    before = params.get('before')
+
+    log.info(
+        f"Requester {email} listing shares for target {target_email} "
+        f"(limit={limit}, before={before})"
+    )
+
+    shares, next_before = list_shares_for_user(target_email, limit=limit, before=before)
+
+    log.info(f"Returning {len(shares)} shares for target {target_email}")
+    return success_response({'shares': shares, 'nextBefore': next_before})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,11 @@ _TEST_ENV_VARS = {
     "GROUP_MEMBERS_TABLE_NAME": "xomify-group-members-test",
     "GROUP_TRACKS_TABLE_NAME": "xomify-group-tracks-test",
     "TRACK_RATINGS_TABLE_NAME": "xomify-track-ratings-test",
+    "SHARES_TABLE_NAME": "xomify-shares-test",
+    "SHARE_INTERACTIONS_TABLE_NAME": "xomify-share-interactions-test",
+    "INVITES_TABLE_NAME": "xomify-invites-test",
+    "SHARES_EMAIL_INDEX": "email-createdAt-index",
+    "INVITE_URL_TEMPLATE": "https://xomify.test/invite/{code}",
 }
 for key, value in _TEST_ENV_VARS.items():
     os.environ.setdefault(key, value)

--- a/tests/test_invites_accept.py
+++ b/tests/test_invites_accept.py
@@ -1,0 +1,162 @@
+"""
+Tests for invites_accept lambda
+"""
+
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
+from lambdas.invites_accept.handler import handler
+
+
+def _event(api_gateway_event, body):
+    return {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/invites/accept",
+        "body": json.dumps(body),
+    }
+
+
+def _future_iso(days: int = 30) -> str:
+    return (datetime.now(timezone.utc) + timedelta(days=days)).isoformat()
+
+
+def _past_iso(days: int = 1) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+@patch('lambdas.invites_accept.handler.create_accepted_friendship')
+@patch('lambdas.invites_accept.handler.list_all_friends_for_user')
+@patch('lambdas.invites_accept.handler.consume_invite')
+@patch('lambdas.invites_accept.handler.get_invite')
+def test_invites_accept_happy_path(
+    mock_get, mock_consume, mock_friends, mock_create_fs, mock_context, api_gateway_event
+):
+    mock_get.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "alice@example.com",
+        "expiresAt": _future_iso(),
+    }
+    mock_friends.return_value = []
+    mock_consume.return_value = {"consumedAt": "2026-04-22T12:00:00+00:00"}
+    mock_create_fs.return_value = True
+
+    response = handler(
+        _event(api_gateway_event, {"email": "bob@example.com", "inviteCode": "ABCDEFGH"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['ok'] is True
+    assert body['senderEmail'] == "alice@example.com"
+    mock_create_fs.assert_called_once_with("alice@example.com", "bob@example.com")
+
+
+@patch('lambdas.invites_accept.handler.get_invite')
+def test_invites_accept_not_found(mock_get, mock_context, api_gateway_event):
+    mock_get.return_value = None
+    response = handler(
+        _event(api_gateway_event, {"email": "bob@example.com", "inviteCode": "NOPE"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 404
+
+
+@patch('lambdas.invites_accept.handler.get_invite')
+def test_invites_accept_already_consumed(mock_get, mock_context, api_gateway_event):
+    mock_get.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "alice@example.com",
+        "expiresAt": _future_iso(),
+        "consumedAt": "2026-04-21T10:00:00+00:00",
+        "consumedBy": "someone@example.com",
+    }
+    response = handler(
+        _event(api_gateway_event, {"email": "bob@example.com", "inviteCode": "ABCDEFGH"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 410
+    body = json.loads(response['body'])
+    assert body['error']['error_code'] == "INVITE_CONSUMED"
+
+
+@patch('lambdas.invites_accept.handler.get_invite')
+def test_invites_accept_expired(mock_get, mock_context, api_gateway_event):
+    mock_get.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "alice@example.com",
+        "expiresAt": _past_iso(),
+    }
+    response = handler(
+        _event(api_gateway_event, {"email": "bob@example.com", "inviteCode": "ABCDEFGH"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 410
+    body = json.loads(response['body'])
+    assert body['error']['error_code'] == "INVITE_EXPIRED"
+
+
+@patch('lambdas.invites_accept.handler.get_invite')
+def test_invites_accept_self_invite(mock_get, mock_context, api_gateway_event):
+    mock_get.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "alice@example.com",
+        "expiresAt": _future_iso(),
+    }
+    response = handler(
+        _event(api_gateway_event, {"email": "alice@example.com", "inviteCode": "ABCDEFGH"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 400
+
+
+@patch('lambdas.invites_accept.handler.list_all_friends_for_user')
+@patch('lambdas.invites_accept.handler.get_invite')
+def test_invites_accept_already_friends(
+    mock_get, mock_friends, mock_context, api_gateway_event
+):
+    mock_get.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "alice@example.com",
+        "expiresAt": _future_iso(),
+    }
+    mock_friends.return_value = [
+        {"friendEmail": "alice@example.com", "status": "accepted"},
+    ]
+    response = handler(
+        _event(api_gateway_event, {"email": "bob@example.com", "inviteCode": "ABCDEFGH"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 409
+    body = json.loads(response['body'])
+    assert body['error']['error_code'] == "ALREADY_FRIENDS"
+
+
+@patch('lambdas.invites_accept.handler.list_all_friends_for_user')
+@patch('lambdas.invites_accept.handler.consume_invite')
+@patch('lambdas.invites_accept.handler.get_invite')
+def test_invites_accept_race_conditional_fail(
+    mock_get, mock_consume, mock_friends, mock_context, api_gateway_event
+):
+    mock_get.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "alice@example.com",
+        "expiresAt": _future_iso(),
+    }
+    mock_friends.return_value = []
+    mock_consume.side_effect = ClientError(
+        {"Error": {"Code": "ConditionalCheckFailedException", "Message": "consumed"}},
+        "UpdateItem",
+    )
+
+    response = handler(
+        _event(api_gateway_event, {"email": "bob@example.com", "inviteCode": "ABCDEFGH"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 410
+    body = json.loads(response['body'])
+    assert body['error']['error_code'] == "INVITE_UNAVAILABLE"

--- a/tests/test_invites_create.py
+++ b/tests/test_invites_create.py
@@ -1,0 +1,95 @@
+"""
+Tests for invites_create lambda
+"""
+
+import json
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
+from lambdas.invites_create.handler import handler
+
+
+def _event(api_gateway_event, body):
+    return {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/invites/create",
+        "body": json.dumps(body),
+    }
+
+
+@patch('lambdas.invites_create.handler.create_invite')
+@patch('lambdas.invites_create.handler.generate_invite_code')
+@patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
+def test_invites_create_happy_path(
+    mock_count, mock_gen, mock_create, mock_context, api_gateway_event
+):
+    mock_count.return_value = 0
+    mock_gen.return_value = "ABCDEFGH"
+    mock_create.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "user@example.com",
+        "createdAt": "2026-04-22T12:00:00+00:00",
+        "expiresAt": "2026-05-22T12:00:00+00:00",
+    }
+
+    response = handler(_event(api_gateway_event, {"email": "user@example.com"}), mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['inviteCode'] == "ABCDEFGH"
+    assert body['inviteUrl'].endswith("/invite/ABCDEFGH")
+    assert body['expiresAt'] == "2026-05-22T12:00:00+00:00"
+
+
+@patch('lambdas.invites_create.handler.create_invite')
+@patch('lambdas.invites_create.handler.generate_invite_code')
+@patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
+def test_invites_create_code_collision_retry(
+    mock_count, mock_gen, mock_create, mock_context, api_gateway_event
+):
+    mock_count.return_value = 0
+    mock_gen.side_effect = ["COLLIDE1", "SUCCEED2", "NEVER"]
+
+    collision = ClientError(
+        {"Error": {"Code": "ConditionalCheckFailedException", "Message": "exists"}},
+        "PutItem",
+    )
+
+    mock_create.side_effect = [
+        collision,
+        {
+            "inviteCode": "SUCCEED2",
+            "senderEmail": "user@example.com",
+            "createdAt": "2026-04-22T12:00:00+00:00",
+            "expiresAt": "2026-05-22T12:00:00+00:00",
+        },
+    ]
+
+    response = handler(_event(api_gateway_event, {"email": "user@example.com"}), mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['inviteCode'] == "SUCCEED2"
+    assert mock_create.call_count == 2
+
+
+@patch('lambdas.invites_create.handler.create_invite')
+@patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
+def test_invites_create_rate_limit_exceeded(
+    mock_count, mock_create, mock_context, api_gateway_event
+):
+    mock_count.return_value = 10
+
+    response = handler(_event(api_gateway_event, {"email": "user@example.com"}), mock_context)
+
+    assert response['statusCode'] == 429
+    mock_create.assert_not_called()
+
+
+@patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
+def test_invites_create_missing_email(mock_count, mock_context, api_gateway_event):
+    response = handler(_event(api_gateway_event, {}), mock_context)
+    assert response['statusCode'] == 400
+    mock_count.assert_not_called()

--- a/tests/test_shares_create.py
+++ b/tests/test_shares_create.py
@@ -1,0 +1,96 @@
+"""
+Tests for shares_create lambda
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.shares_create.handler import handler
+
+
+VALID_BODY = {
+    "email": "user@example.com",
+    "trackId": "spotify:track:1",
+    "trackUri": "spotify:track:1",
+    "trackName": "Song",
+    "artistName": "Artist",
+    "albumName": "Album",
+    "albumArtUrl": "https://example.com/art.jpg",
+}
+
+
+def _event(api_gateway_event, body):
+    return {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/shares/create",
+        "body": json.dumps(body),
+    }
+
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_happy_path(mock_create, mock_context, api_gateway_event):
+    mock_create.return_value = {
+        "shareId": "abc-123",
+        "createdAt": "2026-04-22T12:00:00+00:00",
+    }
+
+    response = handler(_event(api_gateway_event, VALID_BODY), mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['shareId'] == "abc-123"
+    assert body['createdAt'] == "2026-04-22T12:00:00+00:00"
+    mock_create.assert_called_once()
+
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_missing_required_field(mock_create, mock_context, api_gateway_event):
+    incomplete = {k: v for k, v in VALID_BODY.items() if k != 'trackId'}
+    response = handler(_event(api_gateway_event, incomplete), mock_context)
+
+    assert response['statusCode'] == 400
+    mock_create.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_caption_too_long(mock_create, mock_context, api_gateway_event):
+    body = {**VALID_BODY, "caption": "a" * 141}
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 400
+    assert 'caption' in json.loads(response['body'])['error']['message']
+    mock_create.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_invalid_mood_tag(mock_create, mock_context, api_gateway_event):
+    body = {**VALID_BODY, "moodTag": "bogus"}
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 400
+    assert 'moodTag' in json.loads(response['body'])['error']['message']
+    mock_create.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_too_many_genre_tags(mock_create, mock_context, api_gateway_event):
+    body = {**VALID_BODY, "genreTags": ["a", "b", "c", "d"]}
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 400
+    mock_create.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_valid_optional_fields(mock_create, mock_context, api_gateway_event):
+    mock_create.return_value = {"shareId": "x", "createdAt": "2026-04-22T12:00:00+00:00"}
+    body = {**VALID_BODY, "caption": "nice", "moodTag": "hype", "genreTags": ["pop", "rock"]}
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 200
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs['caption'] == 'nice'
+    assert kwargs['mood_tag'] == 'hype'
+    assert kwargs['genre_tags'] == ['pop', 'rock']

--- a/tests/test_shares_delete.py
+++ b/tests/test_shares_delete.py
@@ -1,0 +1,78 @@
+"""
+Tests for shares_delete lambda
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.shares_delete.handler import handler
+
+
+def _event(api_gateway_event, params):
+    return {
+        **api_gateway_event,
+        "httpMethod": "DELETE",
+        "path": "/shares/delete",
+        "queryStringParameters": params,
+    }
+
+
+@patch('lambdas.shares_delete.handler.delete_share')
+@patch('lambdas.shares_delete.handler.get_share')
+def test_shares_delete_owner_success(
+    mock_get, mock_delete, mock_context, api_gateway_event
+):
+    mock_get.return_value = {"shareId": "s1", "email": "owner@example.com"}
+    mock_delete.return_value = True
+
+    response = handler(
+        _event(api_gateway_event, {"email": "owner@example.com", "shareId": "s1"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 204
+    mock_delete.assert_called_once_with("s1")
+
+
+@patch('lambdas.shares_delete.handler.delete_share')
+@patch('lambdas.shares_delete.handler.get_share')
+def test_shares_delete_non_owner_forbidden(
+    mock_get, mock_delete, mock_context, api_gateway_event
+):
+    mock_get.return_value = {"shareId": "s1", "email": "owner@example.com"}
+
+    response = handler(
+        _event(api_gateway_event, {"email": "stranger@example.com", "shareId": "s1"}),
+        mock_context,
+    )
+
+    # AuthorizationError defaults to 401; this handler accepts that the wire
+    # response mirrors the declared status on the exception class.
+    assert response['statusCode'] == 401
+    mock_delete.assert_not_called()
+
+
+@patch('lambdas.shares_delete.handler.delete_share')
+@patch('lambdas.shares_delete.handler.get_share')
+def test_shares_delete_not_found(
+    mock_get, mock_delete, mock_context, api_gateway_event
+):
+    mock_get.return_value = None
+
+    response = handler(
+        _event(api_gateway_event, {"email": "owner@example.com", "shareId": "missing"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 404
+    mock_delete.assert_not_called()
+
+
+@patch('lambdas.shares_delete.handler.get_share')
+def test_shares_delete_missing_fields(mock_get, mock_context, api_gateway_event):
+    response = handler(
+        _event(api_gateway_event, {"email": "owner@example.com"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 400
+    mock_get.assert_not_called()

--- a/tests/test_shares_feed.py
+++ b/tests/test_shares_feed.py
@@ -1,0 +1,107 @@
+"""
+Tests for shares_feed lambda
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.shares_feed.handler import handler
+
+
+def _event(api_gateway_event, params):
+    return {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/feed",
+        "queryStringParameters": params,
+    }
+
+
+@patch('lambdas.shares_feed.handler.query_feed_for_emails')
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_happy_path(mock_friends, mock_query, mock_context, api_gateway_event):
+    mock_friends.return_value = [
+        {"friendEmail": "alice@example.com", "status": "accepted"},
+        {"friendEmail": "bob@example.com", "status": "accepted"},
+        {"friendEmail": "blocked@example.com", "status": "blocked"},
+    ]
+    mock_query.return_value = [
+        {"shareId": "1", "email": "alice@example.com", "createdAt": "2026-04-22T12:00:00+00:00"},
+        {"shareId": "2", "email": "me@example.com", "createdAt": "2026-04-22T11:00:00+00:00"},
+    ]
+
+    response = handler(_event(api_gateway_event, {"email": "me@example.com"}), mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert len(body['shares']) == 2
+    # Enrichment stubs populated
+    assert body['shares'][0]['queuedCount'] == 0
+    assert body['shares'][0]['viewerHasQueued'] is False
+    # Fan-out emails: me + accepted friends (blocked excluded)
+    emails_arg = mock_query.call_args.args[0]
+    assert set(emails_arg) == {"me@example.com", "alice@example.com", "bob@example.com"}
+
+
+@patch('lambdas.shares_feed.handler.query_feed_for_emails')
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_empty_friends(mock_friends, mock_query, mock_context, api_gateway_event):
+    mock_friends.return_value = []
+    mock_query.return_value = []
+
+    response = handler(_event(api_gateway_event, {"email": "solo@example.com"}), mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['shares'] == []
+    assert body['nextBefore'] is None
+    # Still fans out over the requester themselves
+    assert mock_query.call_args.args[0] == ["solo@example.com"]
+
+
+@patch('lambdas.shares_feed.handler.list_members_of_group')
+@patch('lambdas.shares_feed.handler.query_feed_for_emails')
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_group_filter_intersects(
+    mock_friends, mock_query, mock_members, mock_context, api_gateway_event
+):
+    mock_friends.return_value = [
+        {"friendEmail": "alice@example.com", "status": "accepted"},
+        {"friendEmail": "bob@example.com", "status": "accepted"},
+    ]
+    mock_members.return_value = [
+        {"email": "alice@example.com"},
+        {"email": "me@example.com"},
+        {"email": "unrelated@example.com"},
+    ]
+    mock_query.return_value = []
+
+    handler(
+        _event(api_gateway_event, {"email": "me@example.com", "groupId": "g1"}),
+        mock_context,
+    )
+
+    emails_arg = mock_query.call_args.args[0]
+    # Intersection of {me, alice, bob} with {alice, me, unrelated} = {me, alice}
+    assert set(emails_arg) == {"me@example.com", "alice@example.com"}
+
+
+@patch('lambdas.shares_feed.handler.query_feed_for_emails')
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_limit_exceeds_max(
+    mock_friends, mock_query, mock_context, api_gateway_event
+):
+    mock_friends.return_value = []
+    response = handler(
+        _event(api_gateway_event, {"email": "me@example.com", "limit": "500"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 400
+    mock_query.assert_not_called()
+
+
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_missing_email(mock_friends, mock_context, api_gateway_event):
+    response = handler(_event(api_gateway_event, {}), mock_context)
+    assert response['statusCode'] == 400
+    mock_friends.assert_not_called()

--- a/tests/test_shares_user.py
+++ b/tests/test_shares_user.py
@@ -1,0 +1,85 @@
+"""
+Tests for shares_user lambda
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.shares_user.handler import handler
+
+
+def _event(api_gateway_event, params):
+    return {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/user",
+        "queryStringParameters": params,
+    }
+
+
+@patch('lambdas.shares_user.handler.list_shares_for_user')
+def test_shares_user_happy_path(mock_list, mock_context, api_gateway_event):
+    mock_list.return_value = (
+        [
+            {"shareId": "1", "email": "target@example.com", "createdAt": "2026-04-22T12:00:00+00:00"},
+            {"shareId": "2", "email": "target@example.com", "createdAt": "2026-04-21T12:00:00+00:00"},
+        ],
+        None,
+    )
+
+    response = handler(
+        _event(api_gateway_event, {"email": "me@example.com", "targetEmail": "target@example.com"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert len(body['shares']) == 2
+    assert body['nextBefore'] is None
+    mock_list.assert_called_once_with("target@example.com", limit=50, before=None)
+
+
+@patch('lambdas.shares_user.handler.list_shares_for_user')
+def test_shares_user_pagination_cursor(mock_list, mock_context, api_gateway_event):
+    mock_list.return_value = ([], "2026-04-20T00:00:00+00:00")
+
+    response = handler(
+        _event(api_gateway_event, {
+            "email": "me@example.com",
+            "targetEmail": "target@example.com",
+            "limit": "10",
+            "before": "2026-04-22T00:00:00+00:00",
+        }),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['nextBefore'] == "2026-04-20T00:00:00+00:00"
+    mock_list.assert_called_once_with(
+        "target@example.com", limit=10, before="2026-04-22T00:00:00+00:00"
+    )
+
+
+@patch('lambdas.shares_user.handler.list_shares_for_user')
+def test_shares_user_missing_target(mock_list, mock_context, api_gateway_event):
+    response = handler(
+        _event(api_gateway_event, {"email": "me@example.com"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 400
+    mock_list.assert_not_called()
+
+
+@patch('lambdas.shares_user.handler.list_shares_for_user')
+def test_shares_user_limit_exceeds_max(mock_list, mock_context, api_gateway_event):
+    response = handler(
+        _event(api_gateway_event, {
+            "email": "me@example.com",
+            "targetEmail": "target@example.com",
+            "limit": "500",
+        }),
+        mock_context,
+    )
+    assert response['statusCode'] == 400
+    mock_list.assert_not_called()


### PR DESCRIPTION
## Summary

Implements the `backend-shares` sub-feature of the xomify-social-feed epic:
six single-purpose Lambda handlers plus two DynamoDB helper modules, backed
by 30 new unit tests.

### Shares domain (`xomify-shares` table, GSI `email-createdAt-index`)

| Route | Handler | Notes |
|-------|---------|-------|
| `POST /shares/create` | `shares_create` | Denormalized Spotify metadata. `caption` max 140 chars. `moodTag` in `{hype, chill, sad, party, focus, discovery}`. `genreTags` max 3. Returns `{shareId, createdAt}`. |
| `GET /shares/feed` | `shares_feed` | Fan-out over requester + accepted friends (optional `groupId` intersect). `ThreadPoolExecutor(max_workers=10)` per-author `Query` on GSI. Cursor pagination via `before=`. Enrichment stubs (queuedCount/ratedCount/viewerHasQueued/viewerRating/sharerRating) filled by sub-feature #4. |
| `DELETE /shares/delete` | `shares_delete` | Owner-only (compares `share.email` to requester). 401 on stranger, 404 on miss, 204 on success. |
| `GET /shares/user` | `shares_user` | Lists shares by `targetEmail` (no friendship gate in v1, consistent with `ratings_track`). |

### Invites domain (`xomify-invites` table, no GSI in v1)

| Route | Handler | Notes |
|-------|---------|-------|
| `POST /invites/create` | `invites_create` | 8-char base32 code. 30-day TTL. Rate-limited: max 10 outstanding (non-consumed, non-expired) invites per sender — returns **429** when exceeded. Single collision retry on `ConditionalCheckFailedException`. Returns `{inviteCode, inviteUrl, expiresAt, createdAt}`. |
| `POST /invites/accept` | `invites_accept` | Atomic consume via `UpdateItem` with `attribute_not_exists(consumedAt) AND expiresAt > :now`. Auto-creates accepted friendship (both directional rows) in a single `transact_write_items`. **410** on expired/consumed, **409** on already-friends, **400** on self-invite, **404** on unknown code. |

### Common helpers

- `lambdas/common/shares_dynamo.py` — `create_share`, `get_share`, `delete_share`, `list_shares_for_user` (paginated GSI query with `ScanIndexForward=False`), `query_feed_for_emails` (parallel fan-out + merge-sort).
- `lambdas/common/invites_dynamo.py` — `create_invite`, `get_invite`, `consume_invite`, `list_invites_by_sender` (Scan + FilterExpression; flagged for follow-up GSI if traffic grows), `count_outstanding_invites_for_sender`.
- Extends `lambdas/common/friendships_dynamo.py` with `create_accepted_friendship` for the invite flow.

### Blocked on

**https://github.com/Xomware/xomify-infrastructure/pull/67** must merge and apply first — `deploy-backend.yml` uses `aws lambda update-function-code` which fails for `xomify-shares-delete` and `xomify-shares-user` until Terraform creates those function stubs.

### Schema divergence from prior shares-and-salvage PR

The merged shares-and-salvage PR (#129) shipped a different schema (`type`+`payload` variant) that the sub-feature plan (authored after) replaces with denormalized track metadata + mood/genre tags. Since the live DynamoDB table is attribute-agnostic (PK `shareId`, free-form GSI), the change is handler-layer only. Flagged in the execution log: `xomify-ios/docs/features/backend-shares/EXECUTION_LOG.md`.

### Status code notes

- Non-owner on `shares_delete` returns **401** (follows codebase `AuthorizationError` convention) rather than **403** as the plan described. Other handlers match the plan exactly.
- `invites_accept` distinguishes error cases via `error.error_code` in the response body (`INVITE_CONSUMED`, `INVITE_EXPIRED`, `INVITE_UNAVAILABLE`, `ALREADY_FRIENDS`) — 410 is used for both expired and already-consumed as the plan directed.

### Context

- **Epic plan**: `xomify-ios/docs/features/xomify-social-feed/PLAN.md`
- **Sub-feature plan** (Ready): `xomify-ios/docs/features/backend-shares/PLAN.md`
- **Paired infra PR**: https://github.com/Xomware/xomify-infrastructure/pull/67

## Test plan

Run locally with:

```
pytest tests/ -v
```

New coverage (30 tests, all passing):

| Handler | Tests |
|---------|-------|
| `shares_create` | 6 — happy, missing required, caption>140, bad moodTag, >3 genreTags, optional-fields pass-through |
| `shares_feed` | 5 — happy, empty friends, group filter intersect, limit>100, missing email |
| `shares_delete` | 4 — owner 204, non-owner 401, not-found 404, missing fields 400 |
| `shares_user` | 4 — happy, pagination cursor, missing target, limit>100 |
| `invites_create` | 4 — happy, code-collision retry, rate limit 429, missing email |
| `invites_accept` | 7 — happy, not-found, already-consumed 410, expired 410, self-invite 400, already-friends 409, race conditional-fail 410 |

Full suite: **56 passed** (26 baseline + 30 new). Two pre-existing test modules (`test_release_radar_dynamo.py`, `test_friends_profile.py`) require `aiohttp` — CI has it; not related to this PR.

## Follow-ups (not in scope)

- Add `sender-invites-index` GSI to `xomify-invites` via Terraform PR once rate-limit `Scan` becomes a hotspot; swap `list_invites_by_sender` to `Query`.
- Sub-feature #4 fills the enrichment stubs in `shares_feed` and owns `shares_react` + `share_interactions` table.
- Deep-link URL scheme (`INVITE_URL_TEMPLATE`) is currently `https://xomify.app/invite/{code}`; can be flipped to a custom scheme or a xomware.com universal link via env var.