### PR TITLE
(0a) auth_login lambda — mint per-user JWT from Spotify access token

### DIFF
--- a/lambdas/auth_login/handler.py
+++ b/lambdas/auth_login/handler.py
@@ -1,0 +1,148 @@
+"""
+POST /auth/login - Mint per-user Xomify JWT from a Spotify access token.
+
+Public route (no authorizer). Verifies the caller against Spotify's `/me`
+endpoint, then issues a short-lived HS256 JWT containing the caller's
+email and Spotify user id. Downstream authorized routes consume that JWT
+via the custom authorizer, which is how the backend knows who is calling
+without trusting any request-supplied identity field.
+
+Audit log on every mint records email, source IP, iat, and exp. The JWT
+itself and the Spotify access token are never logged.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+import jwt
+import requests
+
+from lambdas.common.errors import (
+    AuthorizationError,
+    SpotifyAPIError,
+    ValidationError,
+    handle_errors,
+)
+from lambdas.common.logger import get_logger
+from lambdas.common.ssm_helpers import API_SECRET_KEY
+from lambdas.common.utility_helpers import parse_body, success_response
+
+log = get_logger(__file__)
+
+HANDLER = "auth_login"
+
+SPOTIFY_ME_URL = "https://api.spotify.com/v1/me"
+SPOTIFY_TIMEOUT_SECONDS = 5
+JWT_ALGORITHM = "HS256"
+JWT_TTL_SECONDS = 7 * 24 * 3600  # 7 days (epic plan, Q1)
+
+
+def _get_source_ip(event: dict) -> str:
+    """Extract the requester source IP from an API Gateway event, if present."""
+    request_context = event.get("requestContext") or {}
+    identity = request_context.get("identity") or {}
+    return identity.get("sourceIp") or "unknown"
+
+
+def _fetch_spotify_me(spotify_access_token: str) -> dict:
+    """
+    Call Spotify's `/me` endpoint with the caller's access token.
+
+    Raises:
+        AuthorizationError: Spotify rejected the token (any non-200 status).
+        SpotifyAPIError: Network/transport problem reaching Spotify.
+    """
+    headers = {"Authorization": f"Bearer {spotify_access_token}"}
+    try:
+        response = requests.get(
+            SPOTIFY_ME_URL,
+            headers=headers,
+            timeout=SPOTIFY_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as err:
+        raise SpotifyAPIError(
+            message=f"Failed to reach Spotify /me: {err}",
+            handler=HANDLER,
+            function="_fetch_spotify_me",
+            endpoint="/me",
+        ) from err
+
+    if response.status_code != 200:
+        raise AuthorizationError(
+            message="Spotify rejected the provided access token.",
+            handler=HANDLER,
+            function="_fetch_spotify_me",
+        )
+
+    try:
+        return response.json()
+    except ValueError as err:
+        raise SpotifyAPIError(
+            message=f"Spotify /me returned non-JSON body: {err}",
+            handler=HANDLER,
+            function="_fetch_spotify_me",
+            endpoint="/me",
+        ) from err
+
+
+def _mint_jwt(email: str, user_id: str) -> tuple[str, int, int]:
+    """
+    Mint an HS256 JWT for the caller.
+
+    Returns:
+        (token, iat, exp) where iat and exp are Unix epoch seconds.
+    """
+    iat = int(datetime.now(timezone.utc).timestamp())
+    exp = iat + JWT_TTL_SECONDS
+    payload: dict[str, Any] = {
+        "email": email,
+        "userId": user_id,
+        "iat": iat,
+        "exp": exp,
+    }
+    token = jwt.encode(payload, API_SECRET_KEY, algorithm=JWT_ALGORITHM)
+    # PyJWT >= 2.0 returns a str; guard against the legacy bytes return.
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
+    return token, iat, exp
+
+
+@handle_errors(HANDLER)
+def handler(event: dict, context: Any) -> dict:
+    body = parse_body(event)
+    spotify_access_token = body.get("spotifyAccessToken")
+
+    if not isinstance(spotify_access_token, str) or not spotify_access_token.strip():
+        raise ValidationError(
+            message="Missing required field: spotifyAccessToken",
+            handler=HANDLER,
+            function="handler",
+            field="spotifyAccessToken",
+        )
+
+    me = _fetch_spotify_me(spotify_access_token)
+
+    email = me.get("email")
+    user_id = me.get("id")
+    if not email or not user_id:
+        raise SpotifyAPIError(
+            message="Spotify /me response missing required fields (email or id).",
+            handler=HANDLER,
+            function="handler",
+            endpoint="/me",
+        )
+
+    token, iat, exp = _mint_jwt(email=email, user_id=user_id)
+
+    source_ip = _get_source_ip(event)
+    log.info(
+        "auth_login mint email=%s ip=%s iat=%s exp=%s",
+        email,
+        source_ip,
+        iat,
+        exp,
+    )
+
+    expires_at = datetime.fromtimestamp(exp, tz=timezone.utc).isoformat()
+
+    return success_response({"token": token, "expiresAt": expires_at})

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -1,0 +1,201 @@
+"""
+Tests for auth_login lambda.
+
+Covers:
+- happy path mints a JWT with correct claims
+- missing spotifyAccessToken in body  -> 400
+- empty body                          -> 400
+- empty/whitespace-only token         -> 400
+- Spotify returns 401                 -> 401 structured error
+- Spotify returns 200 but no email    -> 502 structured error
+- Spotify returns 200 but no id       -> 502 structured error
+- Spotify network failure             -> 502 structured error
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+
+from lambdas.auth_login.handler import JWT_TTL_SECONDS, handler
+
+TEST_SECRET = "test-api-secret-key"
+
+
+def _make_event(body, source_ip: str = "203.0.113.5") -> dict:
+    """Build an API Gateway event with a serialized body and a sourceIp."""
+    return {
+        "httpMethod": "POST",
+        "path": "/auth/login",
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body) if body is not None else None,
+        "queryStringParameters": {},
+        "isBase64Encoded": False,
+        "requestContext": {
+            "identity": {"sourceIp": source_ip},
+        },
+    }
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_happy_path_mints_jwt(mock_requests_get, mock_context):
+    """Spotify /me returns email + id; handler returns a JWT with expected claims."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "email": "user@example.com",
+        "id": "spotify-user-1",
+        "display_name": "User Example",
+    }
+    mock_requests_get.return_value = mock_response
+
+    event = _make_event({"spotifyAccessToken": "valid-spotify-token"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+
+    assert "token" in body
+    assert "expiresAt" in body
+    assert isinstance(body["token"], str)
+    assert isinstance(body["expiresAt"], str)
+
+    # Spotify was called once with the right URL, header, and timeout.
+    mock_requests_get.assert_called_once()
+    args, kwargs = mock_requests_get.call_args
+    assert args[0] == "https://api.spotify.com/v1/me"
+    assert kwargs["headers"]["Authorization"] == "Bearer valid-spotify-token"
+    assert kwargs["timeout"] == 5
+
+    # Decode and assert claims.
+    decoded = jwt.decode(body["token"], TEST_SECRET, algorithms=["HS256"])
+    assert decoded["email"] == "user@example.com"
+    assert decoded["userId"] == "spotify-user-1"
+    assert isinstance(decoded["iat"], int)
+    assert isinstance(decoded["exp"], int)
+    assert decoded["exp"] - decoded["iat"] == JWT_TTL_SECONDS
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_missing_spotify_access_token_returns_400(mock_requests_get, mock_context):
+    """Body missing spotifyAccessToken -> ValidationError -> 400."""
+    event = _make_event({"somethingElse": "nope"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 400
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 400
+    assert "spotifyAccessToken" in body["error"]["message"]
+    mock_requests_get.assert_not_called()
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_empty_body_returns_400(mock_requests_get, mock_context):
+    """Completely empty body -> 400."""
+    event = _make_event(None)
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 400
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 400
+    mock_requests_get.assert_not_called()
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_whitespace_token_returns_400(mock_requests_get, mock_context):
+    """Token that is just whitespace counts as missing -> 400."""
+    event = _make_event({"spotifyAccessToken": "   "})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 400
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 400
+    mock_requests_get.assert_not_called()
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_spotify_401_returns_401(mock_requests_get, mock_context):
+    """Spotify says the token is bad -> handler returns structured 401."""
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.json.return_value = {"error": {"status": 401, "message": "Invalid access token"}}
+    mock_requests_get.return_value = mock_response
+
+    event = _make_event({"spotifyAccessToken": "expired-or-bogus-token"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 401
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 401
+    assert body["error"]["handler"] == "auth_login"
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_spotify_200_missing_email_returns_502(mock_requests_get, mock_context):
+    """Spotify returns 200 but no email -> 502 because upstream is malformed."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "spotify-user-1"}  # no email
+    mock_requests_get.return_value = mock_response
+
+    event = _make_event({"spotifyAccessToken": "valid-but-thin-profile"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 502
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 502
+    assert body["error"]["handler"] == "auth_login"
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_spotify_200_missing_id_returns_502(mock_requests_get, mock_context):
+    """Spotify returns 200 but no id -> 502."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"email": "user@example.com"}  # no id
+    mock_requests_get.return_value = mock_response
+
+    event = _make_event({"spotifyAccessToken": "valid-but-thin-profile"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 502
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 502
+
+
+@patch("lambdas.auth_login.handler.requests.get")
+def test_spotify_network_failure_returns_502(mock_requests_get, mock_context):
+    """Network problems reaching Spotify surface as 502."""
+    import requests as _requests
+
+    mock_requests_get.side_effect = _requests.ConnectionError("boom")
+
+    event = _make_event({"spotifyAccessToken": "any-token"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 502
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 502
+
+
+@pytest.fixture(autouse=True)
+def _patch_api_secret_key(monkeypatch):
+    """
+    Pin the JWT signing secret to a deterministic value for every test in this
+    module. The conftest already injects a fake `lambdas.common.ssm_helpers`
+    with API_SECRET_KEY = 'test-api-secret-key'; we re-pin here defensively
+    against any test that imported the symbol before our module loaded.
+    """
+    import lambdas.auth_login.handler as auth_login_handler
+
+    monkeypatch.setattr(auth_login_handler, "API_SECRET_KEY", TEST_SECRET, raising=False)
+    yield


### PR DESCRIPTION
Closes #141

## Summary
- New `lambdas/auth_login/handler.py` that backs the public `POST /auth/login` route.
- Verifies the caller against Spotify `/me` (5s timeout) and mints a 7-day HS256 JWT signed with the existing `API_SECRET_KEY` SSM parameter.
- JWT claims: `{ email, userId, iat, exp }` — exactly what the (0b) authorizer extension and (0c) caller-identity helper will consume.
- Audit-logs every mint with email + source IP + iat + exp. Never logs the JWT or the Spotify access token.
- 8 unit tests, all green; full suite (178 tests) still green.

## Why
Today every install of every client ships the same `XOMIFY_API_TOKEN` and the authorizer discards the JWT payload. There is no per-user identity in the token at all, so handlers fall back to trusting a caller-supplied `email` query param. This lambda is the foundation of Track 0 in the [auth-identity epic](../tree/master/docs/features/auth-identity-and-live-top-items/PLAN.md) — without it, none of the (0b)/(0c)/(1*) work has anything to consume.

## Out of scope
- Terraform / IAM / API GW route — handled by `(0a-infra)` (PR #74 in `xomify-infrastructure`).
- Authorizer claim extraction — `(0b)`.
- `get_caller_email` / `get_caller_user_id` helper — `(0c)`.

**Do not merge until `(0a-infra)` is applied to AWS** so `POST /auth/login` actually has a route to land on. End-to-end exit verification depends on that infra PR.

## Test plan
- [x] `python -m pytest tests/test_auth_login.py -xvs` — 8 / 8 passing.
- [x] Full suite `python -m pytest tests/` — 178 / 178 passing.
- [ ] After `(0a-infra)` deploy: `curl -X POST https://api.xomify.com/auth/login -d '{"spotifyAccessToken":"<live-token>"}'` returns `{token, expiresAt}`. Decoded JWT has expected claims.
- [ ] CloudWatch shows the audit log line `auth_login mint email=... ip=... iat=... exp=...` and does NOT contain the JWT or the Spotify token.

## Sub-feature
[`docs/features/auth-login-endpoint/PLAN.md`](../tree/master/docs/features/auth-login-endpoint/PLAN.md) (parent epic linked from there).