### PR TITLE
(0b) Dual-mode authorizer — extract per-user JWT claims into context

### DIFF
--- a/lambdas/authorizer/handler.py
+++ b/lambdas/authorizer/handler.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional
+
 import jwt
 from lambdas.common.constants import PRODUCT
 from lambdas.common.ssm_helpers import API_SECRET_KEY
@@ -8,9 +10,19 @@ log = get_logger(__file__)
 
 HANDLER = 'authorizer'
 
-def generate_policy(effect, resource):
-    """Return a valid AWS policy response."""
-    auth_response = {
+# Custom-authorizer context values must be string/number/bool only.
+TOKEN_TYPE_USER = "user"
+TOKEN_TYPE_LEGACY = "legacy"
+
+
+def generate_policy(effect: str, resource: str, context: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """Return a valid AWS API Gateway custom-authorizer policy response.
+
+    When `context` is provided, it is included under the `"context"` key of
+    the response. API Gateway only accepts string/number/bool values in the
+    context dict — callers are responsible for ensuring values conform.
+    """
+    auth_response: dict[str, Any] = {
         'principalId': PRODUCT,
         'policyDocument': {
             'Version': '2012-10-17',
@@ -23,10 +35,12 @@ def generate_policy(effect, resource):
             ]
         }
     }
+    if context is not None:
+        auth_response['context'] = context
     return auth_response
 
-def decode_auth_token(auth_token):
-    """Decodes the auth token."""
+def decode_auth_token(auth_token: str) -> Optional[dict[str, Any]]:
+    """Decodes the auth token. Returns the decoded payload, or None on failure."""
     try:
         # remove "Bearer " from the token string.
         auth_token = auth_token.replace('Bearer ', '')
@@ -39,20 +53,46 @@ def decode_auth_token(auth_token):
         log.warning('Invalid token. Please log in again.')
         return None
 
-def handler(event, context):
+
+def _build_allow_context(payload: dict[str, Any]) -> dict[str, Any]:
+    """Inspect the decoded JWT payload and produce the authorizer context.
+
+    Per-user JWT (both `email` and `userId` are non-empty strings):
+        returns { email, userId, tokenType: "user" } and logs auth_path=context.
+    Legacy static token (either claim missing/empty/non-string):
+        returns { tokenType: "legacy" } and logs auth_path=fallback so we can
+        monitor migration progress (Q5 of the parent epic).
+    """
+    email = payload.get('email')
+    user_id = payload.get('userId')
+
+    if isinstance(email, str) and email and isinstance(user_id, str) and user_id:
+        log.info(f"auth_path=context email={email} tokenType={TOKEN_TYPE_USER}")
+        return {
+            'email': email,
+            'userId': user_id,
+            'tokenType': TOKEN_TYPE_USER,
+        }
+
+    log.info(f"auth_path=fallback tokenType={TOKEN_TYPE_LEGACY}")
+    return {'tokenType': TOKEN_TYPE_LEGACY}
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    method_arn = event.get('methodArn', '')
     try:
-        method_arn = event.get('methodArn', '')
         auth_token = event.get('authorizationToken', '')
 
         if auth_token and method_arn:
             user_details = decode_auth_token(auth_token)
-            if user_details:
+            if user_details is not None:
                 arn_parts = method_arn.split(':')
                 api_gateway_arn_tmp = arn_parts[5].split('/')
                 # Construct: arn:aws:execute-api:region:account:apiId/stage/*
                 resource_arn = f"{arn_parts[0]}:{arn_parts[1]}:{arn_parts[2]}:{arn_parts[3]}:{arn_parts[4]}:{api_gateway_arn_tmp[0]}/{api_gateway_arn_tmp[1]}/*"
 
-                return generate_policy('Allow', resource_arn)
+                allow_context = _build_allow_context(user_details)
+                return generate_policy('Allow', resource_arn, context=allow_context)
 
         log.warning("Authorizer: Deny.")
         return generate_policy('Deny', method_arn)

--- a/tests/test_authorizer_dual_mode.py
+++ b/tests/test_authorizer_dual_mode.py
@@ -1,0 +1,239 @@
+"""
+Tests for the dual-mode JWT authorizer.
+
+Covers:
+- Per-user JWT (claims include email + userId): Allow + populated context.
+- Legacy static token (no email/userId): Allow + tokenType=legacy only.
+- Mixed JWT (email present, userId missing): Allow + tokenType=legacy.
+- Invalid signature: Deny.
+- Expired JWT: Deny.
+- Missing / malformed Authorization header: Deny.
+
+Note: conftest.py mocks `lambdas.common.ssm_helpers` so `API_SECRET_KEY` is
+"test-api-secret-key". We mint test JWTs against that same key so signature
+verification succeeds for the happy paths.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+
+from lambdas.authorizer.handler import generate_policy, handler
+
+API_SECRET_KEY = "test-api-secret-key"
+METHOD_ARN = (
+    "arn:aws:execute-api:us-east-1:123456789012:abc123def4/prod/GET/user/profile"
+)
+EXPECTED_RESOURCE_ARN = (
+    "arn:aws:execute-api:us-east-1:123456789012:abc123def4/prod/*"
+)
+
+
+def _mint(payload: dict[str, Any], secret: str = API_SECRET_KEY) -> str:
+    """Mint an HS256 JWT for tests."""
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _event(token: str | None) -> dict[str, Any]:
+    """Build a minimal authorizer event."""
+    event: dict[str, Any] = {"methodArn": METHOD_ARN}
+    if token is not None:
+        event["authorizationToken"] = f"Bearer {token}"
+    return event
+
+
+@pytest.fixture
+def lambda_context() -> Any:
+    """Lightweight Lambda context — authorizer doesn't read fields off it."""
+    ctx = MagicMock()
+    ctx.aws_request_id = "test-request-id"
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# generate_policy unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_generate_policy_without_context_omits_context_key() -> None:
+    response = generate_policy("Allow", EXPECTED_RESOURCE_ARN)
+    assert "context" not in response
+    assert response["principalId"] == "xomify"
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert response["policyDocument"]["Statement"][0]["Resource"] == EXPECTED_RESOURCE_ARN
+
+
+def test_generate_policy_with_context_includes_context_key() -> None:
+    ctx = {"email": "x@y.com", "userId": "abc", "tokenType": "user"}
+    response = generate_policy("Allow", EXPECTED_RESOURCE_ARN, context=ctx)
+    assert response["context"] == ctx
+
+
+# ---------------------------------------------------------------------------
+# Allow path — per-user JWT
+# ---------------------------------------------------------------------------
+
+
+def test_per_user_jwt_allows_and_populates_context(lambda_context) -> None:
+    payload = {
+        "email": "user@example.com",
+        "userId": "spotify123",
+        "iat": int(datetime.now(timezone.utc).timestamp()),
+        "exp": int((datetime.now(timezone.utc) + timedelta(days=7)).timestamp()),
+    }
+    token = _mint(payload)
+
+    response = handler(_event(token), lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert response["policyDocument"]["Statement"][0]["Resource"] == EXPECTED_RESOURCE_ARN
+    assert response["context"] == {
+        "email": "user@example.com",
+        "userId": "spotify123",
+        "tokenType": "user",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Allow path — legacy static token (no email/userId claims)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_token_allows_with_tokentype_legacy_only(lambda_context) -> None:
+    # Mirrors today's static token: no email, no userId, just iat.
+    payload = {"iat": int(datetime.now(timezone.utc).timestamp())}
+    token = _mint(payload)
+
+    response = handler(_event(token), lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert response["context"] == {"tokenType": "legacy"}
+    assert "email" not in response["context"]
+    assert "userId" not in response["context"]
+
+
+# ---------------------------------------------------------------------------
+# Allow path — mixed: email present, userId missing => legacy
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_payload_email_only_falls_back_to_legacy(lambda_context) -> None:
+    payload = {
+        "email": "user@example.com",
+        # userId intentionally omitted
+        "iat": int(datetime.now(timezone.utc).timestamp()),
+    }
+    token = _mint(payload)
+
+    response = handler(_event(token), lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert response["context"] == {"tokenType": "legacy"}
+
+
+def test_mixed_payload_userid_only_falls_back_to_legacy(lambda_context) -> None:
+    payload = {
+        "userId": "spotify123",
+        # email intentionally omitted
+        "iat": int(datetime.now(timezone.utc).timestamp()),
+    }
+    token = _mint(payload)
+
+    response = handler(_event(token), lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert response["context"] == {"tokenType": "legacy"}
+
+
+def test_empty_string_claims_fall_back_to_legacy(lambda_context) -> None:
+    payload = {
+        "email": "",
+        "userId": "",
+        "iat": int(datetime.now(timezone.utc).timestamp()),
+    }
+    token = _mint(payload)
+
+    response = handler(_event(token), lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert response["context"] == {"tokenType": "legacy"}
+
+
+# ---------------------------------------------------------------------------
+# Deny paths
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_signature_denies(lambda_context) -> None:
+    payload = {
+        "email": "user@example.com",
+        "userId": "spotify123",
+        "exp": int((datetime.now(timezone.utc) + timedelta(days=7)).timestamp()),
+    }
+    # Sign with the WRONG secret.
+    token = _mint(payload, secret="not-the-real-secret")
+
+    response = handler(_event(token), lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+    assert "context" not in response
+
+
+def test_expired_jwt_denies(lambda_context) -> None:
+    payload = {
+        "email": "user@example.com",
+        "userId": "spotify123",
+        # Expired one hour ago.
+        "exp": int((datetime.now(timezone.utc) - timedelta(hours=1)).timestamp()),
+    }
+    token = _mint(payload)
+
+    response = handler(_event(token), lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+    assert "context" not in response
+
+
+def test_missing_authorization_header_denies(lambda_context) -> None:
+    # Event has methodArn but no authorizationToken at all.
+    response = handler({"methodArn": METHOD_ARN}, lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+    assert "context" not in response
+
+
+def test_empty_authorization_header_denies(lambda_context) -> None:
+    event = {"methodArn": METHOD_ARN, "authorizationToken": ""}
+
+    response = handler(event, lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+    assert "context" not in response
+
+
+def test_malformed_token_denies(lambda_context) -> None:
+    event = {"methodArn": METHOD_ARN, "authorizationToken": "Bearer not.a.jwt"}
+
+    response = handler(event, lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+    assert "context" not in response
+
+
+def test_missing_method_arn_denies(lambda_context) -> None:
+    payload = {
+        "email": "user@example.com",
+        "userId": "spotify123",
+        "exp": int((datetime.now(timezone.utc) + timedelta(days=7)).timestamp()),
+    }
+    token = _mint(payload)
+    # No methodArn — handler should not attempt to mint an Allow.
+    event = {"authorizationToken": f"Bearer {token}"}
+
+    response = handler(event, lambda_context)
+
+    assert response["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+    assert "context" not in response


### PR DESCRIPTION
Closes #142

Sub-feature **(0b)** of the **auth-identity-and-live-top-items** epic. See `docs/features/auth-identity-and-live-top-items/PLAN.md` (Track 0, Q2, Q5, Q8) and `docs/features/authorizer-extract-claims/PLAN.md`.

## Summary
- `generate_policy(effect, resource, context=None)` — when `context` is provided, include it under the `"context"` key of the API Gateway custom-authorizer response.
- `handler` now inspects the decoded JWT payload on the Allow path:
  - **Per-user JWT** (both `email` AND `userId` are non-empty strings): Allow + `context = {email, userId, tokenType: "user"}`. Logs `auth_path=context email=<email> tokenType=user`.
  - **Legacy static token** (claims missing/empty/non-string): Allow + `context = {tokenType: "legacy"}`. Logs `auth_path=fallback tokenType=legacy` so we can monitor migration progress per Q5.
- Deny logic and signature verification are unchanged. Invalid signature, expired JWT, missing/empty Authorization header, malformed token, and missing `methodArn` all still Deny.

## Why
Track 1 handler migration will read `event.requestContext.authorizer.email`. Dual-mode lets legacy clients (static `XOMIFY_API_TOKEN`) and new clients (per-user JWTs from `/auth/login`) coexist for the migration window. Sub-feature (1l) removes the legacy path once fallback rate is < 1% for 7 consecutive days.

## Test plan
- [x] New `tests/test_authorizer_dual_mode.py` — **13 tests, all passing**:
  - `generate_policy` with and without `context` param
  - Per-user JWT → Allow + populated context (email, userId, tokenType=user)
  - Legacy token (no claims) → Allow + tokenType=legacy only
  - Mixed: email-only → tokenType=legacy
  - Mixed: userId-only → tokenType=legacy
  - Empty-string claims → tokenType=legacy
  - Invalid signature → Deny, no context
  - Expired JWT → Deny, no context
  - Missing Authorization header → Deny
  - Empty Authorization header → Deny
  - Malformed token → Deny
  - Missing methodArn → Deny
- [x] Full backend test suite: **183 passed** (no regressions)

## Constraints honored
- No new dependencies (PyJWT already used)
- Type hints on all new/modified signatures
- No silent catches; signature verification unchanged
- Custom-authorizer context values are strings only

## Do not merge
Per the sub-feature stub: do NOT merge until (0a) `auth-login-endpoint` is deployed.