### PR TITLE
(1f) Migrate notifications handlers to caller-identity helper

### DIFF
--- a/lambdas/notifications_register/handler.py
+++ b/lambdas/notifications_register/handler.py
@@ -1,9 +1,12 @@
 """
-POST /notifications/register - Store/refresh an APNs device token for a user.
+POST /notifications/register - Store/refresh an APNs device token for the caller.
+
+Caller identity (`email`) is sourced from the JWT-authorizer context via
+`get_caller_email`. The body only carries the target device token + optional
+preference flags.
 
 Body:
     {
-        "email": "user@...",
         "deviceToken": "<hex>",
         "digestEnabled": true,               # optional, default true
         "queueNotificationsEnabled": true    # optional, default true
@@ -12,9 +15,16 @@ Body:
 
 from __future__ import annotations
 
+from typing import Any
+
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    parse_body,
+    require_fields,
+    success_response,
+)
 from lambdas.common.device_tokens_dynamo import upsert_token
 
 log = get_logger(__file__)
@@ -22,7 +32,7 @@ log = get_logger(__file__)
 HANDLER = "notifications_register"
 
 
-def _as_bool(value, default: bool) -> bool:
+def _as_bool(value: Any, default: bool) -> bool:
     if value is None:
         return default
     if isinstance(value, bool):
@@ -33,11 +43,11 @@ def _as_bool(value, default: bool) -> bool:
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
+def handler(event: dict, context: Any) -> dict:
     body = parse_body(event)
-    require_fields(body, "email", "deviceToken")
+    require_fields(body, "deviceToken")
 
-    email = body.get("email")
+    email = get_caller_email(event)
     device_token = body.get("deviceToken")
 
     if not isinstance(device_token, str) or len(device_token) < 8:

--- a/lambdas/notifications_unregister/handler.py
+++ b/lambdas/notifications_unregister/handler.py
@@ -1,18 +1,27 @@
 """
-POST /notifications/unregister - Remove an APNs device token for a user.
+POST /notifications/unregister - Remove an APNs device token for the caller.
+
+Caller identity (`email`) is sourced from the JWT-authorizer context via
+`get_caller_email`. The body only carries the target device token to remove.
 
 Body:
     {
-        "email": "user@...",
         "deviceToken": "<hex>"
     }
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    parse_body,
+    require_fields,
+    success_response,
+)
 from lambdas.common.device_tokens_dynamo import delete_token
 
 log = get_logger(__file__)
@@ -21,11 +30,11 @@ HANDLER = "notifications_unregister"
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
+def handler(event: dict, context: Any) -> dict:
     body = parse_body(event)
-    require_fields(body, "email", "deviceToken")
+    require_fields(body, "deviceToken")
 
-    email = body.get("email")
+    email = get_caller_email(event)
     device_token = body.get("deviceToken")
 
     if not isinstance(device_token, str) or not device_token:

--- a/tests/test_notifications_register.py
+++ b/tests/test_notifications_register.py
@@ -1,0 +1,159 @@
+"""
+Tests for `lambdas.notifications_register.handler`.
+
+Verifies the (1f) auth-identity migration:
+- Caller email is read from `requestContext.authorizer` via `get_caller_email`,
+  not from the request body.
+- `deviceToken` continues to be read from the body (it is the target token, not
+  the caller identity).
+- Missing caller identity returns 401 (MissingCallerIdentityError).
+- Missing `deviceToken` returns 400 (ValidationError).
+- Short / non-string `deviceToken` returns 400.
+"""
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from lambdas.notifications_register.handler import handler
+
+
+def _post_event(base: dict, body: dict) -> dict:
+    """Apply httpMethod/path/body overrides to a base event dict."""
+    return {
+        **base,
+        "httpMethod": "POST",
+        "path": "/notifications/register",
+        "body": json.dumps(body),
+    }
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_happy_path_uses_caller_email_from_context(
+    mock_upsert: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(
+        authorized_event(email="alice@example.com"),
+        {"deviceToken": "abcdef0123456789"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["ok"] is True
+    assert body["email"] == "alice@example.com"
+    assert body["digestEnabled"] is True
+    assert body["queueNotificationsEnabled"] is True
+
+    mock_upsert.assert_called_once_with(
+        email="alice@example.com",
+        device_token="abcdef0123456789",
+        digest_enabled=True,
+        queue_notifications_enabled=True,
+    )
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_ignores_email_in_body_prefers_context(
+    mock_upsert: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    """Spoofed body email must NOT win over the trusted authorizer context."""
+    event = _post_event(
+        authorized_event(email="trusted@example.com"),
+        {"email": "spoofed@evil.com", "deviceToken": "abcdef0123456789"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["email"] == "trusted@example.com"
+    mock_upsert.assert_called_once()
+    assert mock_upsert.call_args.kwargs["email"] == "trusted@example.com"
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_honors_optional_flags(
+    mock_upsert: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(
+        authorized_event(email="alice@example.com"),
+        {
+            "deviceToken": "abcdef0123456789",
+            "digestEnabled": False,
+            "queueNotificationsEnabled": False,
+        },
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["digestEnabled"] is False
+    assert body["queueNotificationsEnabled"] is False
+    mock_upsert.assert_called_once_with(
+        email="alice@example.com",
+        device_token="abcdef0123456789",
+        digest_enabled=False,
+        queue_notifications_enabled=False,
+    )
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_falls_back_to_query_email_when_context_empty(
+    mock_upsert: Any, mock_context: Any, legacy_event: Any
+) -> None:
+    """During the migration window, legacy callers send `email` as a query param."""
+    event = _post_event(
+        legacy_event(email="legacy@example.com"),
+        {"deviceToken": "abcdef0123456789"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["email"] == "legacy@example.com"
+    mock_upsert.assert_called_once()
+    assert mock_upsert.call_args.kwargs["email"] == "legacy@example.com"
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_returns_401_when_caller_identity_missing(
+    mock_upsert: Any, mock_context: Any, legacy_event: Any
+) -> None:
+    """No context AND no fallback email -> MissingCallerIdentityError -> 401."""
+    event = _post_event(legacy_event(), {"deviceToken": "abcdef0123456789"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 401
+    mock_upsert.assert_not_called()
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_returns_400_when_device_token_missing(
+    mock_upsert: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(authorized_event(email="alice@example.com"), {})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 400
+    mock_upsert.assert_not_called()
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_returns_400_when_device_token_too_short(
+    mock_upsert: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(
+        authorized_event(email="alice@example.com"),
+        {"deviceToken": "short"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 400
+    mock_upsert.assert_not_called()

--- a/tests/test_notifications_unregister.py
+++ b/tests/test_notifications_unregister.py
@@ -1,0 +1,127 @@
+"""
+Tests for `lambdas.notifications_unregister.handler`.
+
+Verifies the (1f) auth-identity migration:
+- Caller email is read from `requestContext.authorizer` via `get_caller_email`,
+  not from the request body.
+- `deviceToken` continues to be read from the body (it is the target token, not
+  the caller identity).
+- Missing caller identity returns 401.
+- Missing / non-string `deviceToken` returns 400.
+"""
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from lambdas.notifications_unregister.handler import handler
+
+
+def _post_event(base: dict, body: dict) -> dict:
+    return {
+        **base,
+        "httpMethod": "POST",
+        "path": "/notifications/unregister",
+        "body": json.dumps(body),
+    }
+
+
+@patch("lambdas.notifications_unregister.handler.delete_token")
+def test_unregister_happy_path_uses_caller_email_from_context(
+    mock_delete: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(
+        authorized_event(email="alice@example.com"),
+        {"deviceToken": "abcdef0123456789"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["ok"] is True
+    assert body["email"] == "alice@example.com"
+
+    mock_delete.assert_called_once_with(
+        email="alice@example.com",
+        device_token="abcdef0123456789",
+    )
+
+
+@patch("lambdas.notifications_unregister.handler.delete_token")
+def test_unregister_ignores_email_in_body_prefers_context(
+    mock_delete: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(
+        authorized_event(email="trusted@example.com"),
+        {"email": "spoofed@evil.com", "deviceToken": "abcdef0123456789"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["email"] == "trusted@example.com"
+    mock_delete.assert_called_once_with(
+        email="trusted@example.com",
+        device_token="abcdef0123456789",
+    )
+
+
+@patch("lambdas.notifications_unregister.handler.delete_token")
+def test_unregister_falls_back_to_query_email_when_context_empty(
+    mock_delete: Any, mock_context: Any, legacy_event: Any
+) -> None:
+    event = _post_event(
+        legacy_event(email="legacy@example.com"),
+        {"deviceToken": "abcdef0123456789"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["email"] == "legacy@example.com"
+    mock_delete.assert_called_once_with(
+        email="legacy@example.com",
+        device_token="abcdef0123456789",
+    )
+
+
+@patch("lambdas.notifications_unregister.handler.delete_token")
+def test_unregister_returns_401_when_caller_identity_missing(
+    mock_delete: Any, mock_context: Any, legacy_event: Any
+) -> None:
+    event = _post_event(legacy_event(), {"deviceToken": "abcdef0123456789"})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 401
+    mock_delete.assert_not_called()
+
+
+@patch("lambdas.notifications_unregister.handler.delete_token")
+def test_unregister_returns_400_when_device_token_missing(
+    mock_delete: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(authorized_event(email="alice@example.com"), {})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 400
+    mock_delete.assert_not_called()
+
+
+@patch("lambdas.notifications_unregister.handler.delete_token")
+def test_unregister_returns_400_when_device_token_not_string(
+    mock_delete: Any, mock_context: Any, authorized_event: Any
+) -> None:
+    event = _post_event(
+        authorized_event(email="alice@example.com"),
+        {"deviceToken": 12345},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 400
+    mock_delete.assert_not_called()


### PR DESCRIPTION
Closes #153

Sub-feature **(1f)** of the [auth-identity](docs/features/auth-identity-and-live-top-items/PLAN.md) epic.

## Summary
- Both notifications lambda handlers now read caller email from `requestContext.authorizer` via `get_caller_email` instead of trusting the request body.
- `deviceToken` continues to be a body field — it is the target token, not the caller identity.
- Fallback path (query-string / body `email`) is still active during the migration window. Removed in (1l) once burn-in completes.

## Files changed
- `lambdas/notifications_register/handler.py` — caller email from context; drop `email` from required body fields; add type hints.
- `lambdas/notifications_unregister/handler.py` — same pattern.
- `tests/test_notifications_register.py` (new) — 7 cases.
- `tests/test_notifications_unregister.py` (new) — 6 cases.

## Out of scope
- `notifications_send` is internal-only (invoked by other lambdas via SDK), so it is intentionally NOT migrated in this batch.

## Test plan
- [x] `pytest tests/test_notifications_register.py tests/test_notifications_unregister.py` — 13 passed.
- [x] Full suite: 181 passed (up from 168 baseline). 4 pre-existing collection errors (`jwt`, `aiohttp`) unrelated to this change.
- [x] Authorized-event happy path covered.
- [x] Body-spoofed `email` is ignored (context wins).
- [x] Legacy query-param fallback exercised.
- [x] Missing identity returns 401 (`MissingCallerIdentityError`).
- [x] `deviceToken` validation (missing, too-short, non-string) returns 400.