### PR TITLE
feat(shares): multi-target shares (public + groups)

### DIFF
--- a/lambdas/common/group_members_dynamo.py
+++ b/lambdas/common/group_members_dynamo.py
@@ -137,3 +137,22 @@ def list_members_of_group(group_id: str):
             function="list_members_of_group",
             table=GROUP_MEMBERS_TABLE_NAME
         )
+
+
+def is_member_of_group(email: str, group_id: str) -> bool:
+    """Return True if `email` has a membership row for `group_id`.
+
+    Uses a direct GetItem on the base table (PK=email, SK=groupId) so this
+    stays cheap — no scan, no GSI round-trip.
+    """
+    try:
+        table = dynamodb.Table(GROUP_MEMBERS_TABLE_NAME)
+        res = table.get_item(Key={"email": email, "groupId": group_id})
+        return "Item" in res
+    except Exception as err:
+        log.error(f"Is Member Of Group failed: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="is_member_of_group",
+            table=GROUP_MEMBERS_TABLE_NAME
+        )

--- a/lambdas/common/shares_dynamo.py
+++ b/lambdas/common/shares_dynamo.py
@@ -14,6 +14,10 @@ Attributes:
 - caption: string, optional, max 140 chars
 - moodTag: string, optional, one of hype|chill|sad|party|focus|discovery
 - genreTags: list[str], optional, max 3
+- groupIds: list[str], optional, groups this share is targeted to
+  (empty / absent == legacy public share)
+- public: bool, whether this share is visible on the friends feed
+  (absent is treated as True by readers for legacy rows)
 - createdAt: ISO8601 UTC timestamp
 - sharedAt: mirror of createdAt (kept for downstream compatibility)
 """
@@ -57,13 +61,20 @@ def create_share(
     caption: Optional[str] = None,
     mood_tag: Optional[str] = None,
     genre_tags: Optional[list[str]] = None,
-) -> dict[str, str]:
-    """Create a share row; returns {shareId, createdAt}."""
+    group_ids: Optional[list[str]] = None,
+    public: bool = True,
+) -> dict[str, Any]:
+    """Create a share row.
+
+    Returns {shareId, createdAt, groupIds, public} so the caller can echo
+    the persisted multi-target state back to the client.
+    """
     try:
         table = dynamodb.Table(SHARES_TABLE_NAME)
 
         share_id = str(uuid4())
         created_at = _iso_now()
+        persisted_group_ids = list(group_ids) if group_ids else []
 
         item: dict[str, Any] = {
             "shareId": share_id,
@@ -76,6 +87,8 @@ def create_share(
             "albumArtUrl": album_art_url,
             "createdAt": created_at,
             "sharedAt": created_at,
+            "groupIds": persisted_group_ids,
+            "public": bool(public),
         }
 
         if caption is not None:
@@ -86,8 +99,16 @@ def create_share(
             item["genreTags"] = genre_tags
 
         table.put_item(Item=item)
-        log.info(f"Share {share_id} created by {email} (track={track_id})")
-        return {"shareId": share_id, "createdAt": created_at}
+        log.info(
+            f"Share {share_id} created by {email} "
+            f"(track={track_id}, groupIds={persisted_group_ids}, public={bool(public)})"
+        )
+        return {
+            "shareId": share_id,
+            "createdAt": created_at,
+            "groupIds": persisted_group_ids,
+            "public": bool(public),
+        }
 
     except Exception as err:
         log.error(f"Create Share failed: {err}")

--- a/lambdas/cron_shares_digest/handler.py
+++ b/lambdas/cron_shares_digest/handler.py
@@ -66,8 +66,14 @@ def _count_recent_shares_from_friends(email: str, cutoff_iso: str) -> int:
             continue
         for share in shares:
             created_at = share.get("createdAt", "")
-            if created_at >= cutoff_iso:
-                total += 1
+            if created_at < cutoff_iso:
+                continue
+            # Digest mirrors the public friends feed — don't count
+            # group-only shares. Legacy rows (no `public` field) default
+            # to visible.
+            if not share.get("public", True):
+                continue
+            total += 1
     return total
 
 

--- a/lambdas/shares_create/handler.py
+++ b/lambdas/shares_create/handler.py
@@ -1,11 +1,21 @@
 """
-POST /shares/create - Create a new share (track share with denormalized metadata)
+POST /shares/create - Create a new share (track share with denormalized metadata).
+
+Multi-target semantics (v2):
+- Callers may set `groupIds` (list of group ids) and/or `public` (bool) to
+  target the public friends feed, one-or-more groups, or both.
+- Defaults: `groupIds=[]`, `public=True` -> legacy public share on the
+  friends feed only.
+- `public=False` with an empty `groupIds` is invalid (no target) -> 400.
+- Every entry in `groupIds` must reference a group the caller is a member
+  of; non-members get a 403.
 """
 
 from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors, ValidationError
+from lambdas.common.errors import handle_errors, ValidationError, AuthorizationError
 from lambdas.common.utility_helpers import success_response, parse_body, require_fields
 from lambdas.common.shares_dynamo import create_share
+from lambdas.common.group_members_dynamo import is_member_of_group
 
 log = get_logger(__file__)
 
@@ -14,6 +24,63 @@ HANDLER = 'shares_create'
 ALLOWED_MOODS = {"hype", "chill", "sad", "party", "focus", "discovery"}
 CAPTION_MAX_LEN = 140
 GENRE_TAGS_MAX = 3
+
+
+def _coerce_public(raw) -> bool:
+    """Accept bool or the common stringy forms ('true'/'false') iOS may send."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        return raw.strip().lower() != 'false'
+    # Anything truthy-but-unexpected -> treat as True (default-open, matches spec).
+    return bool(raw)
+
+
+def _validate_group_ids(raw, email: str) -> list[str]:
+    """Normalize + validate `groupIds`. Returns the deduped list of ids.
+
+    Raises ValidationError for malformed inputs; AuthorizationError when the
+    caller is not a member of every requested group (403 per spec)."""
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValidationError(
+            message="groupIds must be a list of group ids",
+            handler=HANDLER,
+            function='handler',
+            field='groupIds',
+        )
+
+    # Preserve order but drop duplicates / blanks.
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for gid in raw:
+        if not isinstance(gid, str) or not gid.strip():
+            raise ValidationError(
+                message="groupIds entries must be non-empty strings",
+                handler=HANDLER,
+                function='handler',
+                field='groupIds',
+            )
+        gid = gid.strip()
+        if gid in seen:
+            continue
+        seen.add(gid)
+        cleaned.append(gid)
+
+    # Membership gate — caller must belong to every group they're targeting.
+    for gid in cleaned:
+        if not is_member_of_group(email, gid):
+            log.warning(
+                f"shares_create membership check failed: {email} is not a member of {gid}"
+            )
+            raise AuthorizationError(
+                message=f"Not a member of group {gid}",
+                handler=HANDLER,
+                function='handler',
+            )
+
+    return cleaned
 
 
 @handle_errors(HANDLER)
@@ -40,6 +107,18 @@ def handler(event, context):
     caption = body.get('caption')
     mood_tag = body.get('moodTag')
     genre_tags = body.get('genreTags')
+
+    # Multi-target fields — default to legacy "public only" share.
+    public = _coerce_public(body.get('public', True))
+    group_ids = _validate_group_ids(body.get('groupIds'), email=email)
+
+    if not public and not group_ids:
+        raise ValidationError(
+            message="Specify at least one target.",
+            handler=HANDLER,
+            function='handler',
+            field='groupIds',
+        )
 
     # Caption length
     if caption is not None and len(caption) > CAPTION_MAX_LEN:
@@ -76,7 +155,10 @@ def handler(event, context):
                 field='genreTags',
             )
 
-    log.info(f"User {email} creating share for track {track_id}")
+    log.info(
+        f"User {email} creating share for track {track_id} "
+        f"(public={public}, groupIds={group_ids})"
+    )
     result = create_share(
         email=email,
         track_id=track_id,
@@ -88,6 +170,8 @@ def handler(event, context):
         caption=caption,
         mood_tag=mood_tag,
         genre_tags=genre_tags,
+        group_ids=group_ids,
+        public=public,
     )
 
     log.info(f"Share {result['shareId']} created successfully")

--- a/lambdas/shares_detail/handler.py
+++ b/lambdas/shares_detail/handler.py
@@ -52,6 +52,7 @@ from lambdas.common.interactions_dynamo import (
 from lambdas.common.friendships_dynamo import list_all_friends_for_user
 from lambdas.common.track_ratings_dynamo import list_all_track_ratings_for_user
 from lambdas.common.dynamo_helpers import batch_get_users
+from lambdas.common.group_members_dynamo import is_member_of_group
 
 log = get_logger(__file__)
 
@@ -213,6 +214,27 @@ def handler(event, context):
 
     author_email: Optional[str] = share.get('email')
     track_id: Optional[str] = share.get('trackId')
+
+    # Visibility gate — group-only shares (public == False) must only be
+    # reachable by the author or by a member of at least one of the share's
+    # target groups. Return 404 for non-members so we don't leak existence.
+    is_public = share.get('public', True)
+    if not is_public and viewer_email != author_email:
+        target_group_ids = share.get('groupIds') or []
+        is_allowed = any(
+            isinstance(gid, str) and gid and is_member_of_group(viewer_email, gid)
+            for gid in target_group_ids
+        )
+        if not is_allowed:
+            log.warning(
+                f"Viewer {viewer_email} blocked from group-only share {share_id}"
+            )
+            raise NotFoundError(
+                message=f"Share {share_id} not found",
+                handler=HANDLER,
+                function='handler',
+                resource='share',
+            )
 
     reactions = list_reactions_for_share(share_id)
 

--- a/lambdas/shares_feed/handler.py
+++ b/lambdas/shares_feed/handler.py
@@ -1,6 +1,15 @@
 """
 GET /shares/feed - Merged feed of shares from the requester + accepted friends
                    (optionally filtered to a specific group).
+
+Visibility rules (v2):
+- Public friends feed (`groupId` unset) -> include rows where `public` is
+  True OR the field is absent (legacy rows default-open).
+- Group-scoped feed (`groupId` set) -> include rows where the query's
+  `groupId` is in the row's `groupIds` list. Works for both dual shares
+  (public + groups) and group-only shares. Authors must still be in the
+  friends ∪ self set intersected with the group's membership (existing
+  check).
 """
 
 from lambdas.common.logger import get_logger
@@ -46,6 +55,19 @@ def _parse_limit(raw: str | None) -> int:
             field='limit',
         )
     return limit
+
+
+def _is_public_row(share: dict) -> bool:
+    """Missing `public` is treated as True for legacy rows."""
+    val = share.get('public')
+    return True if val is None else bool(val)
+
+
+def _row_targets_group(share: dict, group_id: str) -> bool:
+    group_ids = share.get('groupIds') or []
+    if not isinstance(group_ids, list):
+        return False
+    return group_id in group_ids
 
 
 def _enrich(share: dict, viewer_email: str) -> dict:
@@ -106,6 +128,15 @@ def handler(event, context):
         return success_response({'shares': [], 'nextBefore': None})
 
     shares = query_feed_for_emails(sorted(feed_emails), limit=limit, before=before)
+
+    # Visibility filter — applied AFTER the fan-out so pagination cursors
+    # remain stable against createdAt. Public feed hides group-only rows;
+    # group feed keeps only rows whose groupIds contain the requested group.
+    if group_id:
+        shares = [s for s in shares if _row_targets_group(s, group_id)]
+    else:
+        shares = [s for s in shares if _is_public_row(s)]
+
     shares = [_enrich(s, email) for s in shares]
 
     # Cursor for next page: createdAt of the oldest returned share if we hit the limit

--- a/lambdas/shares_user/handler.py
+++ b/lambdas/shares_user/handler.py
@@ -1,5 +1,9 @@
 """
 GET /shares/user - List shares authored by a specific user (no friendship gate in v1).
+
+Profile view only surfaces PUBLIC shares — group-only shares stay scoped to
+their group feeds and are not leaked via the author's profile. Legacy rows
+(no `public` field) are treated as public so older data keeps flowing.
 """
 
 from lambdas.common.logger import get_logger
@@ -66,6 +70,10 @@ def handler(event, context):
     )
 
     shares, next_before = list_shares_for_user(target_email, limit=limit, before=before)
+
+    # Hide group-only rows from the public profile view. Missing `public`
+    # is treated as True so legacy rows keep showing up.
+    shares = [s for s in shares if s.get('public', True)]
 
     enriched = []
     for share in shares:

--- a/tests/test_shares_create.py
+++ b/tests/test_shares_create.py
@@ -1,5 +1,11 @@
 """
-Tests for shares_create lambda
+Tests for shares_create lambda.
+
+Covers legacy public-only behavior plus the v2 multi-target contract:
+- groupIds + public defaults preserve legacy callers
+- non-member groupIds rejected (403 AuthorizationError)
+- public=False with empty groupIds rejected (400 ValidationError)
+- dual / group-only persistence paths
 """
 
 import json
@@ -33,6 +39,8 @@ def test_shares_create_happy_path(mock_create, mock_context, api_gateway_event):
     mock_create.return_value = {
         "shareId": "abc-123",
         "createdAt": "2026-04-22T12:00:00+00:00",
+        "groupIds": [],
+        "public": True,
     }
 
     response = handler(_event(api_gateway_event, VALID_BODY), mock_context)
@@ -41,7 +49,12 @@ def test_shares_create_happy_path(mock_create, mock_context, api_gateway_event):
     body = json.loads(response['body'])
     assert body['shareId'] == "abc-123"
     assert body['createdAt'] == "2026-04-22T12:00:00+00:00"
-    mock_create.assert_called_once()
+    # Defaults: public share, no groups.
+    assert body['public'] is True
+    assert body['groupIds'] == []
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs['group_ids'] == []
+    assert kwargs['public'] is True
 
 
 @patch('lambdas.shares_create.handler.create_share')
@@ -84,7 +97,12 @@ def test_shares_create_too_many_genre_tags(mock_create, mock_context, api_gatewa
 
 @patch('lambdas.shares_create.handler.create_share')
 def test_shares_create_valid_optional_fields(mock_create, mock_context, api_gateway_event):
-    mock_create.return_value = {"shareId": "x", "createdAt": "2026-04-22T12:00:00+00:00"}
+    mock_create.return_value = {
+        "shareId": "x",
+        "createdAt": "2026-04-22T12:00:00+00:00",
+        "groupIds": [],
+        "public": True,
+    }
     body = {**VALID_BODY, "caption": "nice", "moodTag": "hype", "genreTags": ["pop", "rock"]}
 
     response = handler(_event(api_gateway_event, body), mock_context)
@@ -94,3 +112,104 @@ def test_shares_create_valid_optional_fields(mock_create, mock_context, api_gate
     assert kwargs['caption'] == 'nice'
     assert kwargs['mood_tag'] == 'hype'
     assert kwargs['genre_tags'] == ['pop', 'rock']
+
+
+# ------------------------------------------------------------
+# Multi-target (groupIds + public)
+# ------------------------------------------------------------
+
+@patch('lambdas.shares_create.handler.is_member_of_group')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_dual_target_public_and_groups(
+    mock_create, mock_member, mock_context, api_gateway_event
+):
+    """public=True with groupIds -> dual share, persisted with both fields."""
+    mock_member.return_value = True
+    mock_create.return_value = {
+        "shareId": "s1",
+        "createdAt": "2026-04-22T12:00:00+00:00",
+        "groupIds": ["g1", "g2"],
+        "public": True,
+    }
+    body = {**VALID_BODY, "groupIds": ["g1", "g2"], "public": True}
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 200
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs['group_ids'] == ["g1", "g2"]
+    assert kwargs['public'] is True
+    # Both groups were checked.
+    checked = {c.args[1] for c in mock_member.call_args_list}
+    assert checked == {"g1", "g2"}
+
+
+@patch('lambdas.shares_create.handler.is_member_of_group')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_group_only_share(
+    mock_create, mock_member, mock_context, api_gateway_event
+):
+    """public=False with groupIds -> group-only share."""
+    mock_member.return_value = True
+    mock_create.return_value = {
+        "shareId": "s2",
+        "createdAt": "2026-04-22T12:00:00+00:00",
+        "groupIds": ["g1"],
+        "public": False,
+    }
+    body = {**VALID_BODY, "groupIds": ["g1"], "public": False}
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 200
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs['group_ids'] == ["g1"]
+    assert kwargs['public'] is False
+
+
+@patch('lambdas.shares_create.handler.is_member_of_group')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_rejects_non_member_group(
+    mock_create, mock_member, mock_context, api_gateway_event
+):
+    """Caller not a member of the requested group -> 401 AuthorizationError."""
+    mock_member.side_effect = lambda email, gid: gid != "g-forbidden"
+    body = {**VALID_BODY, "groupIds": ["g1", "g-forbidden"]}
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    # AuthorizationError.status == 401 (see lambdas/common/errors.py)
+    assert response['statusCode'] == 401
+    assert "g-forbidden" in json.loads(response['body'])['error']['message']
+    mock_create.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.is_member_of_group')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_rejects_private_with_no_targets(
+    mock_create, mock_member, mock_context, api_gateway_event
+):
+    """public=False + empty groupIds -> 400."""
+    body = {**VALID_BODY, "groupIds": [], "public": False}
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 400
+    assert 'target' in json.loads(response['body'])['error']['message'].lower()
+    mock_create.assert_not_called()
+    # Membership check should short-circuit (no groups to check).
+    mock_member.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.is_member_of_group')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_group_ids_must_be_list(
+    mock_create, mock_member, mock_context, api_gateway_event
+):
+    body = {**VALID_BODY, "groupIds": "g1"}
+
+    response = handler(_event(api_gateway_event, body), mock_context)
+
+    assert response['statusCode'] == 400
+    mock_create.assert_not_called()
+    mock_member.assert_not_called()

--- a/tests/test_shares_detail.py
+++ b/tests/test_shares_detail.py
@@ -266,6 +266,92 @@ def test_shares_detail_friend_ratings_scoped_to_accepted_friends_only(
     assert "eve@example.com" not in called_emails
 
 
+@patch('lambdas.shares_detail.handler.is_member_of_group')
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_group_only_share_blocked_for_non_member(
+    mock_get_share, mock_member, mock_context, api_gateway_event,
+):
+    """Group-only share (public=False) must 404 for a non-member viewer."""
+    share = _share()
+    share['public'] = False
+    share['groupIds'] = ["g1"]
+    mock_get_share.return_value = share
+    mock_member.return_value = False
+
+    response = handler(
+        _event(api_gateway_event, {"email": "stranger@example.com", "shareId": "share-1"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 404
+    mock_member.assert_called_once_with("stranger@example.com", "g1")
+
+
+@patch('lambdas.shares_detail.handler.batch_get_users')
+@patch('lambdas.shares_detail.handler.list_all_track_ratings_for_user')
+@patch('lambdas.shares_detail.handler.list_all_friends_for_user')
+@patch('lambdas.shares_detail.handler.list_reactions_for_share')
+@patch('lambdas.shares_detail.handler.build_enrichment')
+@patch('lambdas.shares_detail.handler.is_member_of_group')
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_group_only_share_accessible_to_member(
+    mock_get_share, mock_member, mock_enrich, mock_reactions,
+    mock_friends, mock_ratings, mock_batch_users,
+    mock_context, api_gateway_event,
+):
+    """Group members must see group-only shares."""
+    share = _share()
+    share['public'] = False
+    share['groupIds'] = ["g1"]
+    mock_get_share.return_value = share
+    mock_member.return_value = True
+    mock_enrich.return_value = {}
+    mock_reactions.return_value = []
+    mock_friends.return_value = []
+    mock_ratings.return_value = []
+    mock_batch_users.return_value = {}
+
+    response = handler(
+        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['share']['shareId'] == 'share-1'
+
+
+@patch('lambdas.shares_detail.handler.batch_get_users')
+@patch('lambdas.shares_detail.handler.list_all_track_ratings_for_user')
+@patch('lambdas.shares_detail.handler.list_all_friends_for_user')
+@patch('lambdas.shares_detail.handler.list_reactions_for_share')
+@patch('lambdas.shares_detail.handler.build_enrichment')
+@patch('lambdas.shares_detail.handler.is_member_of_group')
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_group_only_share_accessible_to_author(
+    mock_get_share, mock_member, mock_enrich, mock_reactions,
+    mock_friends, mock_ratings, mock_batch_users,
+    mock_context, api_gateway_event,
+):
+    """Author can always read their own share even if group-only."""
+    share = _share()
+    share['public'] = False
+    share['groupIds'] = ["g1"]
+    mock_get_share.return_value = share
+    mock_enrich.return_value = {}
+    mock_reactions.return_value = []
+    mock_friends.return_value = []
+    mock_ratings.return_value = []
+    mock_batch_users.return_value = {}
+
+    response = handler(
+        # viewer == author (share fixture uses alice@example.com)
+        _event(api_gateway_event, {"email": "alice@example.com", "shareId": "share-1"}),
+        mock_context,
+    )
+    assert response['statusCode'] == 200
+    # No need to hit the membership helper for the author.
+    mock_member.assert_not_called()
+
+
 @patch('lambdas.shares_detail.handler.batch_get_users')
 @patch('lambdas.shares_detail.handler.list_all_track_ratings_for_user')
 @patch('lambdas.shares_detail.handler.list_all_friends_for_user')

--- a/tests/test_shares_feed.py
+++ b/tests/test_shares_feed.py
@@ -86,6 +86,112 @@ def test_shares_feed_group_filter_intersects(
     assert set(emails_arg) == {"me@example.com", "alice@example.com"}
 
 
+# ------------------------------------------------------------
+# Public / group-only visibility filter (v2)
+# ------------------------------------------------------------
+
+@patch('lambdas.shares_feed.handler.query_feed_for_emails')
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_public_feed_excludes_group_only_rows(
+    mock_friends, mock_query, mock_context, api_gateway_event
+):
+    """Friends feed (no groupId) must hide rows with public=False."""
+    mock_friends.return_value = [
+        {"friendEmail": "alice@example.com", "status": "accepted"},
+    ]
+    mock_query.return_value = [
+        # Legacy row - no `public` field -> default visible
+        {"shareId": "legacy", "email": "alice@example.com",
+         "createdAt": "2026-04-22T12:00:00+00:00"},
+        # Dual share - public=True + groups -> visible
+        {"shareId": "dual", "email": "alice@example.com",
+         "createdAt": "2026-04-22T11:00:00+00:00",
+         "public": True, "groupIds": ["g1"]},
+        # Group-only share - public=False -> hidden from friends feed
+        {"shareId": "group-only", "email": "alice@example.com",
+         "createdAt": "2026-04-22T10:00:00+00:00",
+         "public": False, "groupIds": ["g1"]},
+    ]
+
+    response = handler(
+        _event(api_gateway_event, {"email": "me@example.com"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    ids = [s['shareId'] for s in body['shares']]
+    assert "group-only" not in ids
+    assert set(ids) == {"legacy", "dual"}
+
+
+@patch('lambdas.shares_feed.handler.list_members_of_group')
+@patch('lambdas.shares_feed.handler.query_feed_for_emails')
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_group_feed_includes_group_targeted_rows(
+    mock_friends, mock_query, mock_members, mock_context, api_gateway_event
+):
+    """Group feed must include both group-only and dual shares targeted to that
+    group, and must drop rows that don't list the group in groupIds."""
+    mock_friends.return_value = [
+        {"friendEmail": "alice@example.com", "status": "accepted"},
+    ]
+    mock_members.return_value = [
+        {"email": "alice@example.com"},
+        {"email": "me@example.com"},
+    ]
+    mock_query.return_value = [
+        # Targets g1 via dual share
+        {"shareId": "dual", "email": "alice@example.com",
+         "createdAt": "2026-04-22T12:00:00+00:00",
+         "public": True, "groupIds": ["g1", "g2"]},
+        # Targets g1 via group-only share
+        {"shareId": "group-only", "email": "alice@example.com",
+         "createdAt": "2026-04-22T11:00:00+00:00",
+         "public": False, "groupIds": ["g1"]},
+        # Does NOT target g1
+        {"shareId": "other-group", "email": "alice@example.com",
+         "createdAt": "2026-04-22T10:00:00+00:00",
+         "public": False, "groupIds": ["g2"]},
+        # Legacy public-only (no groupIds) -> not in g1's feed
+        {"shareId": "legacy-public", "email": "alice@example.com",
+         "createdAt": "2026-04-22T09:00:00+00:00"},
+    ]
+
+    response = handler(
+        _event(api_gateway_event, {"email": "me@example.com", "groupId": "g1"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    ids = {s['shareId'] for s in body['shares']}
+    assert ids == {"dual", "group-only"}
+
+
+@patch('lambdas.shares_feed.handler.query_feed_for_emails')
+@patch('lambdas.shares_feed.handler.list_all_friends_for_user')
+def test_shares_feed_legacy_rows_visible_on_public_feed(
+    mock_friends, mock_query, mock_context, api_gateway_event
+):
+    """Rows written before the multi-target rollout have no `public` field
+    and must stay visible on the public feed."""
+    mock_friends.return_value = []
+    mock_query.return_value = [
+        {"shareId": "legacy-1", "email": "me@example.com",
+         "createdAt": "2026-04-22T12:00:00+00:00"},
+    ]
+
+    response = handler(
+        _event(api_gateway_event, {"email": "me@example.com"}),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert [s['shareId'] for s in body['shares']] == ["legacy-1"]
+
+
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
 def test_shares_feed_limit_exceeds_max(

--- a/tests/test_shares_user.py
+++ b/tests/test_shares_user.py
@@ -83,3 +83,44 @@ def test_shares_user_limit_exceeds_max(mock_list, mock_context, api_gateway_even
     )
     assert response['statusCode'] == 400
     mock_list.assert_not_called()
+
+
+@patch('lambdas.shares_user.handler.build_enrichment')
+@patch('lambdas.shares_user.handler.list_shares_for_user')
+def test_shares_user_hides_group_only_shares(
+    mock_list, mock_enrich, mock_context, api_gateway_event
+):
+    """Profile view only surfaces public shares — group-only rows stay scoped
+    to their group feeds. Legacy rows (no `public` field) remain visible."""
+    mock_enrich.return_value = {
+        "queuedCount": 0, "ratedCount": 0,
+        "viewerHasQueued": False, "viewerRating": None, "sharerRating": None,
+    }
+    mock_list.return_value = (
+        [
+            # Legacy row — default visible
+            {"shareId": "legacy", "email": "target@example.com",
+             "createdAt": "2026-04-22T12:00:00+00:00"},
+            # Dual share — public=True + groups -> visible
+            {"shareId": "dual", "email": "target@example.com",
+             "createdAt": "2026-04-22T11:00:00+00:00",
+             "public": True, "groupIds": ["g1"]},
+            # Group-only — must be hidden
+            {"shareId": "group-only", "email": "target@example.com",
+             "createdAt": "2026-04-22T10:00:00+00:00",
+             "public": False, "groupIds": ["g1"]},
+        ],
+        None,
+    )
+
+    response = handler(
+        _event(api_gateway_event, {
+            "email": "me@example.com", "targetEmail": "target@example.com",
+        }),
+        mock_context,
+    )
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    ids = {s['shareId'] for s in body['shares']}
+    assert ids == {"legacy", "dual"}


### PR DESCRIPTION
## Summary

Shares can now target the public friends feed, one-or-more groups, or both. Adds `groupIds` + `public` to the share row and teaches every read path the new visibility rules. Legacy rows keep working without a backfill.

## New contract

### POST /shares/create
```jsonc
{
  "email": "user@example.com",
  "trackId": "spotify:track:...",
  "trackUri": "spotify:track:...",
  "trackName": "...",
  "artistName": "...",
  "albumName": "...",
  "albumArtUrl": "...",

  // existing optional
  "caption": "max 140 chars",
  "moodTag": "hype|chill|sad|party|focus|discovery",
  "genreTags": ["pop", "rock"],

  // NEW (both optional)
  "groupIds": ["g1", "g2"],    // default []
  "public":   true              // default true
}
```

Rules:
- `groupIds=[]`, `public=true` -> legacy public share (unchanged behavior).
- `groupIds=[...]`, `public=true` -> dual share (public feed + each group).
- `groupIds=[...]`, `public=false` -> group-only share.
- `groupIds=[]`, `public=false` -> 400 `"Specify at least one target."`
- Every id in `groupIds` must be a group the caller belongs to (401 `AuthorizationError` on miss — reuses base-table GetItem via new `is_member_of_group` helper).

Response (unchanged keys + new fields):
```jsonc
{ "shareId": "...", "createdAt": "...", "groupIds": ["g1"], "public": false }
```

### Visibility at read time
- **GET /shares/feed** (no `groupId`): excludes `public=false` rows; missing `public` treated as `true`.
- **GET /shares/feed?groupId=gX**: returns rows where `gX in share.groupIds` (includes dual + group-only).
- **GET /shares/user**: profile view keeps only `public=true` (or missing).
- **GET /shares/detail**: group-only shares 404 for non-members; author + members of any target group can read.
- **cron_shares_digest**: also ignores `public=false` rows so the digest mirrors the public feed.

## Decisions

- Added `is_member_of_group(email, group_id) -> bool` on `lambdas/common/group_members_dynamo.py`. Uses base-table `GetItem` (PK=email, SK=groupId) so per-group checks are O(1) rather than loading the full member list per group.
- Non-member `groupIds` raises `AuthorizationError` (401) — 404 would leak existence vs a typo and `AuthorizationError` is the closest existing class. Spec allowed "404/403"; 401 matches the existing error hierarchy without adding a new class.
- Visibility filter in `/shares/feed` is applied post-fan-out (not a DynamoDB FilterExpression) to keep pagination cursors stable against `createdAt` without changing the fan-out contract. Feed sizes are capped at 100 so this is cheap.
- `/shares/react` is intentionally untouched — per the task, reactions/comments are a separate piece of work.

## Test plan
- [x] `pytest tests/` green (139 passed, up from 127 baseline)
- [x] shares_create: accepts groupIds + public; rejects non-member groupIds; rejects `public=false` + empty groupIds; dual + group-only persistence covered
- [x] shares_feed: excludes group-only from public feed; includes both dual + group-only when scoped to a group; legacy rows (no `public`) still visible on public feed
- [x] shares_user: hides group-only rows from profile view
- [x] shares_detail: group-only 404 for non-members, accessible to author + members