### PR TITLE
(1e) Migrate ratings handlers to caller-identity helper

### DIFF
--- a/lambdas/ratings_all/handler.py
+++ b/lambdas/ratings_all/handler.py
@@ -1,10 +1,10 @@
 """
-GET /ratings/all - Get all user's track ratings
+GET /ratings/all - Get all of the caller's track ratings
 """
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.track_ratings_dynamo import list_all_track_ratings_for_user
 
 log = get_logger(__file__)
@@ -14,10 +14,7 @@ HANDLER = 'ratings_all'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
-
-    email = params.get('email')
+    email: str = get_caller_email(event)
 
     log.info(f"Getting all Track Ratings for user {email}")
     ratings = list_all_track_ratings_for_user(email)

--- a/lambdas/ratings_publish/handler.py
+++ b/lambdas/ratings_publish/handler.py
@@ -1,10 +1,15 @@
 """
-POST /ratings/publish - Create/Update user's track rating for single track
+POST /ratings/publish - Create/Update caller's track rating for single track
 """
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.track_ratings_dynamo import upsert_track_rating
 
 log = get_logger(__file__)
@@ -15,19 +20,19 @@ HANDLER = 'ratings_publish'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'trackId', 'rating', 'trackName', 'artistName', 'albumArt')
+    require_fields(body, 'trackId', 'rating', 'trackName', 'artistName', 'albumArt')
 
-    email = body.get('email')
+    email: str = get_caller_email(event)
     track_id = body.get('trackId')
     rating = body.get('rating')
     track_name = body.get('trackName')
     artist_name = body.get('artistName')
     album_art = body.get('albumArt')
     album_name = body.get('album_name', None)
-    context = body.get('contetxt', None)                  
+    rating_context = body.get('contetxt', None)
 
     log.info(f"Creating/Updating Single Track Rating for user {email} and track id {track_id} with rating {rating}")
-    rating = upsert_track_rating(email, track_id, rating, track_name, artist_name, album_art, album_name, context)
+    rating = upsert_track_rating(email, track_id, rating, track_name, artist_name, album_art, album_name, rating_context)
 
     return success_response({
         'rating': rating,

--- a/lambdas/ratings_remove/handler.py
+++ b/lambdas/ratings_remove/handler.py
@@ -1,10 +1,15 @@
 """
-DELETE /ratings/remove - Delete user's track rating for single track
+DELETE /ratings/remove - Delete caller's track rating for single track
 """
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.track_ratings_dynamo import delete_track_rating
 
 log = get_logger(__file__)
@@ -15,9 +20,9 @@ HANDLER = 'ratings_remove'
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email', 'trackId')
+    require_fields(params, 'trackId')
 
-    email = params.get('email')
+    email: str = get_caller_email(event)
     track_id = params.get('trackId')
 
     log.info(f"Deleting Single Track Rating for user {email} and track id {track_id}")

--- a/lambdas/ratings_track/handler.py
+++ b/lambdas/ratings_track/handler.py
@@ -1,10 +1,15 @@
 """
-GET /ratings/all - Get user's track rating for single track
+GET /ratings/track - Get caller's track rating for single track
 """
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.track_ratings_dynamo import get_single_track_rating_for_user
 
 log = get_logger(__file__)
@@ -15,9 +20,9 @@ HANDLER = 'ratings_track'
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email', 'trackId')
+    require_fields(params, 'trackId')
 
-    email = params.get('email')
+    email: str = get_caller_email(event)
     track_id = params.get('trackId')
 
     log.info(f"Getting Single Track Rating for user {email} and track id {track_id}")

--- a/tests/test_ratings_all.py
+++ b/tests/test_ratings_all.py
@@ -1,0 +1,86 @@
+"""
+Tests for ratings_all lambda
+
+Covers the Track 1e migration: caller email is sourced from
+`requestContext.authorizer.email` (per-user JWT) with fallback to query
+string while legacy static-token clients are still in flight.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.ratings_all.handler import handler
+
+
+SAMPLE_RATINGS = [
+    {
+        "email": "alice@example.com",
+        "trackId": "track1",
+        "rating": 5.0,
+        "trackName": "Song One",
+        "artistName": "Artist A",
+        "albumArt": "https://example.com/a.jpg",
+    },
+    {
+        "email": "alice@example.com",
+        "trackId": "track2",
+        "rating": 3.5,
+        "trackName": "Song Two",
+        "artistName": "Artist B",
+        "albumArt": "https://example.com/b.jpg",
+    },
+]
+
+
+@patch('lambdas.ratings_all.handler.list_all_track_ratings_for_user')
+def test_ratings_all_uses_caller_context(
+    mock_list, mock_context, authorized_event
+):
+    """Trusted authorizer context drives the lookup; no query param needed."""
+    mock_list.return_value = SAMPLE_RATINGS
+    event = authorized_event(
+        email="alice@example.com",
+        httpMethod="GET",
+        path="/ratings/all",
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_list.assert_called_once_with("alice@example.com")
+    body = json.loads(response['body'])
+    assert body['totalRatings'] == 2
+    assert body['ratings'] == SAMPLE_RATINGS
+
+
+@patch('lambdas.ratings_all.handler.list_all_track_ratings_for_user')
+def test_ratings_all_falls_back_to_query_param(
+    mock_list, mock_context, legacy_event
+):
+    """Legacy static-token callers still send caller email on the query string."""
+    mock_list.return_value = []
+    event = legacy_event(email="legacy@example.com")
+    event["httpMethod"] = "GET"
+    event["path"] = "/ratings/all"
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_list.assert_called_once_with("legacy@example.com")
+    body = json.loads(response['body'])
+    assert body['totalRatings'] == 0
+
+
+@patch('lambdas.ratings_all.handler.list_all_track_ratings_for_user')
+def test_ratings_all_missing_identity_returns_401(
+    mock_list, mock_context, legacy_event
+):
+    """No context, no query, no body -> structured 401, no DB call."""
+    event = legacy_event()
+    event["httpMethod"] = "GET"
+    event["path"] = "/ratings/all"
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_list.assert_not_called()

--- a/tests/test_ratings_publish.py
+++ b/tests/test_ratings_publish.py
@@ -1,0 +1,113 @@
+"""
+Tests for ratings_publish lambda
+
+Covers the Track 1e migration: caller email is sourced from
+`requestContext.authorizer.email` (per-user JWT) with fallback to body
+during the migration window. Track-level fields (trackId, rating, etc.)
+remain explicit body inputs.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.ratings_publish.handler import handler
+
+
+def _publish_body(**overrides):
+    body = {
+        "trackId": "track1",
+        "rating": 4.5,
+        "trackName": "Song One",
+        "artistName": "Artist A",
+        "albumArt": "https://example.com/a.jpg",
+    }
+    body.update(overrides)
+    return body
+
+
+@patch('lambdas.ratings_publish.handler.upsert_track_rating')
+def test_ratings_publish_uses_caller_context(
+    mock_upsert, mock_context, authorized_event
+):
+    """Caller email comes from authorizer context; track fields from body."""
+    mock_upsert.return_value = {
+        "email": "alice@example.com",
+        "trackId": "track1",
+        "rating": 4.5,
+    }
+    event = authorized_event(
+        email="alice@example.com",
+        httpMethod="POST",
+        path="/ratings/publish",
+        body=json.dumps(_publish_body()),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_upsert.assert_called_once_with(
+        "alice@example.com",
+        "track1",
+        4.5,
+        "Song One",
+        "Artist A",
+        "https://example.com/a.jpg",
+        None,
+        None,
+    )
+    body = json.loads(response['body'])
+    assert body['rating']['trackId'] == "track1"
+
+
+@patch('lambdas.ratings_publish.handler.upsert_track_rating')
+def test_ratings_publish_falls_back_to_body_email(
+    mock_upsert, mock_context, legacy_event
+):
+    """Legacy clients send caller email in the JSON body alongside track data."""
+    mock_upsert.return_value = {"email": "legacy@example.com", "trackId": "track1"}
+    event = legacy_event()
+    event["httpMethod"] = "POST"
+    event["path"] = "/ratings/publish"
+    event["body"] = json.dumps(_publish_body(email="legacy@example.com"))
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    args, _ = mock_upsert.call_args
+    assert args[0] == "legacy@example.com"
+    assert args[1] == "track1"
+
+
+@patch('lambdas.ratings_publish.handler.upsert_track_rating')
+def test_ratings_publish_missing_identity_returns_401(
+    mock_upsert, mock_context, legacy_event
+):
+    """No caller email anywhere -> 401, upsert never invoked."""
+    event = legacy_event()
+    event["httpMethod"] = "POST"
+    event["path"] = "/ratings/publish"
+    event["body"] = json.dumps(_publish_body())  # no email field
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_upsert.assert_not_called()
+
+
+@patch('lambdas.ratings_publish.handler.upsert_track_rating')
+def test_ratings_publish_missing_track_id_returns_400(
+    mock_upsert, mock_context, authorized_event
+):
+    """Track id is still validated as a required body field."""
+    body = _publish_body()
+    body.pop("trackId")
+    event = authorized_event(
+        httpMethod="POST",
+        path="/ratings/publish",
+        body=json.dumps(body),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_upsert.assert_not_called()

--- a/tests/test_ratings_remove.py
+++ b/tests/test_ratings_remove.py
@@ -1,0 +1,84 @@
+"""
+Tests for ratings_remove lambda
+
+Covers the Track 1e migration: caller email is sourced from
+`requestContext.authorizer.email` (per-user JWT) with fallback to query
+string. `trackId` stays a required query parameter (it identifies which
+of the caller's ratings to delete, not who the caller is).
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.ratings_remove.handler import handler
+
+
+@patch('lambdas.ratings_remove.handler.delete_track_rating')
+def test_ratings_remove_uses_caller_context(
+    mock_delete, mock_context, authorized_event
+):
+    """Caller email comes from authorizer; trackId stays in query params."""
+    mock_delete.return_value = True
+    event = authorized_event(
+        email="alice@example.com",
+        httpMethod="DELETE",
+        path="/ratings/remove",
+        queryStringParameters={"trackId": "track1"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_delete.assert_called_once_with("alice@example.com", "track1")
+    body = json.loads(response['body'])
+    assert body['success'] is True
+
+
+@patch('lambdas.ratings_remove.handler.delete_track_rating')
+def test_ratings_remove_falls_back_to_query_email(
+    mock_delete, mock_context, legacy_event
+):
+    """Legacy clients still pass caller email on the query string."""
+    mock_delete.return_value = True
+    event = legacy_event(email="legacy@example.com")
+    event["httpMethod"] = "DELETE"
+    event["path"] = "/ratings/remove"
+    event["queryStringParameters"]["trackId"] = "track1"
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_delete.assert_called_once_with("legacy@example.com", "track1")
+
+
+@patch('lambdas.ratings_remove.handler.delete_track_rating')
+def test_ratings_remove_missing_identity_returns_401(
+    mock_delete, mock_context, legacy_event
+):
+    """No caller anywhere -> 401, delete never invoked."""
+    event = legacy_event()
+    event["httpMethod"] = "DELETE"
+    event["path"] = "/ratings/remove"
+    event["queryStringParameters"] = {"trackId": "track1"}
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_delete.assert_not_called()
+
+
+@patch('lambdas.ratings_remove.handler.delete_track_rating')
+def test_ratings_remove_missing_track_id_returns_400(
+    mock_delete, mock_context, authorized_event
+):
+    """trackId is still a required query parameter."""
+    event = authorized_event(
+        httpMethod="DELETE",
+        path="/ratings/remove",
+        queryStringParameters={},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_delete.assert_not_called()

--- a/tests/test_ratings_track.py
+++ b/tests/test_ratings_track.py
@@ -1,0 +1,93 @@
+"""
+Tests for ratings_track lambda
+
+Covers the Track 1e migration: caller email is sourced from
+`requestContext.authorizer.email` (per-user JWT) with fallback to query
+string. `trackId` stays a required query parameter.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.ratings_track.handler import handler
+
+
+SAMPLE_RATING = {
+    "email": "alice@example.com",
+    "trackId": "track1",
+    "rating": 4.0,
+    "trackName": "Song One",
+    "artistName": "Artist A",
+    "albumArt": "https://example.com/a.jpg",
+}
+
+
+@patch('lambdas.ratings_track.handler.get_single_track_rating_for_user')
+def test_ratings_track_uses_caller_context(
+    mock_get, mock_context, authorized_event
+):
+    """Caller email comes from authorizer; trackId stays in query params."""
+    mock_get.return_value = SAMPLE_RATING
+    event = authorized_event(
+        email="alice@example.com",
+        httpMethod="GET",
+        path="/ratings/track",
+        queryStringParameters={"trackId": "track1"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_get.assert_called_once_with("alice@example.com", "track1")
+    body = json.loads(response['body'])
+    assert body['rating'] == SAMPLE_RATING
+
+
+@patch('lambdas.ratings_track.handler.get_single_track_rating_for_user')
+def test_ratings_track_falls_back_to_query_email(
+    mock_get, mock_context, legacy_event
+):
+    """Legacy clients pass caller email on the query string."""
+    mock_get.return_value = SAMPLE_RATING
+    event = legacy_event(email="legacy@example.com")
+    event["httpMethod"] = "GET"
+    event["path"] = "/ratings/track"
+    event["queryStringParameters"]["trackId"] = "track1"
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_get.assert_called_once_with("legacy@example.com", "track1")
+
+
+@patch('lambdas.ratings_track.handler.get_single_track_rating_for_user')
+def test_ratings_track_missing_identity_returns_401(
+    mock_get, mock_context, legacy_event
+):
+    """No caller anywhere -> 401, lookup never invoked."""
+    event = legacy_event()
+    event["httpMethod"] = "GET"
+    event["path"] = "/ratings/track"
+    event["queryStringParameters"] = {"trackId": "track1"}
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_get.assert_not_called()
+
+
+@patch('lambdas.ratings_track.handler.get_single_track_rating_for_user')
+def test_ratings_track_missing_track_id_returns_400(
+    mock_get, mock_context, authorized_event
+):
+    """trackId is still a required query parameter."""
+    event = authorized_event(
+        httpMethod="GET",
+        path="/ratings/track",
+        queryStringParameters={},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_get.assert_not_called()


### PR DESCRIPTION
Closes #154

Track 1e of the [auth-identity-and-live-top-items](docs/features/auth-identity-and-live-top-items/PLAN.md) epic.

## Summary
- All four ratings handlers (`ratings_all`, `ratings_publish`, `ratings_remove`, `ratings_track`) read caller email from `requestContext.authorizer.email` via `get_caller_email`. The helper keeps the query-string / body fallback live so legacy static-token clients continue to work through the migration window.
- `email` is dropped from `require_fields` so the helper's structured 401 path runs when no identity is resolvable, instead of the generic 400.
- New per-handler test files use the `authorized_event` and `legacy_event` fixtures and cover the trusted-context path, the fallback path, and the missing-identity 401 (plus the remaining required-field 400 where applicable).

## Caller vs. target
The `TRACK_RATINGS` table is keyed on `(email, trackId)` and no handler in this batch reads anyone else's ratings — there is no `friendEmail` / `targetEmail` field. So `email` is unambiguously the caller (rater) in every case. `trackId`, `rating`, `trackName`, `artistName`, `albumArt`, `albumName`, and `context` stay as explicit request inputs.

## Test plan
- [x] `pytest tests/test_ratings_*.py` — 15 passed
- [x] Full suite: `pytest` — 226 passed (was 211)
- [ ] Post-deploy: CloudWatch shows `caller_identity ... auth_path=context` for new clients and `auth_path=fallback` warns for legacy. Counts feed the (1l) burn-in gate.