### PR TITLE
fix(friends): scope /user/all to caller; harden /friends/list

### DIFF
--- a/lambdas/friends_list/handler.py
+++ b/lambdas/friends_list/handler.py
@@ -29,15 +29,23 @@ def handler(event, context):
     pending = []
 
     for friend in friends:
-        if friend['status'] == 'accepted':
+        status = friend.get('status')
+        if status == 'accepted':
             accepted.append(friend)
-        elif friend['status'] == 'pending':
-            if friend['direction'] == 'outgoing':
+        elif status == 'pending':
+            # Legacy rows may be missing `direction`; treat unknown as
+            # incoming so a single bad row can't 500 the whole response.
+            if friend.get('direction') == 'outgoing':
                 requested.append(friend)
             else:
                 pending.append(friend)
-        else:
+        elif status == 'blocked':
             blocked.append(friend)
+        else:
+            log.warning(
+                f"Skipping friend row with unexpected status={status!r} "
+                f"for {email}: {friend.get('friendEmail') or friend.get('email')}"
+            )
 
     log.info(f"Found {len(friends)} friends for user {email}")
 

--- a/lambdas/user_all/handler.py
+++ b/lambdas/user_all/handler.py
@@ -1,10 +1,13 @@
 """
 GET /user/all - Get all users
+
+When called with `?email=<me>`, filters the caller out of the result so
+discovery UIs never show "add yourself" as an option.
 """
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response
+from lambdas.common.utility_helpers import success_response, get_query_params
 from lambdas.common.constants import USERS_TABLE_NAME
 from lambdas.common.dynamo_helpers import full_table_scan
 
@@ -15,14 +18,21 @@ HANDLER = 'user_all'
 
 @handle_errors(HANDLER)
 def handler(event, context):
+    params = get_query_params(event)
+    caller_email = (params.get('email') or '').strip().lower()
+
     users = full_table_scan(USERS_TABLE_NAME)
 
-    # Remove sensitive data
     clean_users = []
     for user in users:
         user.pop('refreshToken', None)
+        if caller_email and (user.get('email') or '').strip().lower() == caller_email:
+            continue
         clean_users.append(user)
 
-    log.info(f"Retrieved {len(clean_users)} users from user table")
+    log.info(
+        f"Retrieved {len(clean_users)} users from user table "
+        f"(caller={'<anon>' if not caller_email else caller_email})"
+    )
 
     return success_response(clean_users)

--- a/tests/test_user_all.py
+++ b/tests/test_user_all.py
@@ -1,0 +1,72 @@
+"""
+Tests for user_all lambda
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.user_all.handler import handler
+
+
+@patch('lambdas.user_all.handler.full_table_scan')
+def test_user_all_no_caller_returns_everyone(mock_scan, mock_context, api_gateway_event):
+    """Without an `email` query param, return all users (legacy behavior)."""
+    mock_scan.return_value = [
+        {"email": "a@test.com", "displayName": "A", "refreshToken": "REDACT-ME"},
+        {"email": "b@test.com", "displayName": "B"},
+    ]
+    event = {
+        **api_gateway_event,
+        "path": "/user/all",
+        "queryStringParameters": None,
+    }
+
+    response = handler(event, mock_context)
+    body = json.loads(response['body'])
+
+    assert response['statusCode'] == 200
+    assert len(body) == 2
+    # refreshToken always stripped
+    assert all('refreshToken' not in u for u in body)
+
+
+@patch('lambdas.user_all.handler.full_table_scan')
+def test_user_all_filters_caller(mock_scan, mock_context, api_gateway_event):
+    """With `?email=caller`, the caller's own row is omitted."""
+    mock_scan.return_value = [
+        {"email": "me@test.com", "displayName": "Me"},
+        {"email": "friend@test.com", "displayName": "Friend"},
+    ]
+    event = {
+        **api_gateway_event,
+        "path": "/user/all",
+        "queryStringParameters": {"email": "me@test.com"},
+    }
+
+    response = handler(event, mock_context)
+    body = json.loads(response['body'])
+
+    assert response['statusCode'] == 200
+    assert len(body) == 1
+    assert body[0]['email'] == "friend@test.com"
+
+
+@patch('lambdas.user_all.handler.full_table_scan')
+def test_user_all_filter_is_case_insensitive(mock_scan, mock_context, api_gateway_event):
+    """Email casing shouldn't let the caller slip through."""
+    mock_scan.return_value = [
+        {"email": "Me@Test.com", "displayName": "Me"},
+        {"email": "friend@test.com", "displayName": "Friend"},
+    ]
+    event = {
+        **api_gateway_event,
+        "path": "/user/all",
+        "queryStringParameters": {"email": "ME@test.com"},
+    }
+
+    response = handler(event, mock_context)
+    body = json.loads(response['body'])
+
+    assert response['statusCode'] == 200
+    assert len(body) == 1
+    assert body[0]['email'] == "friend@test.com"


### PR DESCRIPTION
## Summary
- **/user/all self-filter** — accepts an optional `?email=<caller>` and omits the caller's own row server-side. Case-insensitive match. Both the iOS client and Angular frontend were relying on a client-side filter that fails when the cached session email is empty — that's the root cause of "show me as an Add Friend option" on web.
- **/friends/list hardening** — replaces direct dict access on `status`/`direction` with `.get()` plus a defensive fallback (unknown direction defaults to incoming; unknown status is skipped with a warning). Legacy rows missing `direction` were crashing the whole response → web error toast, iOS empty state.

## Test plan
- [x] `tests/test_user_all.py` (new, 3 cases)
- [x] `tests/test_friends_list.py` (existing, still green)
- [ ] Deploy + verify web "Add Friends" no longer shows self
- [ ] Deploy + verify iOS Friends tab populates buckets

Paired with iOS PR: Xomware/xomify-ios#40