### PR TITLE
fix(groups): hydrate /groups/list with full group metadata

### DIFF
--- a/lambdas/common/groups_dynamo.py
+++ b/lambdas/common/groups_dynamo.py
@@ -68,3 +68,61 @@ def get_group(group_id: str):
             function="get_group",
             table=GROUPS_TABLE_NAME
         )
+
+
+def batch_get_groups(group_ids: list[str]) -> list[dict]:
+    """
+    Fetch multiple Group items in chunks of 100 (DynamoDB BatchGetItem
+    limit). Missing IDs are simply absent from the returned list — callers
+    should handle the membership → group join upstream.
+    """
+    if not group_ids:
+        return []
+
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    out: list[dict] = []
+
+    # BatchGetItem caps at 100 keys per call. We deduplicate first to avoid
+    # wasted throughput when a user has duplicate membership rows.
+    unique_ids = list({gid for gid in group_ids if gid})
+
+    for i in range(0, len(unique_ids), 100):
+        chunk = unique_ids[i:i + 100]
+        try:
+            res = client.batch_get_item(
+                RequestItems={
+                    GROUPS_TABLE_NAME: {
+                        "Keys": [{"groupId": {"S": gid}} for gid in chunk]
+                    }
+                }
+            )
+            raw_items = res.get("Responses", {}).get(GROUPS_TABLE_NAME, [])
+            for raw in raw_items:
+                out.append(_deserialize_item(raw))
+        except Exception as err:
+            log.error(f"Batch Get Groups failed: {err}")
+            raise DynamoDBError(
+                message=str(err),
+                function="batch_get_groups",
+                table=GROUPS_TABLE_NAME
+            )
+
+    return out
+
+
+def _deserialize_item(raw: dict) -> dict:
+    """Unwrap DynamoDB low-level attribute format to plain dict."""
+    out: dict = {}
+    for key, val in raw.items():
+        if "S" in val:
+            out[key] = val["S"]
+        elif "N" in val:
+            try:
+                out[key] = int(val["N"])
+            except ValueError:
+                out[key] = float(val["N"])
+        elif "BOOL" in val:
+            out[key] = val["BOOL"]
+        elif "NULL" in val:
+            out[key] = None
+    return out

--- a/lambdas/groups_list/handler.py
+++ b/lambdas/groups_list/handler.py
@@ -1,11 +1,17 @@
 """
 GET /groups/list - Get user's groups
+
+Returns fully-hydrated group objects. The membership table only stores
+(email, groupId, role, joinedAt), so we BatchGetItem the GROUPS table to
+attach name / createdBy / memberCount / etc. Without this join, clients
+see headless membership rows and fail to decode.
 """
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
 from lambdas.common.group_members_dynamo import list_groups_for_user
+from lambdas.common.groups_dynamo import batch_get_groups
 
 log = get_logger(__file__)
 
@@ -20,10 +26,31 @@ def handler(event, context):
     email = params.get('email')
 
     log.info(f"Listing all groups for user {email}")
-    groups = list_groups_for_user(email)
-    log.info(f"Found {len(groups)} groups for user {email}")
+    memberships = list_groups_for_user(email)
+    log.info(f"Found {len(memberships)} memberships for user {email}")
+
+    group_ids = [m.get("groupId") for m in memberships if m.get("groupId")]
+    group_items = batch_get_groups(group_ids)
+    group_by_id = {g["groupId"]: g for g in group_items if g.get("groupId")}
+
+    # Merge membership metadata (role, joinedAt) into the hydrated group
+    # object so clients get both the group state and the caller's relationship
+    # in one payload. Drops memberships whose group has been deleted.
+    hydrated = []
+    for m in memberships:
+        gid = m.get("groupId")
+        group = group_by_id.get(gid)
+        if not group:
+            log.warning(f"Membership references missing group {gid}; dropping")
+            continue
+        merged = {**group}
+        if "role" in m:
+            merged["role"] = m["role"]
+        if "joinedAt" in m:
+            merged["joinedAt"] = m["joinedAt"]
+        hydrated.append(merged)
 
     return success_response({
-        "groups": groups,
-        "totalGroups": len(groups)
+        "groups": hydrated,
+        "totalGroups": len(hydrated)
     })

--- a/tests/test_groups_list.py
+++ b/tests/test_groups_list.py
@@ -1,0 +1,105 @@
+"""
+Tests for groups_list lambda — ensures membership rows are hydrated
+with full Group metadata before returning, so clients don't see
+headless rows that fail to decode.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.groups_list.handler import handler
+
+
+@patch('lambdas.groups_list.handler.batch_get_groups')
+@patch('lambdas.groups_list.handler.list_groups_for_user')
+def test_groups_list_hydrates_membership_with_group_metadata(
+    mock_list_memberships, mock_batch_get, mock_context, api_gateway_event
+):
+    """Membership rows get merged with the full Group item so `name`,
+    `createdBy`, `memberCount` end up on the wire."""
+    mock_list_memberships.return_value = [
+        {"email": "test@example.com", "groupId": "g1", "role": "owner",  "joinedAt": "2026-01-01 00:00:00"},
+        {"email": "test@example.com", "groupId": "g2", "role": "member", "joinedAt": "2026-02-01 00:00:00"}
+    ]
+    mock_batch_get.return_value = [
+        {"groupId": "g1", "name": "Summer Tunes", "createdBy": "test@example.com", "memberCount": 4, "createdAt": "2026-01-01 00:00:00"},
+        {"groupId": "g2", "name": "Road Trip",   "createdBy": "other@example.com", "memberCount": 7, "createdAt": "2026-01-10 00:00:00"}
+    ]
+
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/groups/list",
+        "queryStringParameters": {"email": "test@example.com"}
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['totalGroups'] == 2
+    assert len(body['groups']) == 2
+
+    g1 = next(g for g in body['groups'] if g['groupId'] == 'g1')
+    assert g1['name'] == 'Summer Tunes'
+    assert g1['memberCount'] == 4
+    assert g1['role'] == 'owner'
+    assert g1['joinedAt'] == '2026-01-01 00:00:00'
+
+    g2 = next(g for g in body['groups'] if g['groupId'] == 'g2')
+    assert g2['name'] == 'Road Trip'
+    assert g2['role'] == 'member'
+
+
+@patch('lambdas.groups_list.handler.batch_get_groups')
+@patch('lambdas.groups_list.handler.list_groups_for_user')
+def test_groups_list_drops_memberships_with_missing_group(
+    mock_list_memberships, mock_batch_get, mock_context, api_gateway_event
+):
+    """If the Groups table no longer has a row for a membership's groupId
+    (e.g. the group was deleted but the membership wasn't cleaned up), the
+    stale membership is dropped rather than returning a headless row."""
+    mock_list_memberships.return_value = [
+        {"email": "test@example.com", "groupId": "alive",   "role": "member"},
+        {"email": "test@example.com", "groupId": "deleted", "role": "member"}
+    ]
+    mock_batch_get.return_value = [
+        {"groupId": "alive", "name": "Still Here", "createdBy": "owner@test.com", "memberCount": 2}
+    ]
+
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/groups/list",
+        "queryStringParameters": {"email": "test@example.com"}
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['totalGroups'] == 1
+    assert body['groups'][0]['groupId'] == 'alive'
+
+
+@patch('lambdas.groups_list.handler.batch_get_groups')
+@patch('lambdas.groups_list.handler.list_groups_for_user')
+def test_groups_list_empty(
+    mock_list_memberships, mock_batch_get, mock_context, api_gateway_event
+):
+    mock_list_memberships.return_value = []
+    mock_batch_get.return_value = []
+
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/groups/list",
+        "queryStringParameters": {"email": "test@example.com"}
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['totalGroups'] == 0
+    assert body['groups'] == []


### PR DESCRIPTION
## Summary
- `/groups/list` now joins user memberships against the GROUPS table with `BatchGetItem` so every row includes `name`, `description`, `memberCount`, `trackCount`, `createdBy`, `createdAt`
- Drops memberships that point at a deleted group (table miss) instead of returning a headless stub
- Role + joinedAt from the membership record are merged onto the hydrated group

## Root cause
The handler was returning the raw membership rows, which only carry `groupId`, `role`, and `joinedAt`. iOS `XomifyGroup` requires `name` (among others), so the client failed to decode with "The data couldn't be read because it is missing."

## Test plan
- [x] New unit tests: `tests/test_groups_list.py` — hydrates membership with metadata, drops memberships whose group is gone, empty list
- [ ] Deploy → verify iOS Groups tab renders names + counts (no decode error)