### PR TITLE
fix(groups,shares): add-song flat fields + live memberCount + /shares/detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ List shares authored by `targetEmail`, newest first.
 **POST** `/shares/react`
 Toggle or set a reaction on a share (see sub-feature #4 for full schema).
 
+**GET** `/shares/detail?email={viewer}&shareId={shareId}`
+Full detail view for a single share. Returns `{ share, interactions, friendRatings }` where `share` is the full share row with viewer-specific enrichment (queuedCount, ratedCount, viewerHasQueued, viewerRating, sharerRating), `interactions` is a deduped list of `(email, action)` events with viewer profiles hydrated, and `friendRatings` is the viewer's accepted friends' ratings (plus the author's rating) for the share's track. Accepts optional `sharedBy` / `sharedAt` for forward compat with iOS payloads — both are ignored server-side.
+
 ### Invites Service (`/invites`)
 
 **POST** `/invites/create`

--- a/lambdas/common/dynamo_helpers.py
+++ b/lambdas/common/dynamo_helpers.py
@@ -330,6 +330,48 @@ def get_user_table_data(email: str) -> dict:
         raise
 
 
+def batch_get_users(emails: list[str]) -> dict:
+    """
+    BatchGetItem helper for the USERS table — returns a
+    {email: {email, displayName, avatar, ...}} map.
+
+    DynamoDB caps BatchGetItem at 100 keys per call; we chunk
+    transparently. Missing emails are simply absent from the map
+    (callers should handle the miss). Duplicates are deduped first
+    to avoid wasted RCUs.
+    """
+    if not emails:
+        return {}
+
+    unique = [e for e in {x for x in emails if x}]
+    out: dict[str, dict] = {}
+
+    for i in range(0, len(unique), 100):
+        chunk = unique[i:i + 100]
+        try:
+            response = dynamodb.batch_get_item(
+                RequestItems={
+                    USERS_TABLE_NAME: {
+                        "Keys": [{"email": e} for e in chunk]
+                    }
+                }
+            )
+            items = response.get("Responses", {}).get(USERS_TABLE_NAME, []) or []
+            for item in items:
+                email = item.get("email")
+                if email:
+                    out[email] = item
+        except Exception as err:
+            log.error(f"Batch get users failed: {err}")
+            raise DynamoDBError(
+                message=str(err),
+                function="batch_get_users",
+                table=USERS_TABLE_NAME,
+            )
+
+    return out
+
+
 # ============================================
 # Wrapped History Table Operations
 # ============================================

--- a/lambdas/common/groups_dynamo.py
+++ b/lambdas/common/groups_dynamo.py
@@ -113,6 +113,33 @@ def batch_get_groups(group_ids: list[str]) -> list[dict]:
     return out
 
 
+def update_group_member_count(group_id: str, member_count: int) -> bool:
+    """
+    Overwrite the cached `memberCount` attribute on a GROUPS row.
+
+    Used by /groups/list to heal stale counts left over from the pre-PR#136
+    seed bug. Callers should treat failures as non-fatal — this is a
+    best-effort self-heal, never a required side effect.
+    """
+    try:
+        table = dynamodb.Table(GROUPS_TABLE_NAME)
+        table.update_item(
+            Key={"groupId": group_id},
+            UpdateExpression="SET memberCount = :c",
+            ExpressionAttributeValues={":c": member_count},
+            ConditionExpression="attribute_exists(groupId)",
+        )
+        return True
+
+    except Exception as err:
+        log.error(f"Update Group Member Count failed: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="update_group_member_count",
+            table=GROUPS_TABLE_NAME,
+        )
+
+
 def _deserialize_item(raw: dict) -> dict:
     """Unwrap DynamoDB low-level attribute format to plain dict."""
     out: dict = {}

--- a/lambdas/groups_add_song/handler.py
+++ b/lambdas/groups_add_song/handler.py
@@ -1,5 +1,27 @@
 """
-POST /groups/add-song - Add a song to group (with track data)
+POST /groups/add-song - Add a song to group (with track data).
+
+Accepts two request shapes so iOS and legacy web callers can share the
+endpoint:
+
+1. Nested (legacy):
+    {
+        email, groupId, trackId,
+        track: {
+            name,
+            artists: [{name}],
+            album:  {images: [{url}]}
+        }
+    }
+
+2. Flat (iOS client):
+    {
+        email, groupId, trackId,
+        trackName, artistName, albumName, imageUrl
+    }
+
+email / groupId / trackId are required in both shapes. All other track
+metadata is optional — a missing field just won't be persisted.
 """
 
 from lambdas.common.logger import get_logger
@@ -12,25 +34,46 @@ log = get_logger(__file__)
 HANDLER = 'groups_add_song'
 
 
+def _extract_track_fields(body: dict) -> tuple[str | None, str | None, str | None, str | None]:
+    """Return (trackName, artistName, albumName, imageUrl) regardless of shape.
+
+    Prefer the nested `track` object when present (legacy callers), fall back
+    to the flat top-level fields (iOS)."""
+    track = body.get('track')
+    if isinstance(track, dict):
+        track_name = track.get('name')
+        artists = track.get('artists') or []
+        artist_name = artists[0].get('name') if artists and isinstance(artists[0], dict) else None
+        album = track.get('album') or {}
+        album_name = album.get('name') if isinstance(album, dict) else None
+        images = album.get('images') or [] if isinstance(album, dict) else []
+        image_url = images[0].get('url') if images and isinstance(images[0], dict) else None
+        return track_name, artist_name, album_name, image_url
+
+    # Flat shape — iOS client
+    return (
+        body.get('trackName'),
+        body.get('artistName'),
+        body.get('albumName'),
+        body.get('imageUrl'),
+    )
+
+
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId', 'trackId', 'track')
+    require_fields(body, 'email', 'groupId', 'trackId')
 
     email = body.get('email')
     group_id = body.get('groupId')
     track_id = body.get('trackId')
-    track = body.get('track')
 
-    # Extract track details
-    track_name = track.get('name')
-    artists = track.get('artists', [])
-    artist_name = artists[0].get('name') if artists else None
-    album = track.get('album', {})
-    images = album.get('images', [])
-    album_image_url = images[0].get('url') if images else None
+    track_name, artist_name, album_name, image_url = _extract_track_fields(body)
 
-    log.info(f"User {email} adding track {track_id} to group {group_id}")
+    log.info(
+        f"User {email} adding track {track_id} to group {group_id} "
+        f"(trackName={track_name!r} artistName={artist_name!r})"
+    )
 
     add_track_to_group(
         group_id=group_id,
@@ -38,7 +81,7 @@ def handler(event, context):
         added_by=email,
         track_name=track_name,
         artist_name=artist_name,
-        album_image_url=album_image_url
+        album_image_url=image_url,
     )
 
     log.info(f"Track {track_id} added to group {group_id}")
@@ -49,5 +92,6 @@ def handler(event, context):
         'addedBy': email,
         'trackName': track_name,
         'artistName': artist_name,
-        'albumImageUrl': album_image_url
+        'albumName': album_name,
+        'albumImageUrl': image_url,
     })

--- a/lambdas/groups_list/handler.py
+++ b/lambdas/groups_list/handler.py
@@ -5,13 +5,21 @@ Returns fully-hydrated group objects. The membership table only stores
 (email, groupId, role, joinedAt), so we BatchGetItem the GROUPS table to
 attach name / createdBy / memberCount / etc. Without this join, clients
 see headless membership rows and fail to decode.
+
+memberCount is recomputed LIVE from the membership GSI on every call.
+The cached `memberCount` attribute on the GROUPS row was historically
+populated by a buggy seed that set fresh 1-member groups to 2 (fixed by
+PR #136 for new groups but never backfilled). To avoid showing stale
+counts to users we always recount, and opportunistically heal the row
+with a best-effort write-back (log and continue on failure — this path
+must never break /groups/list).
 """
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
-from lambdas.common.group_members_dynamo import list_groups_for_user
-from lambdas.common.groups_dynamo import batch_get_groups
+from lambdas.common.group_members_dynamo import list_groups_for_user, list_members_of_group
+from lambdas.common.groups_dynamo import batch_get_groups, update_group_member_count
 
 log = get_logger(__file__)
 
@@ -48,6 +56,39 @@ def handler(event, context):
             merged["role"] = m["role"]
         if "joinedAt" in m:
             merged["joinedAt"] = m["joinedAt"]
+
+        # Recount members live — stale cached memberCount is the whole reason
+        # we're here. N+1 reads are acceptable because a user's group count is
+        # small (typically < 20); the alternative is shipping wrong numbers.
+        try:
+            members = list_members_of_group(gid)
+            live_count = len(members)
+        except Exception as err:
+            log.warning(
+                f"Live recount failed for group {gid}, "
+                f"falling back to cached memberCount: {err}"
+            )
+            live_count = merged.get("memberCount", 0)
+
+        cached = merged.get("memberCount")
+        merged["memberCount"] = live_count
+
+        # Opportunistic heal: if the cached value drifted, write the live
+        # count back so future reads don't have to recount. Never let this
+        # break the request.
+        if cached != live_count:
+            try:
+                update_group_member_count(gid, live_count)
+                log.info(
+                    f"Healed stale memberCount on group {gid}: "
+                    f"cached={cached} -> live={live_count}"
+                )
+            except Exception as err:
+                log.warning(
+                    f"memberCount heal failed for group {gid} "
+                    f"(cached={cached} live={live_count}): {err}"
+                )
+
         hydrated.append(merged)
 
     return success_response({

--- a/lambdas/shares_detail/handler.py
+++ b/lambdas/shares_detail/handler.py
@@ -1,0 +1,262 @@
+"""
+GET /shares/detail - Full detail view for a single share.
+
+Query params:
+    email    (required) - viewer email (used for viewer-specific enrichment +
+                           scoping friendRatings to the viewer's friends)
+    shareId  (required) - the share to load
+    sharedAt (optional) - accepted for forward compat; unused, since the
+                           shares table is keyed on shareId alone in v1
+    sharedBy (optional) - accepted for forward compat; unused, since the
+                           share row itself carries the author email
+
+Response:
+    {
+        "share": { ...full share + viewer enrichment (queuedCount, ratedCount,
+                   viewerHasQueued, viewerRating, sharerRating)... },
+        "interactions": [
+            {email, displayName, avatar, action, createdAt}
+            ...deduped by (email, action), derived from the share-interactions table
+        ],
+        "friendRatings": [
+            {email, displayName, avatar, rating, review, ratedAt}
+            ...the viewer's accepted friends (plus the share's author) who
+               have rated this track in the track-ratings table
+        ]
+    }
+
+Notes:
+- `review` is included in the friendRatings contract even though the track
+  ratings table doesn't currently persist a review field — it's kept as a
+  nullable slot for when the feature lands client-side.
+- Interactions with both queued=True and rated=True produce two rows (one
+  per action); that matches the iOS client's expected shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from lambdas.common.logger import get_logger
+from lambdas.common.errors import handle_errors, NotFoundError
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+)
+from lambdas.common.shares_dynamo import get_share
+from lambdas.common.interactions_dynamo import (
+    build_enrichment,
+    list_reactions_for_share,
+)
+from lambdas.common.friendships_dynamo import list_all_friends_for_user
+from lambdas.common.track_ratings_dynamo import list_all_track_ratings_for_user
+from lambdas.common.dynamo_helpers import batch_get_users
+
+log = get_logger(__file__)
+
+HANDLER = 'shares_detail'
+
+
+def _user_profile(users: dict, email: str) -> tuple[Optional[str], Optional[str]]:
+    """Return (displayName, avatar) for `email`, falling back to (None, None)."""
+    user = users.get(email) or {}
+    return user.get('displayName'), user.get('avatar')
+
+
+def _build_interactions(
+    reactions: list[dict[str, Any]],
+    users: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Collapse the share-interactions rows (one row per viewer, with
+    queued/rated boolean attributes) into a flat, deduped list of
+    (email, action) events. Output is stable-sorted by createdAt desc.
+    """
+    seen: set[tuple[str, str]] = set()
+    out: list[dict[str, Any]] = []
+
+    for item in reactions:
+        email = item.get('email')
+        if not email:
+            continue
+
+        display_name, avatar = _user_profile(users, email)
+        ts = item.get('updatedAt') or item.get('createdAt')
+
+        if item.get('queued'):
+            key = (email, 'queued')
+            if key not in seen:
+                seen.add(key)
+                out.append({
+                    'email': email,
+                    'displayName': display_name,
+                    'avatar': avatar,
+                    'action': 'queued',
+                    'createdAt': item.get('queuedAt') or ts,
+                })
+
+        if item.get('rated'):
+            key = (email, 'rated')
+            if key not in seen:
+                seen.add(key)
+                out.append({
+                    'email': email,
+                    'displayName': display_name,
+                    'avatar': avatar,
+                    'action': 'rated',
+                    'createdAt': item.get('ratedAt') or ts,
+                })
+
+    out.sort(key=lambda r: r.get('createdAt') or '', reverse=True)
+    return out
+
+
+def _accepted_friend_emails(viewer_email: str) -> list[str]:
+    """Return the viewer's accepted-friend emails."""
+    friends = list_all_friends_for_user(viewer_email)
+    return [
+        f.get('friendEmail')
+        for f in friends
+        if f.get('status') == 'accepted' and f.get('friendEmail')
+    ]
+
+
+def _build_friend_ratings(
+    viewer_email: str,
+    author_email: Optional[str],
+    track_id: str,
+    users: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """
+    Load the viewer's accepted-friend ratings for this track, plus the
+    share's author rating (even if not a friend).
+
+    Returns (ratings, emails_lookup_list) — the second element lets the
+    caller ensure every rater's profile was fetched.
+    """
+    friend_emails = _accepted_friend_emails(viewer_email)
+    candidates = list(friend_emails)
+    if author_email and author_email not in candidates and author_email != viewer_email:
+        candidates.append(author_email)
+
+    ratings: list[dict[str, Any]] = []
+    for candidate in candidates:
+        try:
+            rows = list_all_track_ratings_for_user(candidate)
+        except Exception as err:
+            log.warning(f"Failed to load ratings for {candidate}: {err}")
+            continue
+        for row in rows or []:
+            if row.get('trackId') != track_id:
+                continue
+            display_name, avatar = _user_profile(users, candidate)
+            ratings.append({
+                'email': candidate,
+                'displayName': display_name,
+                'avatar': avatar,
+                'rating': row.get('rating'),
+                'review': row.get('review'),  # slot for future content
+                'ratedAt': row.get('ratedAt'),
+            })
+
+    ratings.sort(key=lambda r: r.get('ratedAt') or '', reverse=True)
+    return ratings, candidates
+
+
+def _enrich_share(share: dict[str, Any], viewer_email: str) -> dict[str, Any]:
+    """Mirror shares_feed's _enrich — never let enrichment drop the share."""
+    share_id = share.get('shareId')
+    if not share_id:
+        share.setdefault('queuedCount', 0)
+        share.setdefault('ratedCount', 0)
+        share.setdefault('viewerHasQueued', False)
+        share.setdefault('viewerRating', None)
+        share.setdefault('sharerRating', None)
+        return share
+    try:
+        share.update(build_enrichment(share_id, viewer_email))
+    except Exception as err:
+        log.warning(f"Detail enrichment failed for share {share_id}: {err}")
+        share.setdefault('queuedCount', 0)
+        share.setdefault('ratedCount', 0)
+        share.setdefault('viewerHasQueued', False)
+        share.setdefault('viewerRating', None)
+        share.setdefault('sharerRating', None)
+    return share
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    params = get_query_params(event)
+    require_fields(params, 'email', 'shareId')
+
+    viewer_email = params.get('email')
+    share_id = params.get('shareId')
+    # Accepted for forward compat with iOS payloads; not required because
+    # the shares table is keyed on shareId alone and the row carries the
+    # author email. Keep them out of validation so the client can evolve
+    # without breaking this endpoint.
+    _ = params.get('sharedAt')
+    _ = params.get('sharedBy')
+
+    log.info(f"Loading share detail {share_id} for viewer {viewer_email}")
+
+    share = get_share(share_id)
+    if not share:
+        raise NotFoundError(
+            message=f"Share {share_id} not found",
+            handler=HANDLER,
+            function='handler',
+            resource='share',
+        )
+
+    author_email: Optional[str] = share.get('email')
+    track_id: Optional[str] = share.get('trackId')
+
+    reactions = list_reactions_for_share(share_id)
+
+    # Resolve user profiles (displayName, avatar) for every email we'll
+    # surface. Collect the full set up front so we make ONE batch-get call.
+    reactor_emails = [r.get('email') for r in reactions if r.get('email')]
+    friend_emails = _accepted_friend_emails(viewer_email)
+
+    profile_emails: set[str] = set()
+    profile_emails.update(reactor_emails)
+    profile_emails.update(friend_emails)
+    if author_email:
+        profile_emails.add(author_email)
+    profile_emails.add(viewer_email)
+
+    try:
+        users = batch_get_users(list(profile_emails))
+    except Exception as err:
+        log.warning(f"Batch user lookup failed, degrading to empty map: {err}")
+        users = {}
+
+    interactions_payload = _build_interactions(reactions, users)
+
+    friend_ratings_payload: list[dict[str, Any]] = []
+    if track_id:
+        friend_ratings_payload, _ = _build_friend_ratings(
+            viewer_email=viewer_email,
+            author_email=author_email,
+            track_id=track_id,
+            users=users,
+        )
+    else:
+        log.warning(f"Share {share_id} has no trackId; skipping friendRatings")
+
+    enriched_share = _enrich_share(dict(share), viewer_email)
+
+    log.info(
+        f"Returning detail for share {share_id}: "
+        f"{len(interactions_payload)} interactions, "
+        f"{len(friend_ratings_payload)} friendRatings"
+    )
+
+    return success_response({
+        'share': enriched_share,
+        'interactions': interactions_payload,
+        'friendRatings': friend_ratings_payload,
+    })

--- a/tests/test_groups_add_song.py
+++ b/tests/test_groups_add_song.py
@@ -1,0 +1,147 @@
+"""
+Tests for groups_add_song lambda.
+
+The handler must accept BOTH request shapes:
+  1. nested `track: {name, artists[{name}], album.images[{url}]}` (legacy)
+  2. flat `{trackName, artistName, albumName, imageUrl}` (iOS client)
+
+email / groupId / trackId are always required.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.groups_add_song.handler import handler
+
+
+def _event(api_gateway_event, body):
+    return {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/groups/add-song",
+        "body": json.dumps(body),
+    }
+
+
+@patch('lambdas.groups_add_song.handler.add_track_to_group')
+def test_groups_add_song_flat_shape_ios(mock_add, mock_context, api_gateway_event):
+    """iOS sends flat top-level fields — no `track` object."""
+    body = {
+        "email": "user@example.com",
+        "groupId": "g1",
+        "trackId": "spotify:track:1",
+        "trackName": "Bohemian Rhapsody",
+        "artistName": "Queen",
+        "albumName": "A Night at the Opera",
+        "imageUrl": "https://i.scdn.co/image/abc.jpg",
+    }
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 200
+    payload = json.loads(response['body'])
+    assert payload['trackId'] == "spotify:track:1"
+    assert payload['trackName'] == "Bohemian Rhapsody"
+    assert payload['artistName'] == "Queen"
+    assert payload['albumName'] == "A Night at the Opera"
+    assert payload['albumImageUrl'] == "https://i.scdn.co/image/abc.jpg"
+
+    kwargs = mock_add.call_args.kwargs
+    assert kwargs['group_id'] == 'g1'
+    assert kwargs['track_id'] == 'spotify:track:1'
+    assert kwargs['added_by'] == 'user@example.com'
+    assert kwargs['track_name'] == 'Bohemian Rhapsody'
+    assert kwargs['artist_name'] == 'Queen'
+    assert kwargs['album_image_url'] == 'https://i.scdn.co/image/abc.jpg'
+
+
+@patch('lambdas.groups_add_song.handler.add_track_to_group')
+def test_groups_add_song_nested_shape_legacy(mock_add, mock_context, api_gateway_event):
+    """Legacy nested `track` object still works."""
+    body = {
+        "email": "user@example.com",
+        "groupId": "g1",
+        "trackId": "spotify:track:1",
+        "track": {
+            "name": "Bohemian Rhapsody",
+            "artists": [{"name": "Queen"}],
+            "album": {
+                "name": "A Night at the Opera",
+                "images": [{"url": "https://i.scdn.co/image/abc.jpg"}],
+            },
+        },
+    }
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 200
+    payload = json.loads(response['body'])
+    assert payload['trackName'] == "Bohemian Rhapsody"
+    assert payload['artistName'] == "Queen"
+    assert payload['albumName'] == "A Night at the Opera"
+    assert payload['albumImageUrl'] == "https://i.scdn.co/image/abc.jpg"
+
+    kwargs = mock_add.call_args.kwargs
+    assert kwargs['track_name'] == 'Bohemian Rhapsody'
+    assert kwargs['artist_name'] == 'Queen'
+    assert kwargs['album_image_url'] == 'https://i.scdn.co/image/abc.jpg'
+
+
+@patch('lambdas.groups_add_song.handler.add_track_to_group')
+def test_groups_add_song_missing_required_field(mock_add, mock_context, api_gateway_event):
+    """Missing trackId -> 400, and we don't touch Dynamo."""
+    body = {
+        "email": "user@example.com",
+        "groupId": "g1",
+        "trackName": "Bohemian Rhapsody",
+    }
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 400
+    mock_add.assert_not_called()
+
+
+@patch('lambdas.groups_add_song.handler.add_track_to_group')
+def test_groups_add_song_flat_shape_tolerates_missing_metadata(
+    mock_add, mock_context, api_gateway_event
+):
+    """Only the three required keys are needed — track metadata is optional."""
+    body = {
+        "email": "user@example.com",
+        "groupId": "g1",
+        "trackId": "spotify:track:1",
+    }
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 200
+    kwargs = mock_add.call_args.kwargs
+    assert kwargs['track_name'] is None
+    assert kwargs['artist_name'] is None
+    assert kwargs['album_image_url'] is None
+
+
+@patch('lambdas.groups_add_song.handler.add_track_to_group')
+def test_groups_add_song_nested_shape_with_empty_arrays(
+    mock_add, mock_context, api_gateway_event
+):
+    """Nested shape with empty artists/images lists — should not crash."""
+    body = {
+        "email": "user@example.com",
+        "groupId": "g1",
+        "trackId": "spotify:track:1",
+        "track": {
+            "name": "Some Song",
+            "artists": [],
+            "album": {"name": "X", "images": []},
+        },
+    }
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 200
+    kwargs = mock_add.call_args.kwargs
+    assert kwargs['track_name'] == 'Some Song'
+    assert kwargs['artist_name'] is None
+    assert kwargs['album_image_url'] is None

--- a/tests/test_groups_list.py
+++ b/tests/test_groups_list.py
@@ -2,6 +2,11 @@
 Tests for groups_list lambda — ensures membership rows are hydrated
 with full Group metadata before returning, so clients don't see
 headless rows that fail to decode.
+
+memberCount is always recomputed live from the membership GSI — the
+cached attribute on the GROUPS row has historically drifted (old seed
+set fresh 1-member groups to 2 until PR #136). The handler also issues
+a best-effort write-back to heal the stored value.
 """
 
 import json
@@ -10,10 +15,13 @@ from unittest.mock import patch
 from lambdas.groups_list.handler import handler
 
 
+@patch('lambdas.groups_list.handler.update_group_member_count')
+@patch('lambdas.groups_list.handler.list_members_of_group')
 @patch('lambdas.groups_list.handler.batch_get_groups')
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_hydrates_membership_with_group_metadata(
-    mock_list_memberships, mock_batch_get, mock_context, api_gateway_event
+    mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
+    mock_context, api_gateway_event,
 ):
     """Membership rows get merged with the full Group item so `name`,
     `createdBy`, `memberCount` end up on the wire."""
@@ -25,6 +33,11 @@ def test_groups_list_hydrates_membership_with_group_metadata(
         {"groupId": "g1", "name": "Summer Tunes", "createdBy": "test@example.com", "memberCount": 4, "createdAt": "2026-01-01 00:00:00"},
         {"groupId": "g2", "name": "Road Trip",   "createdBy": "other@example.com", "memberCount": 7, "createdAt": "2026-01-10 00:00:00"}
     ]
+    # Live membership matches cached counts -> no heal.
+    mock_list_members.side_effect = lambda gid: (
+        [{"email": f"u{i}@example.com"} for i in range(4)] if gid == 'g1'
+        else [{"email": f"u{i}@example.com"} for i in range(7)]
+    )
 
     event = {
         **api_gateway_event,
@@ -49,12 +62,19 @@ def test_groups_list_hydrates_membership_with_group_metadata(
     g2 = next(g for g in body['groups'] if g['groupId'] == 'g2')
     assert g2['name'] == 'Road Trip'
     assert g2['role'] == 'member'
+    assert g2['memberCount'] == 7
+
+    # Cached == live so no heal should fire.
+    mock_update_count.assert_not_called()
 
 
+@patch('lambdas.groups_list.handler.update_group_member_count')
+@patch('lambdas.groups_list.handler.list_members_of_group')
 @patch('lambdas.groups_list.handler.batch_get_groups')
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_drops_memberships_with_missing_group(
-    mock_list_memberships, mock_batch_get, mock_context, api_gateway_event
+    mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
+    mock_context, api_gateway_event,
 ):
     """If the Groups table no longer has a row for a membership's groupId
     (e.g. the group was deleted but the membership wasn't cleaned up), the
@@ -65,6 +85,10 @@ def test_groups_list_drops_memberships_with_missing_group(
     ]
     mock_batch_get.return_value = [
         {"groupId": "alive", "name": "Still Here", "createdBy": "owner@test.com", "memberCount": 2}
+    ]
+    mock_list_members.return_value = [
+        {"email": "owner@test.com"},
+        {"email": "test@example.com"},
     ]
 
     event = {
@@ -80,12 +104,16 @@ def test_groups_list_drops_memberships_with_missing_group(
     body = json.loads(response['body'])
     assert body['totalGroups'] == 1
     assert body['groups'][0]['groupId'] == 'alive'
+    assert body['groups'][0]['memberCount'] == 2
 
 
+@patch('lambdas.groups_list.handler.update_group_member_count')
+@patch('lambdas.groups_list.handler.list_members_of_group')
 @patch('lambdas.groups_list.handler.batch_get_groups')
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_empty(
-    mock_list_memberships, mock_batch_get, mock_context, api_gateway_event
+    mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
+    mock_context, api_gateway_event,
 ):
     mock_list_memberships.return_value = []
     mock_batch_get.return_value = []
@@ -103,3 +131,77 @@ def test_groups_list_empty(
     body = json.loads(response['body'])
     assert body['totalGroups'] == 0
     assert body['groups'] == []
+    mock_list_members.assert_not_called()
+    mock_update_count.assert_not_called()
+
+
+@patch('lambdas.groups_list.handler.update_group_member_count')
+@patch('lambdas.groups_list.handler.list_members_of_group')
+@patch('lambdas.groups_list.handler.batch_get_groups')
+@patch('lambdas.groups_list.handler.list_groups_for_user')
+def test_groups_list_returns_live_member_count_when_cache_is_stale(
+    mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
+    mock_context, api_gateway_event,
+):
+    """Regression test for the seed-bug leftover: cached memberCount=2 on a
+    group that actually has 1 member. The response must carry the live count,
+    and the handler should opportunistically heal the stored value."""
+    mock_list_memberships.return_value = [
+        {"email": "solo@example.com", "groupId": "stale", "role": "owner"},
+    ]
+    # Stale cached value — the bug that motivated this fix.
+    mock_batch_get.return_value = [
+        {"groupId": "stale", "name": "Just Me", "createdBy": "solo@example.com", "memberCount": 2}
+    ]
+    # GSI shows the group truly has one member.
+    mock_list_members.return_value = [{"email": "solo@example.com"}]
+
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/groups/list",
+        "queryStringParameters": {"email": "solo@example.com"}
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['totalGroups'] == 1
+    assert body['groups'][0]['memberCount'] == 1, (
+        "response must carry live count, not cached stale value"
+    )
+    # Heal fired exactly once with the corrected count.
+    mock_update_count.assert_called_once_with("stale", 1)
+
+
+@patch('lambdas.groups_list.handler.update_group_member_count')
+@patch('lambdas.groups_list.handler.list_members_of_group')
+@patch('lambdas.groups_list.handler.batch_get_groups')
+@patch('lambdas.groups_list.handler.list_groups_for_user')
+def test_groups_list_heal_failure_does_not_break_response(
+    mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
+    mock_context, api_gateway_event,
+):
+    """A blow-up from the best-effort write-back must not fail the request."""
+    mock_list_memberships.return_value = [
+        {"email": "solo@example.com", "groupId": "stale", "role": "owner"},
+    ]
+    mock_batch_get.return_value = [
+        {"groupId": "stale", "name": "Just Me", "createdBy": "solo@example.com", "memberCount": 2}
+    ]
+    mock_list_members.return_value = [{"email": "solo@example.com"}]
+    mock_update_count.side_effect = RuntimeError("DynamoDB threw")
+
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/groups/list",
+        "queryStringParameters": {"email": "solo@example.com"}
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['groups'][0]['memberCount'] == 1

--- a/tests/test_shares_detail.py
+++ b/tests/test_shares_detail.py
@@ -1,0 +1,296 @@
+"""
+Tests for shares_detail lambda.
+
+Covers:
+- happy path (share + interactions + friendRatings are wired together)
+- missing share -> 404
+- missing required fields -> 400
+- interactions dedupe on (email, action)
+- friendRatings filtered to the viewer's accepted friends + the author
+- enrichment failures do not drop the share
+"""
+
+from unittest.mock import patch
+import json
+
+from lambdas.shares_detail.handler import handler
+
+
+def _event(api_gateway_event, params):
+    return {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/detail",
+        "queryStringParameters": params,
+    }
+
+
+def _share():
+    return {
+        "shareId": "share-1",
+        "email": "alice@example.com",          # author
+        "trackId": "spotify:track:1",
+        "trackUri": "spotify:track:1",
+        "trackName": "Bohemian Rhapsody",
+        "artistName": "Queen",
+        "albumName": "A Night at the Opera",
+        "albumArtUrl": "https://img.example.com/boh.jpg",
+        "createdAt": "2026-04-20T12:00:00+00:00",
+        "sharedAt": "2026-04-20T12:00:00+00:00",
+    }
+
+
+@patch('lambdas.shares_detail.handler.batch_get_users')
+@patch('lambdas.shares_detail.handler.list_all_track_ratings_for_user')
+@patch('lambdas.shares_detail.handler.list_all_friends_for_user')
+@patch('lambdas.shares_detail.handler.list_reactions_for_share')
+@patch('lambdas.shares_detail.handler.build_enrichment')
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_happy_path(
+    mock_get_share,
+    mock_enrich,
+    mock_reactions,
+    mock_friends,
+    mock_ratings,
+    mock_batch_users,
+    mock_context,
+    api_gateway_event,
+):
+    mock_get_share.return_value = _share()
+    mock_enrich.return_value = {
+        "queuedCount": 2,
+        "ratedCount": 2,
+        "viewerHasQueued": True,
+        "viewerRating": 4.5,
+        "sharerRating": 5.0,
+    }
+    # 2 reactions -> should produce interactions for each (viewer queued,
+    # bob queued + rated).
+    mock_reactions.return_value = [
+        {
+            "shareId": "share-1", "email": "bob@example.com",
+            "queued": True, "rated": True, "rating": 4.0,
+            "queuedAt": "2026-04-21T09:00:00+00:00",
+            "ratedAt":  "2026-04-21T09:05:00+00:00",
+            "updatedAt":"2026-04-21T09:05:00+00:00",
+            "createdAt":"2026-04-21T09:00:00+00:00",
+            "sharedBy": "alice@example.com",
+        },
+        {
+            "shareId": "share-1", "email": "viewer@example.com",
+            "queued": True, "rated": True, "rating": 4.5,
+            "queuedAt": "2026-04-21T10:00:00+00:00",
+            "ratedAt":  "2026-04-21T10:05:00+00:00",
+            "sharedBy": "alice@example.com",
+        },
+    ]
+    # viewer has 2 accepted friends (bob + carol) and 1 blocked (should
+    # be filtered out).
+    mock_friends.return_value = [
+        {"friendEmail": "bob@example.com",   "status": "accepted"},
+        {"friendEmail": "carol@example.com", "status": "accepted"},
+        {"friendEmail": "eve@example.com",   "status": "blocked"},
+    ]
+
+    def _ratings_for(email):
+        # Only bob and carol (friends) + alice (author) should be queried.
+        if email == "bob@example.com":
+            return [
+                {"email": email, "trackId": "spotify:track:1", "rating": 4.0,
+                 "ratedAt": "2026-04-21 09:05:00"},
+                {"email": email, "trackId": "spotify:track:OTHER", "rating": 3.0,
+                 "ratedAt": "2026-04-18 09:00:00"},
+            ]
+        if email == "carol@example.com":
+            return [
+                {"email": email, "trackId": "spotify:track:1", "rating": 5.0,
+                 "ratedAt": "2026-04-22 00:00:00"},
+            ]
+        if email == "alice@example.com":
+            # author's own rating — surfaces alongside friend ratings.
+            return [
+                {"email": email, "trackId": "spotify:track:1", "rating": 5.0,
+                 "ratedAt": "2026-04-20 12:00:00"},
+            ]
+        return []
+
+    mock_ratings.side_effect = _ratings_for
+    mock_batch_users.return_value = {
+        "alice@example.com": {"email": "alice@example.com", "displayName": "Alice",  "avatar": "a.jpg"},
+        "bob@example.com":   {"email": "bob@example.com",   "displayName": "Bob",    "avatar": "b.jpg"},
+        "carol@example.com": {"email": "carol@example.com", "displayName": "Carol",  "avatar": "c.jpg"},
+        "viewer@example.com":{"email": "viewer@example.com","displayName": "Viewer", "avatar": "v.jpg"},
+    }
+
+    response = handler(
+        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+
+    # ----- share (with enrichment merged)
+    share = body['share']
+    assert share['shareId'] == 'share-1'
+    assert share['trackName'] == 'Bohemian Rhapsody'
+    assert share['queuedCount'] == 2
+    assert share['ratedCount'] == 2
+    assert share['viewerRating'] == 4.5
+    assert share['sharerRating'] == 5.0
+    assert share['viewerHasQueued'] is True
+
+    # ----- interactions: bob queued, bob rated, viewer queued, viewer rated = 4 rows
+    interactions = body['interactions']
+    assert len(interactions) == 4
+    actions_by_email = {(i['email'], i['action']) for i in interactions}
+    assert ('bob@example.com', 'queued') in actions_by_email
+    assert ('bob@example.com', 'rated') in actions_by_email
+    assert ('viewer@example.com', 'queued') in actions_by_email
+    assert ('viewer@example.com', 'rated') in actions_by_email
+    # displayName + avatar hydrated
+    bob_q = next(i for i in interactions if i['email'] == 'bob@example.com' and i['action'] == 'queued')
+    assert bob_q['displayName'] == 'Bob'
+    assert bob_q['avatar'] == 'b.jpg'
+
+    # ----- friendRatings: bob (friend) + carol (friend) + alice (author)
+    friend_ratings = body['friendRatings']
+    rating_emails = {r['email'] for r in friend_ratings}
+    assert rating_emails == {"bob@example.com", "carol@example.com", "alice@example.com"}
+    # filtered to this trackId only (no spotify:track:OTHER leak)
+    assert all(r.get('rating') is not None for r in friend_ratings)
+    # author hydrated
+    alice_rating = next(r for r in friend_ratings if r['email'] == 'alice@example.com')
+    assert alice_rating['displayName'] == 'Alice'
+
+    # ratings for non-friends should NOT have been requested — only bob, carol, alice
+    called_emails = {call.args[0] for call in mock_ratings.call_args_list}
+    assert called_emails == {"bob@example.com", "carol@example.com", "alice@example.com"}
+
+
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_missing_share_returns_404(
+    mock_get_share, mock_context, api_gateway_event
+):
+    mock_get_share.return_value = None
+    response = handler(
+        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "missing"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 404
+
+
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_missing_required_fields_returns_400(
+    mock_get_share, mock_context, api_gateway_event
+):
+    response = handler(_event(api_gateway_event, {"email": "viewer@example.com"}), mock_context)
+    assert response['statusCode'] == 400
+    mock_get_share.assert_not_called()
+
+
+@patch('lambdas.shares_detail.handler.batch_get_users')
+@patch('lambdas.shares_detail.handler.list_all_track_ratings_for_user')
+@patch('lambdas.shares_detail.handler.list_all_friends_for_user')
+@patch('lambdas.shares_detail.handler.list_reactions_for_share')
+@patch('lambdas.shares_detail.handler.build_enrichment')
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_interactions_dedupe_by_email_action(
+    mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
+    mock_context, api_gateway_event,
+):
+    """Single row with queued=True rated=True -> two events, not one merged."""
+    mock_get_share.return_value = _share()
+    mock_enrich.return_value = {}
+    mock_reactions.return_value = [
+        {
+            "shareId": "share-1", "email": "bob@example.com",
+            "queued": True, "rated": True, "rating": 4.0,
+            "queuedAt": "2026-04-21T09:00:00+00:00",
+            "ratedAt":  "2026-04-21T09:05:00+00:00",
+        },
+    ]
+    mock_friends.return_value = []
+    mock_ratings.return_value = []
+    mock_batch_users.return_value = {}
+
+    response = handler(
+        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        mock_context,
+    )
+    body = json.loads(response['body'])
+    # One queued + one rated for the same email, no collapsing.
+    actions = [(i['email'], i['action']) for i in body['interactions']]
+    assert ('bob@example.com', 'queued') in actions
+    assert ('bob@example.com', 'rated') in actions
+    assert len(actions) == 2
+
+
+@patch('lambdas.shares_detail.handler.batch_get_users')
+@patch('lambdas.shares_detail.handler.list_all_track_ratings_for_user')
+@patch('lambdas.shares_detail.handler.list_all_friends_for_user')
+@patch('lambdas.shares_detail.handler.list_reactions_for_share')
+@patch('lambdas.shares_detail.handler.build_enrichment')
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_friend_ratings_scoped_to_accepted_friends_only(
+    mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
+    mock_context, api_gateway_event,
+):
+    """Pending / blocked friends must NOT appear in friendRatings."""
+    mock_get_share.return_value = _share()
+    mock_enrich.return_value = {}
+    mock_reactions.return_value = []
+    mock_friends.return_value = [
+        {"friendEmail": "bob@example.com",     "status": "accepted"},
+        {"friendEmail": "carol@example.com",   "status": "pending"},
+        {"friendEmail": "eve@example.com",     "status": "blocked"},
+    ]
+    mock_ratings.side_effect = lambda email: (
+        [{"email": email, "trackId": "spotify:track:1", "rating": 4.0,
+          "ratedAt": "2026-04-21 09:00:00"}]
+        if email in {"bob@example.com", "alice@example.com"} else []
+    )
+    mock_batch_users.return_value = {}
+
+    response = handler(
+        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        mock_context,
+    )
+    body = json.loads(response['body'])
+    emails = {r['email'] for r in body['friendRatings']}
+    # bob (friend) + alice (author). Carol (pending) and Eve (blocked) must be absent.
+    assert emails == {"bob@example.com", "alice@example.com"}
+    # Ratings lookup was restricted to accepted friends + author.
+    called_emails = {call.args[0] for call in mock_ratings.call_args_list}
+    assert "carol@example.com" not in called_emails
+    assert "eve@example.com" not in called_emails
+
+
+@patch('lambdas.shares_detail.handler.batch_get_users')
+@patch('lambdas.shares_detail.handler.list_all_track_ratings_for_user')
+@patch('lambdas.shares_detail.handler.list_all_friends_for_user')
+@patch('lambdas.shares_detail.handler.list_reactions_for_share')
+@patch('lambdas.shares_detail.handler.build_enrichment')
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_enrichment_failure_is_non_fatal(
+    mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
+    mock_context, api_gateway_event,
+):
+    """If build_enrichment explodes, the share still comes back with defaults."""
+    mock_get_share.return_value = _share()
+    mock_enrich.side_effect = RuntimeError("interactions table unreachable")
+    mock_reactions.return_value = []
+    mock_friends.return_value = []
+    mock_ratings.return_value = []
+    mock_batch_users.return_value = {}
+
+    response = handler(
+        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['share']['shareId'] == 'share-1'
+    assert body['share']['queuedCount'] == 0
+    assert body['share']['viewerHasQueued'] is False


### PR DESCRIPTION
## Summary

Three production fixes + one new endpoint, shipped together.

### Fix 1 — `POST /groups/add-song` accepts flat fields
Handler previously required a nested `track: {name, artists: [...], album: {...}}` object. iOS sends flat fields. Now accepts **both** shapes:
- Legacy nested: `{email, groupId, trackId, track: {name, artists, album.images}}`
- Flat (iOS): `{email, groupId, trackId, trackName, artistName, albumName, imageUrl}`

`email`, `groupId`, `trackId` remain required. Other track metadata is optional — a missing field just won't be persisted.

### Fix 2 — `GET /groups/list` returns live memberCount
The handler used to emit the cached `memberCount` attribute off the GROUPS row. That value has drifted for every group created before #136 (old seed set fresh 1-member groups to 2). Fix:
- After `batch_get_groups`, recount members for each hydrated group via `list_members_of_group(groupId)`.
- Overwrite `memberCount` with the live count before serializing.
- Opportunistically write the live count back to the GROUPS row so future reads don't have to recount. Write failures are logged and swallowed — the heal path can never break `/groups/list`.
- Added new helper `groups_dynamo.update_group_member_count(group_id, count)`.

N+1 reads per request (one `list_members_of_group` per group). Acceptable: a user's group count is bounded small (typically <20) and the alternative is shipping wrong numbers to the UI.

### Fix 3 — New `GET /shares/detail`
Query params: `email` (viewer, required), `shareId` (required). Optional `sharedBy` / `sharedAt` are accepted for iOS forward-compat but unused — the shares table is keyed on `shareId` alone in this repo and the author email lives on the share row.

Response:
```json
{
  "share":         { ...share row + viewer enrichment (queuedCount, ratedCount, viewerHasQueued, viewerRating, sharerRating)... },
  "interactions":  [{ "email", "displayName", "avatar", "action": "queued"|"rated", "createdAt" }],
  "friendRatings": [{ "email", "displayName", "avatar", "rating", "review", "ratedAt" }]
}
```

Implementation highlights:
- `interactions`: collapses the share-interactions rows (one per viewer, with `queued` and `rated` flags) into a flat, deduped list of `(email, action)` events. A row with both flags produces two events.
- `friendRatings`: calls `list_all_friends_for_user(viewer)`, filters to `status == 'accepted'`, then pulls `list_all_track_ratings_for_user(friend)` for each and filters to the share's `trackId`. The share's author rating is included even if the author isn't a friend of the viewer.
- Profiles: single `batch_get_users([...])` call (new helper on `dynamo_helpers.py`) to resolve `displayName` + `avatar` for every email surfaced in the response.
- Enrichment failures (`build_enrichment` raising, batch user lookup failing) never drop the response — they degrade gracefully with defaults.

## Assumptions

- **`sharedAt` / `sharedBy` not required.** Prompt said "shares table uses composite key" — in this repo `get_share` takes `shareId` alone, and the row carries `email` (author). I accept both params as optional so iOS can send them without breaking, but nothing on the server needs them.
- **`review` is a slot in `friendRatings`** even though the track-ratings table doesn't persist reviews yet. Keeps the contract stable for when the feature lands client-side.
- **No infra changes here.** API Gateway / Terraform lives in `xomify-infrastructure`. This PR ships the lambda + handler + tests; route registration happens separately.
- **Lambda name:** `shares_detail` (mirrors existing `shares_feed`, `shares_user`, `shares_react`).

## Files

- `lambdas/groups_add_song/handler.py` — accept flat + nested shapes
- `lambdas/groups_list/handler.py` — live memberCount + self-heal
- `lambdas/common/groups_dynamo.py` — new `update_group_member_count`
- `lambdas/shares_detail/handler.py` (new) — `GET /shares/detail`
- `lambdas/shares_detail/__init__.py` (new)
- `lambdas/common/dynamo_helpers.py` — new `batch_get_users` helper
- `tests/test_groups_add_song.py` (new) — 5 cases
- `tests/test_groups_list.py` — updated for live count + new stale-cache regression
- `tests/test_shares_detail.py` (new) — 6 cases
- `README.md` — documented `/shares/detail`

## Test plan

- [x] `python -m pytest tests/test_groups_add_song.py -v` — 5 pass (flat, nested, missing required, tolerates missing metadata, empty nested arrays)
- [x] `python -m pytest tests/test_groups_list.py -v` — 5 pass (includes stale-cache regression + heal-failure tolerance)
- [x] `python -m pytest tests/test_shares_detail.py -v` — 6 pass (happy path, 404, 400, dedupe, friend scoping, enrichment failure)
- [x] `python -m pytest -q` — full suite 127 passed