### PR TITLE
(1g) Migrate release-radar handlers to caller-identity helper

### DIFF
--- a/lambdas/release_radar_check/handler.py
+++ b/lambdas/release_radar_check/handler.py
@@ -4,7 +4,7 @@ GET /release-radar/check - Check user's release radar enrollment status
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.dynamo_helpers import get_user_table_data
 from lambdas.common.release_radar_dynamo import (
     check_user_has_history,
@@ -19,11 +19,8 @@ HANDLER = 'release_radar_check'
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
-
-    email = params.get('email')
+def handler(event: dict, context) -> dict:
+    email: str = get_caller_email(event)
 
     has_history = check_user_has_history(email)
     current_week = get_week_key()

--- a/lambdas/release_radar_history/handler.py
+++ b/lambdas/release_radar_history/handler.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_query_params, get_caller_email
 from lambdas.common.release_radar_dynamo import (
     get_user_release_radar_history,
     get_week_key,
@@ -95,11 +95,10 @@ def group_releases(releases: list) -> list:
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
+def handler(event: dict, context) -> dict:
+    email: str = get_caller_email(event)
 
-    email = params.get('email')
+    params = get_query_params(event)
     limit = int(params.get('limit', 26))
 
     weeks = get_user_release_radar_history(email, limit=limit)

--- a/tests/test_release_radar_check.py
+++ b/tests/test_release_radar_check.py
@@ -1,0 +1,129 @@
+"""
+Tests for release_radar_check lambda.
+
+Covers caller-identity migration (Track 1g): handler reads caller email
+from authorizer context, with query-string fallback during the migration
+window.
+"""
+
+import json
+from datetime import date
+from unittest.mock import patch
+
+from lambdas.release_radar_check.handler import handler
+
+
+@patch('lambdas.release_radar_check.handler.get_user_table_data')
+@patch('lambdas.release_radar_check.handler.format_week_display')
+@patch('lambdas.release_radar_check.handler.get_week_date_range')
+@patch('lambdas.release_radar_check.handler.get_week_key')
+@patch('lambdas.release_radar_check.handler.check_user_has_history')
+def test_release_radar_check_success_authorized(
+    mock_has_history,
+    mock_week_key,
+    mock_week_range,
+    mock_week_display,
+    mock_user_data,
+    mock_context,
+    authorized_event,
+):
+    """Caller email comes from trusted authorizer context."""
+    mock_has_history.return_value = True
+    mock_week_key.return_value = '2024-W10'
+    mock_week_range.return_value = (date(2024, 3, 4), date(2024, 3, 10))
+    mock_week_display.return_value = 'Week 10, 2024'
+    mock_user_data.return_value = {'activeReleaseRadar': True}
+
+    event = authorized_event(
+        email='ctx@example.com',
+        httpMethod='GET',
+        path='/release-radar/check',
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == 'ctx@example.com'
+    assert body['enrolled'] is True
+    assert body['hasHistory'] is True
+    assert body['currentWeek'] == '2024-W10'
+    assert body['weekStartDate'] == '2024-03-04'
+    assert body['weekEndDate'] == '2024-03-10'
+    mock_has_history.assert_called_once_with('ctx@example.com')
+    mock_user_data.assert_called_once_with('ctx@example.com')
+
+
+@patch('lambdas.release_radar_check.handler.get_user_table_data')
+@patch('lambdas.release_radar_check.handler.format_week_display')
+@patch('lambdas.release_radar_check.handler.get_week_date_range')
+@patch('lambdas.release_radar_check.handler.get_week_key')
+@patch('lambdas.release_radar_check.handler.check_user_has_history')
+def test_release_radar_check_not_enrolled_when_user_missing(
+    mock_has_history,
+    mock_week_key,
+    mock_week_range,
+    mock_week_display,
+    mock_user_data,
+    mock_context,
+    authorized_event,
+):
+    """Missing user record -> enrolled=False (no crash)."""
+    mock_has_history.return_value = False
+    mock_week_key.return_value = '2024-W10'
+    mock_week_range.return_value = (date(2024, 3, 4), date(2024, 3, 10))
+    mock_week_display.return_value = 'Week 10, 2024'
+    mock_user_data.return_value = None
+
+    event = authorized_event(email='nouser@example.com')
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['enrolled'] is False
+    assert body['hasHistory'] is False
+
+
+@patch('lambdas.release_radar_check.handler.get_user_table_data')
+@patch('lambdas.release_radar_check.handler.format_week_display')
+@patch('lambdas.release_radar_check.handler.get_week_date_range')
+@patch('lambdas.release_radar_check.handler.get_week_key')
+@patch('lambdas.release_radar_check.handler.check_user_has_history')
+def test_release_radar_check_legacy_query_fallback(
+    mock_has_history,
+    mock_week_key,
+    mock_week_range,
+    mock_week_display,
+    mock_user_data,
+    mock_context,
+    legacy_event,
+):
+    """Legacy callers (no JWT context) still resolve email via query string."""
+    mock_has_history.return_value = False
+    mock_week_key.return_value = '2024-W10'
+    mock_week_range.return_value = (date(2024, 3, 4), date(2024, 3, 10))
+    mock_week_display.return_value = 'Week 10, 2024'
+    mock_user_data.return_value = {'activeReleaseRadar': False}
+
+    event = legacy_event(email='legacy@example.com')
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == 'legacy@example.com'
+    mock_has_history.assert_called_once_with('legacy@example.com')
+
+
+def test_release_radar_check_missing_identity_returns_401(
+    mock_context, legacy_event
+):
+    """No context email and no query email -> structured 401 from helper."""
+    event = legacy_event()
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    body = json.loads(response['body'])
+    assert body['error']['status'] == 401

--- a/tests/test_release_radar_history.py
+++ b/tests/test_release_radar_history.py
@@ -1,66 +1,105 @@
 """
-Tests for release_radar_history lambda
+Tests for release_radar_history lambda.
+
+Covers caller-identity migration (Track 1g): handler now reads the caller's
+email from the trusted authorizer context via `get_caller_email`, with a
+query-string fallback retained during the migration window.
 """
 
-import pytest
 import json
 from unittest.mock import patch
+
+import pytest
+
 from lambdas.release_radar_history.handler import handler
 
 
 @patch('lambdas.release_radar_history.handler.get_user_release_radar_history')
 @patch('lambdas.release_radar_history.handler.get_week_key')
 @patch('lambdas.release_radar_history.handler.format_week_display')
-def test_release_radar_history_success(mock_format, mock_get_week, mock_get_history, mock_context, api_gateway_event):
-    """Test successful release radar history retrieval"""
-    # Setup
+def test_release_radar_history_success_authorized(
+    mock_format, mock_get_week, mock_get_history, mock_context, authorized_event
+):
+    """Caller email comes from authorizer context — no query param needed."""
     mock_get_history.return_value = [
         {'weekKey': '2024-W01', 'trackCount': 10},
-        {'weekKey': '2024-W02', 'trackCount': 15}
+        {'weekKey': '2024-W02', 'trackCount': 15},
     ]
     mock_get_week.return_value = '2024-W10'
     mock_format.return_value = 'Week 10, 2024'
 
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/release-radar/history",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = authorized_event(
+        email='ctx@example.com',
+        httpMethod='GET',
+        path='/release-radar/history',
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
     assert body['count'] == 2
-    assert body['email'] == 'test@example.com'
+    assert body['email'] == 'ctx@example.com'
+    mock_get_history.assert_called_once_with('ctx@example.com', limit=26)
 
 
 @patch('lambdas.release_radar_history.handler.get_user_release_radar_history')
 @patch('lambdas.release_radar_history.handler.get_week_key')
 @patch('lambdas.release_radar_history.handler.format_week_display')
-def test_release_radar_history_with_limit(mock_format, mock_get_week, mock_get_history, mock_context, api_gateway_event):
-    """Test history retrieval with custom limit"""
-    # Setup
+def test_release_radar_history_with_limit(
+    mock_format, mock_get_week, mock_get_history, mock_context, authorized_event
+):
+    """`limit` query param is still honored alongside context-sourced email."""
     mock_get_history.return_value = []
     mock_get_week.return_value = '2024-W10'
     mock_format.return_value = 'Week 10, 2024'
 
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/release-radar/history",
-        "queryStringParameters": {
-            "email": "test@example.com",
-            "limit": "10"
-        }
-    }
+    event = authorized_event(
+        email='ctx@example.com',
+        httpMethod='GET',
+        path='/release-radar/history',
+        queryStringParameters={'limit': '10'},
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
-    mock_get_history.assert_called_once_with('test@example.com', limit=10)
+    mock_get_history.assert_called_once_with('ctx@example.com', limit=10)
+
+
+@patch('lambdas.release_radar_history.handler.get_user_release_radar_history')
+@patch('lambdas.release_radar_history.handler.get_week_key')
+@patch('lambdas.release_radar_history.handler.format_week_display')
+def test_release_radar_history_legacy_query_fallback(
+    mock_format, mock_get_week, mock_get_history, mock_context, legacy_event
+):
+    """Legacy clients (no per-user JWT) still work via the query-string fallback."""
+    mock_get_history.return_value = []
+    mock_get_week.return_value = '2024-W10'
+    mock_format.return_value = 'Week 10, 2024'
+
+    event = legacy_event(email='legacy@example.com')
+    event['httpMethod'] = 'GET'
+    event['path'] = '/release-radar/history'
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == 'legacy@example.com'
+    mock_get_history.assert_called_once_with('legacy@example.com', limit=26)
+
+
+def test_release_radar_history_missing_identity_returns_401(
+    mock_context, legacy_event
+):
+    """No authorizer context AND no query/body email -> structured 401."""
+    event = legacy_event()  # neither context email nor query email
+    event['httpMethod'] = 'GET'
+    event['path'] = '/release-radar/history'
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    body = json.loads(response['body'])
+    assert body['error']['status'] == 401


### PR DESCRIPTION
## Summary
Track 1 sub-feature (1g) of the auth-identity epic. Migrates the 2 authorized release-radar handlers to read the caller's email from the trusted authorizer context, retaining the query-string fallback during the migration window.

- `lambdas/release_radar_check/handler.py`: `email = get_caller_email(event)` (was `params.get('email')` + `require_fields`).
- `lambdas/release_radar_history/handler.py`: same migration; `limit` query param still honored.
- `require_fields(params, 'email')` guard removed — the helper raises `MissingCallerIdentityError` (HTTP 401) when no source provides the email.

## Tests
- `tests/test_release_radar_history.py`: rewritten — happy path now uses `authorized_event`, plus a `legacy_event` fallback case and a 401-on-missing-identity case.
- `tests/test_release_radar_check.py`: new — happy path (authorized), missing-user (authorized), legacy fallback, 401 on missing identity.
- All 8 release-radar tests pass; full suite (231 tests) passes.

## Scope notes
- `cron_release_radar` and `cron_release_radar_email` are CloudWatch-triggered, not behind the authorizer — out of scope per parent epic.

## Test plan
- [x] `python -m pytest tests/test_release_radar*.py -xvs` — 8 passed
- [x] `python -m pytest -x` — 231 passed
- [ ] Post-deploy smoke: hit `/release-radar/check?email=...` from a legacy client — expect 200 + a CloudWatch WARN line `caller_identity field=email auth_path=fallback ...`

Closes #152