### PR TITLE
(0c) Caller-identity helper + authorized_event/legacy_event fixtures

### DIFF
--- a/lambdas/common/errors.py
+++ b/lambdas/common/errors.py
@@ -86,7 +86,7 @@ class XomifyError(Exception):
 
 class AuthorizationError(XomifyError):
     """Raised when authorization fails."""
-    
+
     def __init__(self, message: str = "Unauthorized", handler: str = "authorizer", function: str = "unknown"):
         super().__init__(
             message=message,
@@ -94,6 +94,30 @@ class AuthorizationError(XomifyError):
             function=function,
             status=401
         )
+
+
+class MissingCallerIdentityError(AuthorizationError):
+    """
+    Raised when caller identity (email/userId) cannot be resolved from either
+    the authorizer context or the request fallback (query/body).
+
+    Maps to HTTP 401 — the caller is unauthenticated for the purposes of
+    this endpoint because we have no way to know who they are.
+    """
+
+    def __init__(
+        self,
+        field: str,
+        handler: str = "utility_helpers",
+        function: str = "unknown",
+    ):
+        message = f"Missing caller identity: '{field}' not present in authorizer context, query string, or body"
+        super().__init__(
+            message=message,
+            handler=handler,
+            function=function,
+        )
+        self.details = {"field": field}
 
 
 class ValidationError(XomifyError):

--- a/lambdas/common/utility_helpers.py
+++ b/lambdas/common/utility_helpers.py
@@ -205,18 +205,116 @@ def validate_input(
 def require_fields(data: dict, *fields: str) -> None:
     """
     Raise ValidationError if any required fields are missing.
-    
+
     Usage:
         require_fields(body, 'email', 'userId')
     """
     from lambdas.common.errors import ValidationError
-    
+
     missing = [f for f in fields if f not in data or data[f] is None]
     if missing:
         raise ValidationError(
             message=f"Missing required fields: {', '.join(missing)}",
             field=missing[0]
         )
+
+
+# ============================================
+# Caller Identity Resolution
+# ============================================
+# These helpers exist to bridge the migration window introduced by Track 0
+# of the auth-identity epic. During the window:
+#   * New per-user JWTs populate `requestContext.authorizer.{email,userId}`.
+#   * Legacy static-token clients still send `email`/`userId` in the query
+#     string or body.
+# Once the fallback rate drops below the burn-in threshold (Q5 in the epic
+# plan), Track 1l strips the fallback path entirely.
+
+def _get_header_case_insensitive(event: dict, name: str) -> Optional[str]:
+    """Return a header value from the event, matching the name case-insensitively."""
+    headers = event.get("headers") or {}
+    if not isinstance(headers, dict):
+        return None
+    target = name.lower()
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == target:
+            return value if isinstance(value, str) else None
+    return None
+
+
+def _resolve_caller_identity(event: dict, field: str) -> str:
+    """
+    Resolve a caller-identity field from (in order): authorizer context,
+    query string, then body. Raises MissingCallerIdentityError if absent
+    in all three places.
+
+    Args:
+        event: Lambda event dict (API Gateway shape).
+        field: Either 'email' or 'userId'.
+
+    Returns:
+        The resolved value as a string.
+    """
+    from lambdas.common.errors import MissingCallerIdentityError
+
+    # 1. Trusted: authorizer context (populated by per-user JWTs).
+    request_context = event.get("requestContext") or {}
+    authorizer = request_context.get("authorizer") if isinstance(request_context, dict) else None
+    if isinstance(authorizer, dict):
+        ctx_value = authorizer.get(field)
+        if isinstance(ctx_value, str) and ctx_value:
+            log.debug(f"caller_identity field={field} auth_path=context")
+            return ctx_value
+
+    # 2. Fallback: query string.
+    query_params = get_query_params(event)
+    qs_value = query_params.get(field) if isinstance(query_params, dict) else None
+    if isinstance(qs_value, str) and qs_value:
+        user_agent = _get_header_case_insensitive(event, "User-Agent") or "unknown"
+        log.warning(
+            f"caller_identity field={field} auth_path=fallback source=query user_agent={user_agent}"
+        )
+        return qs_value
+
+    # 3. Fallback: body (only if it parses as JSON dict).
+    body = parse_body(event)
+    body_value = body.get(field) if isinstance(body, dict) else None
+    if isinstance(body_value, str) and body_value:
+        user_agent = _get_header_case_insensitive(event, "User-Agent") or "unknown"
+        log.warning(
+            f"caller_identity field={field} auth_path=fallback source=body user_agent={user_agent}"
+        )
+        return body_value
+
+    # 4. Nothing — structured 401.
+    raise MissingCallerIdentityError(field=field)
+
+
+def get_caller_email(event: dict) -> str:
+    """
+    Resolve the caller's email.
+
+    Trusts `event.requestContext.authorizer.email` first. Falls back to
+    `queryStringParameters.email`, then JSON body `email`, during the Track 0
+    -> Track 1 migration window. Raises `MissingCallerIdentityError` (HTTP 401)
+    if no source provides a value.
+
+    The fallback path emits a WARN log; CloudWatch counts gate the Track 1l
+    cleanup that removes the fallback entirely (epic Q5).
+    """
+    return _resolve_caller_identity(event, "email")
+
+
+def get_caller_user_id(event: dict) -> str:
+    """
+    Resolve the caller's Spotify user id.
+
+    Trusts `event.requestContext.authorizer.userId` first. Falls back to
+    `queryStringParameters.userId`, then JSON body `userId`, during the
+    Track 0 -> Track 1 migration window. Raises `MissingCallerIdentityError`
+    (HTTP 401) if no source provides a value.
+    """
+    return _resolve_caller_identity(event, "userId")
 
 
 # ============================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,77 @@ def api_gateway_event():
     }
 
 
+def _base_api_gateway_event() -> dict:
+    """Internal helper — returns a fresh base event dict (avoids fixture-state sharing)."""
+    return {
+        "httpMethod": "GET",
+        "path": "/test",
+        "queryStringParameters": {},
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "body": None,
+        "isBase64Encoded": False,
+    }
+
+
+@pytest.fixture
+def authorized_event():
+    """
+    Build an API Gateway event WITH per-user JWT authorizer context populated.
+
+    Mirrors what API Gateway places into `event.requestContext.authorizer`
+    after the (0b) authorizer change. Top-level keys can be overridden via
+    kwargs (e.g. httpMethod, path, body, queryStringParameters).
+    """
+    def _make(
+        email: str = "test@example.com",
+        user_id: str = "spotify123",
+        **overrides,
+    ) -> dict:
+        event = _base_api_gateway_event()
+        event["requestContext"] = {
+            "authorizer": {
+                "email": email,
+                "userId": user_id,
+                "tokenType": "user",
+            }
+        }
+        event.update(overrides)
+        return event
+    return _make
+
+
+@pytest.fixture
+def legacy_event():
+    """
+    Build an API Gateway event WITHOUT authorizer identity context (legacy
+    static-token path). If `email` / `user_id` are provided, they are placed
+    into `queryStringParameters` to mimic the current pre-migration callers.
+    """
+    def _make(
+        email: str | None = None,
+        user_id: str | None = None,
+        **overrides,
+    ) -> dict:
+        event = _base_api_gateway_event()
+        event["requestContext"] = {
+            "authorizer": {
+                "tokenType": "legacy",
+            }
+        }
+        query: dict = {}
+        if email is not None:
+            query["email"] = email
+        if user_id is not None:
+            query["userId"] = user_id
+        if query:
+            event["queryStringParameters"] = query
+        event.update(overrides)
+        return event
+    return _make
+
+
 @pytest.fixture
 def sample_user():
     """Sample user data"""

--- a/tests/test_caller_identity_helper.py
+++ b/tests/test_caller_identity_helper.py
@@ -1,0 +1,232 @@
+"""
+Tests for caller-identity helpers in lambdas.common.utility_helpers.
+
+Covers:
+- Trusted authorizer-context resolution (preferred path).
+- Query-string fallback (transition window).
+- JSON-body fallback (transition window).
+- Missing identity (raises MissingCallerIdentityError -> HTTP 401).
+- Edge cases: missing requestContext / missing authorizer keys.
+
+The WARN log emitted on the fallback path is what we grep CloudWatch for to
+gate the Track 1l cleanup. Tests assert on that log string explicitly.
+"""
+
+import json
+import logging
+
+import pytest
+
+from lambdas.common.errors import MissingCallerIdentityError
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    get_caller_user_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def _propagate_xomify_logs():
+    """
+    The xomify logger is configured with `propagate=False` to prevent duplicate
+    Lambda log lines. caplog intercepts records through propagation to the root
+    logger, so we flip propagation on for the duration of each test in this
+    module. The change is reverted afterwards so other tests are unaffected.
+    """
+    logger = logging.getLogger("xomify")
+    original = logger.propagate
+    logger.propagate = True
+    try:
+        yield
+    finally:
+        logger.propagate = original
+
+
+# ============================================
+# get_caller_email
+# ============================================
+
+class TestGetCallerEmail:
+    def test_returns_context_value_when_authorizer_populated(
+        self, authorized_event, caplog
+    ):
+        event = authorized_event(email="alice@example.com")
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_email(event)
+        assert result == "alice@example.com"
+        assert not any("auth_path=fallback" in r.message for r in caplog.records)
+
+    def test_returns_query_param_when_context_empty(self, legacy_event, caplog):
+        event = legacy_event(email="bob@example.com")
+        event["headers"]["User-Agent"] = "XomifyiOS/1.2.3"
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_email(event)
+        assert result == "bob@example.com"
+        warn_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(
+            "auth_path=fallback" in m
+            and "field=email" in m
+            and "user_agent=XomifyiOS/1.2.3" in m
+            for m in warn_messages
+        )
+
+    def test_returns_body_value_when_context_and_query_empty(
+        self, legacy_event, caplog
+    ):
+        event = legacy_event()
+        event["body"] = json.dumps({"email": "carol@example.com"})
+        event["headers"]["user-agent"] = "AngularApp/0.9"  # case-insensitive header
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_email(event)
+        assert result == "carol@example.com"
+        warn_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(
+            "auth_path=fallback" in m
+            and "source=body" in m
+            and "user_agent=AngularApp/0.9" in m
+            for m in warn_messages
+        )
+
+    def test_user_agent_unknown_when_header_missing(self, legacy_event, caplog):
+        event = legacy_event(email="dan@example.com")
+        event["headers"] = {}  # strip headers
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_email(event)
+        assert result == "dan@example.com"
+        warn_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("user_agent=unknown" in m for m in warn_messages)
+
+    def test_raises_when_nothing_present(self, legacy_event):
+        event = legacy_event()
+        with pytest.raises(MissingCallerIdentityError) as exc_info:
+            get_caller_email(event)
+        assert exc_info.value.status == 401
+        assert exc_info.value.details.get("field") == "email"
+
+    def test_handles_missing_request_context_gracefully(self, legacy_event):
+        event = legacy_event(email="eve@example.com")
+        event.pop("requestContext", None)
+        result = get_caller_email(event)
+        assert result == "eve@example.com"
+
+    def test_handles_missing_authorizer_key_gracefully(self, legacy_event):
+        event = legacy_event(email="frank@example.com")
+        event["requestContext"] = {}  # no `authorizer`
+        result = get_caller_email(event)
+        assert result == "frank@example.com"
+
+    def test_empty_string_in_context_falls_back(self, legacy_event, caplog):
+        event = legacy_event(email="grace@example.com")
+        event["requestContext"] = {"authorizer": {"email": ""}}
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_email(event)
+        assert result == "grace@example.com"
+
+    def test_malformed_body_does_not_raise_value_error(self, legacy_event):
+        event = legacy_event()
+        event["body"] = "{not valid json"
+        with pytest.raises(MissingCallerIdentityError):
+            get_caller_email(event)
+
+
+# ============================================
+# get_caller_user_id
+# ============================================
+
+class TestGetCallerUserId:
+    def test_returns_context_value_when_authorizer_populated(
+        self, authorized_event, caplog
+    ):
+        event = authorized_event(user_id="spotifyAlice")
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_user_id(event)
+        assert result == "spotifyAlice"
+        assert not any("auth_path=fallback" in r.message for r in caplog.records)
+
+    def test_returns_query_param_when_context_empty(self, legacy_event, caplog):
+        event = legacy_event(user_id="spotifyBob")
+        event["headers"]["User-Agent"] = "XomifyiOS/2.0"
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_user_id(event)
+        assert result == "spotifyBob"
+        warn_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(
+            "auth_path=fallback" in m
+            and "field=userId" in m
+            and "user_agent=XomifyiOS/2.0" in m
+            for m in warn_messages
+        )
+
+    def test_returns_body_value_when_context_and_query_empty(
+        self, legacy_event, caplog
+    ):
+        event = legacy_event()
+        event["body"] = json.dumps({"userId": "spotifyCarol"})
+        with caplog.at_level(logging.WARNING, logger="xomify"):
+            result = get_caller_user_id(event)
+        assert result == "spotifyCarol"
+        warn_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("source=body" in m for m in warn_messages)
+
+    def test_raises_when_nothing_present(self, legacy_event):
+        event = legacy_event()
+        with pytest.raises(MissingCallerIdentityError) as exc_info:
+            get_caller_user_id(event)
+        assert exc_info.value.status == 401
+        assert exc_info.value.details.get("field") == "userId"
+
+    def test_handles_missing_request_context_gracefully(self, legacy_event):
+        event = legacy_event(user_id="spotifyEve")
+        event.pop("requestContext", None)
+        result = get_caller_user_id(event)
+        assert result == "spotifyEve"
+
+    def test_handles_missing_authorizer_key_gracefully(self, legacy_event):
+        event = legacy_event(user_id="spotifyFrank")
+        event["requestContext"] = {}
+        result = get_caller_user_id(event)
+        assert result == "spotifyFrank"
+
+    def test_context_takes_precedence_over_query(self, authorized_event):
+        event = authorized_event(user_id="contextWinner")
+        event["queryStringParameters"] = {"userId": "queryLoser"}
+        result = get_caller_user_id(event)
+        assert result == "contextWinner"
+
+
+# ============================================
+# Fixture sanity
+# ============================================
+
+class TestFixtures:
+    def test_authorized_event_default_shape(self, authorized_event):
+        event = authorized_event()
+        assert event["requestContext"]["authorizer"]["email"] == "test@example.com"
+        assert event["requestContext"]["authorizer"]["userId"] == "spotify123"
+        assert event["requestContext"]["authorizer"]["tokenType"] == "user"
+
+    def test_authorized_event_overrides(self, authorized_event):
+        event = authorized_event(httpMethod="POST", path="/foo", body='{"x":1}')
+        assert event["httpMethod"] == "POST"
+        assert event["path"] == "/foo"
+        assert event["body"] == '{"x":1}'
+
+    def test_legacy_event_no_identity_in_context(self, legacy_event):
+        event = legacy_event()
+        assert "email" not in event["requestContext"]["authorizer"]
+        assert "userId" not in event["requestContext"]["authorizer"]
+        assert event["requestContext"]["authorizer"]["tokenType"] == "legacy"
+        assert event["queryStringParameters"] == {}
+
+    def test_legacy_event_with_identity_routes_to_query(self, legacy_event):
+        event = legacy_event(email="x@y.z", user_id="abc")
+        assert event["queryStringParameters"] == {"email": "x@y.z", "userId": "abc"}


### PR DESCRIPTION
Closes #143

## Summary
Adds two helpers to `lambdas/common/utility_helpers.py` to resolve caller identity from the authorizer context first, falling back to query/body during the Track 0 -> Track 1 migration window.

- `get_caller_email(event)` - returns trusted email from `event.requestContext.authorizer.email`, falls back to query then body, raises `MissingCallerIdentityError` (HTTP 401) if absent.
- `get_caller_user_id(event)` - same resolution pattern for `userId`.
- Trusted path logs DEBUG; fallback path logs WARN with `field=` + `user_agent=` so CloudWatch can gate Track 1l cleanup (epic Q5).

Also adds:
- `MissingCallerIdentityError` in `lambdas/common/errors.py` (subclass of `AuthorizationError`, status 401, with `field` detail).
- `authorized_event` and `legacy_event` pytest fixtures in `tests/conftest.py`. Existing `api_gateway_event` fixture preserved.
- `tests/test_caller_identity_helper.py` - 20 unit tests.

No handlers migrated; that is Track 1.

## Refs
- Epic: `docs/features/auth-identity-and-live-top-items/PLAN.md` (Q5, Q8)
- Sub-feature stub: `docs/features/caller-identity-helper/PLAN.md`

## Test plan
- [x] `pytest tests/test_caller_identity_helper.py` - 20 passed
- [x] Full backend suite - 190 passed (170 baseline + 20 new)
- [x] Conftest changes preserve all existing fixtures (`api_gateway_event`, `mock_context`, `sample_user`, etc.) - confirmed by green full suite
- [x] Trusted path returns context value, no WARN log
- [x] Query-string fallback path returns query value, emits WARN with `auth_path=fallback field=email user_agent=...`
- [x] Body fallback path returns body value, emits WARN with `source=body`
- [x] All-empty case raises `MissingCallerIdentityError` with `status=401` and `details.field=email`/`userId`
- [x] Edge cases: missing `requestContext`, missing `authorizer` key, empty-string context, malformed JSON body

## Out of scope
- Migrating handlers to use these helpers (Track 1, sub-features 1a-1i).
- Touching the authorizer (sub-feature 0b).
- Removing existing helpers (`require_fields` etc. unchanged).

## Notes
- DO NOT MERGE. Per epic sequencing this is gated on (0b-infra) being deployed; this PR is review-only until then.