### PR TITLE
feat(friends_profile): include owner's public playlists

### DIFF
--- a/lambdas/common/friends_profile_helper.py
+++ b/lambdas/common/friends_profile_helper.py
@@ -1,8 +1,12 @@
 import aiohttp
 from lambdas.common.spotify import Spotify
+from lambdas.common.aiohttp_helper import fetch_json
 from lambdas.common.logger import get_logger
 
 log = get_logger(__file__)
+
+SPOTIFY_BASE_URL = "https://api.spotify.com/v1"
+PUBLIC_PLAYLISTS_LIMIT = 50
 
 
 async def get_user_top_items(user: dict) -> dict:
@@ -32,3 +36,65 @@ async def get_user_top_items(user: dict) -> dict:
     except Exception as err:
         log.error(f"Get User Top Items: {err}")
         raise Exception(f"Get User Top Items: {err}") from err
+
+
+async def get_user_public_playlists(user: dict) -> list:
+    """
+    Fetch a user's *public* playlists (ones they own and marked public).
+
+    Called via the target user's own access token. `/me/playlists` returns
+    followed playlists too — we filter to `public=True AND owner.id == user_id`
+    so the friend profile only shows playlists they authored publicly.
+
+    Returns a slim list of dicts ready to embed in the friend-profile
+    response: `id, name, description, imageUrl, trackCount, uri, externalUrl`.
+    On any error, returns an empty list so the profile still renders.
+    """
+    try:
+        user_id = user.get('userId', '')
+        log.info(f"Fetching public playlists for user {user.get('email', 'unknown')} (id={user_id})")
+
+        async with aiohttp.ClientSession() as session:
+            spotify = Spotify(user, session)
+            access_token = await spotify.aiohttp_get_access_token()
+            headers = {
+                'Authorization': f'Bearer {access_token}',
+                'Content-Type': 'application/json'
+            }
+
+            url = f"{SPOTIFY_BASE_URL}/me/playlists?limit={PUBLIC_PLAYLISTS_LIMIT}"
+            data = await fetch_json(session, url, headers=headers)
+
+            items = data.get('items', []) or []
+
+            slim = []
+            for p in items:
+                if not p:
+                    continue
+                if not p.get('public'):
+                    continue
+                owner = p.get('owner') or {}
+                if owner.get('id') != user_id:
+                    continue
+
+                images = p.get('images') or []
+                image_url = images[0].get('url') if images else None
+                tracks = p.get('tracks') or {}
+
+                slim.append({
+                    'id': p.get('id'),
+                    'name': p.get('name'),
+                    'description': p.get('description') or '',
+                    'imageUrl': image_url,
+                    'trackCount': tracks.get('total', 0),
+                    'uri': p.get('uri'),
+                    'externalUrl': (p.get('external_urls') or {}).get('spotify')
+                })
+
+            log.info(f"Returning {len(slim)} public playlists for {user.get('email', 'unknown')}")
+            return slim
+
+    except Exception as err:
+        # Don't fail the whole friend profile just because playlists failed
+        log.error(f"Get User Public Playlists: {err}")
+        return []

--- a/lambdas/friends_profile/handler.py
+++ b/lambdas/friends_profile/handler.py
@@ -7,11 +7,19 @@ from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
 from lambdas.common.dynamo_helpers import get_user_table_data
-from lambdas.common.friends_profile_helper import get_user_top_items
+from lambdas.common.friends_profile_helper import get_user_top_items, get_user_public_playlists
 
 log = get_logger(__file__)
 
 HANDLER = 'friends_profile'
+
+
+async def _gather_profile(friend_user: dict) -> dict:
+    """Fetch top items and public playlists concurrently."""
+    top_items_task = get_user_top_items(friend_user)
+    playlists_task = get_user_public_playlists(friend_user)
+    top_items, playlists = await asyncio.gather(top_items_task, playlists_task)
+    return {'top_items': top_items, 'playlists': playlists}
 
 
 @handle_errors(HANDLER)
@@ -25,7 +33,9 @@ def handler(event, context):
     friend_user = get_user_table_data(friend_email)
     log.info(f"Retrieved data for {friend_email}")
 
-    friend_top_items = asyncio.run(get_user_top_items(friend_user))
+    result = asyncio.run(_gather_profile(friend_user))
+    friend_top_items = result['top_items']
+    friend_playlists = result['playlists']
 
     return success_response({
         'displayName': friend_user.get('displayName', None),
@@ -35,4 +45,5 @@ def handler(event, context):
         'topSongs': friend_top_items['tracks'],
         'topArtists': friend_top_items['artists'],
         'topGenres': friend_top_items['genres'],
+        'playlists': friend_playlists,
     })

--- a/tests/test_friends_profile.py
+++ b/tests/test_friends_profile.py
@@ -8,14 +8,16 @@ from unittest.mock import patch, AsyncMock
 from lambdas.friends_profile.handler import handler
 
 
+@patch('lambdas.friends_profile.handler.get_user_public_playlists')
 @patch('lambdas.friends_profile.handler.get_user_top_items')
 @patch('lambdas.friends_profile.handler.get_user_table_data')
-def test_friends_profile_success(mock_get_user, mock_get_top_items, mock_context, api_gateway_event, sample_user, sample_top_items):
+def test_friends_profile_success(mock_get_user, mock_get_top_items, mock_get_playlists, mock_context, api_gateway_event, sample_user, sample_top_items):
     """Test successful friend profile retrieval"""
     # Setup
     mock_get_user.return_value = sample_user
-    # Mock the async function properly
+    # Mock the async coroutines
     mock_get_top_items.return_value = sample_top_items
+    mock_get_playlists.return_value = []
 
     event = {
         **api_gateway_event,
@@ -34,12 +36,15 @@ def test_friends_profile_success(mock_get_user, mock_get_top_items, mock_context
     assert 'topSongs' in body
     assert 'topArtists' in body
     assert 'topGenres' in body
+    assert 'playlists' in body
+    assert body['playlists'] == []
     assert body['displayName'] == sample_user['displayName']
 
 
+@patch('lambdas.friends_profile.handler.get_user_public_playlists')
 @patch('lambdas.friends_profile.handler.get_user_top_items')
 @patch('lambdas.friends_profile.handler.get_user_table_data')
-def test_friends_profile_missing_email(mock_get_user, mock_get_top_items, mock_context, api_gateway_event):
+def test_friends_profile_missing_email(mock_get_user, mock_get_top_items, mock_get_playlists, mock_context, api_gateway_event):
     """Test missing friendEmail parameter"""
     # Setup
     event = {


### PR DESCRIPTION
## Summary
- `friends_profile` now returns a `playlists` array alongside top items.
- New helper `get_user_public_playlists(user)` hits `/me/playlists` with the target user's access token and filters to `public=True AND owner.id==user_id`. Followed (non-owned) playlists are intentionally excluded.
- Top items + playlists fetch runs in parallel via `asyncio.gather`.
- Playlist errors are swallowed and return `[]` so a flaky playlist fetch doesn't break the whole friend profile response.

## Response shape
Each playlist item:
```
{ id, name, description, imageUrl, trackCount, uri, externalUrl }
```

## Test plan
- [x] Unit: existing `test_friends_profile` tests updated to mock the new async helper — both pass.
- [ ] Smoke: GET /friends/profile?friendEmail=... in staging and confirm `playlists` is present and shaped as above.
- [ ] iOS: verify friend profile Playlists tab renders once backend is deployed.