### PR TITLE
(1a) Migrate friends handlers (7) to caller-identity helper

### DIFF
--- a/lambdas/friends_accept/handler.py
+++ b/lambdas/friends_accept/handler.py
@@ -4,7 +4,7 @@ POST /friends/accept - Accept a friend request
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import success_response, parse_body, require_fields, get_caller_email
 from lambdas.common.friendships_dynamo import accept_friend_request
 
 log = get_logger(__file__)
@@ -14,10 +14,10 @@ HANDLER = 'friends_accept'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    body = parse_body(event)
-    require_fields(body, 'email', 'requestEmail')
+    email = get_caller_email(event)
 
-    email = body.get('email')
+    body = parse_body(event)
+    require_fields(body, 'requestEmail')
     request_email = body.get('requestEmail')
 
     log.info(f"User {email} is accepting friend request from {request_email}.")

--- a/lambdas/friends_list/handler.py
+++ b/lambdas/friends_list/handler.py
@@ -4,7 +4,7 @@ GET /friends/list - Get user's friends list with counts
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.friendships_dynamo import list_all_friends_for_user
 
 log = get_logger(__file__)
@@ -14,10 +14,7 @@ HANDLER = 'friends_list'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
-
-    email = params.get('email')
+    email = get_caller_email(event)
 
     log.info(f"Listing all friends for user {email}")
     friends = list_all_friends_for_user(email)

--- a/lambdas/friends_pending/handler.py
+++ b/lambdas/friends_pending/handler.py
@@ -4,7 +4,7 @@ GET /friends/pending - Get pending friend requests
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.friendships_dynamo import list_all_friends_for_user
 
 log = get_logger(__file__)
@@ -14,10 +14,7 @@ HANDLER = 'friends_pending'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
-
-    email = params.get('email')
+    email = get_caller_email(event)
 
     log.info(f"Getting all pending friends for user {email}")
     friends = list_all_friends_for_user(email)

--- a/lambdas/friends_reject/handler.py
+++ b/lambdas/friends_reject/handler.py
@@ -4,7 +4,7 @@ POST /friends/reject - Reject a friend request
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import success_response, parse_body, require_fields, get_caller_email
 from lambdas.common.friendships_dynamo import delete_friends
 
 log = get_logger(__file__)
@@ -14,10 +14,10 @@ HANDLER = 'friends_reject'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    body = parse_body(event)
-    require_fields(body, 'email', 'requestEmail')
+    email = get_caller_email(event)
 
-    email = body.get('email')
+    body = parse_body(event)
+    require_fields(body, 'requestEmail')
     request_email = body.get('requestEmail')
 
     log.info(f"User {email} is rejecting friend request from {request_email}.")

--- a/lambdas/friends_remove/handler.py
+++ b/lambdas/friends_remove/handler.py
@@ -4,7 +4,7 @@ DELETE /friends/remove - Remove a friend
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_query_params, require_fields, get_caller_email
 from lambdas.common.friendships_dynamo import delete_friends
 
 log = get_logger(__file__)
@@ -14,10 +14,10 @@ HANDLER = 'friends_remove'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email', 'friendEmail')
+    email = get_caller_email(event)
 
-    email = params.get('email')
+    params = get_query_params(event)
+    require_fields(params, 'friendEmail')
     friend_email = params.get('friendEmail')
 
     log.info(f"User {email} is removing friend {friend_email}.")

--- a/lambdas/friends_request/handler.py
+++ b/lambdas/friends_request/handler.py
@@ -4,7 +4,7 @@ POST /friends/request - Send a friend request
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import success_response, parse_body, require_fields, get_caller_email
 from lambdas.common.friendships_dynamo import send_friend_request
 
 log = get_logger(__file__)
@@ -14,10 +14,10 @@ HANDLER = 'friends_request'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    body = parse_body(event)
-    require_fields(body, 'email', 'requestEmail')
+    email = get_caller_email(event)
 
-    email = body.get('email')
+    body = parse_body(event)
+    require_fields(body, 'requestEmail')
     request_email = body.get('requestEmail')
 
     log.info(f"User {email} is sending request to {request_email} to be a friend.")

--- a/tests/test_friends_accept.py
+++ b/tests/test_friends_accept.py
@@ -1,0 +1,59 @@
+"""
+Tests for friends_accept lambda
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+from lambdas.friends_accept.handler import handler
+
+
+@patch('lambdas.friends_accept.handler.accept_friend_request')
+def test_friends_accept_success(mock_accept, mock_context, authorized_event):
+    """Caller from context, target (requestEmail) from body"""
+    mock_accept.return_value = True
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="POST",
+        path="/friends/accept",
+        body=json.dumps({"requestEmail": "user2@example.com"}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['success'] is True
+    mock_accept.assert_called_once_with('user1@example.com', 'user2@example.com')
+
+
+@patch('lambdas.friends_accept.handler.accept_friend_request')
+def test_friends_accept_missing_target(mock_accept, mock_context, authorized_event):
+    """Caller in context but no requestEmail -> 400"""
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="POST",
+        path="/friends/accept",
+        body=json.dumps({}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_accept.assert_not_called()
+
+
+@patch('lambdas.friends_accept.handler.accept_friend_request')
+def test_friends_accept_missing_caller_identity(mock_accept, mock_context, api_gateway_event):
+    """No context, no body email -> 401"""
+    event = {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/friends/accept",
+        "body": json.dumps({"requestEmail": "user2@example.com"}),
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_accept.assert_not_called()

--- a/tests/test_friends_list.py
+++ b/tests/test_friends_list.py
@@ -2,76 +2,93 @@
 Tests for friends_list lambda
 """
 
+import json
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from lambdas.friends_list.handler import handler
 
 
 @patch('lambdas.friends_list.handler.list_all_friends_for_user')
-def test_friends_list_success(mock_list_friends, mock_context, api_gateway_event):
-    """Test successful friends list retrieval"""
+def test_friends_list_success(mock_list_friends, mock_context, authorized_event):
+    """Test successful friends list retrieval (caller from authorizer context)"""
     # Setup
     mock_list_friends.return_value = [
         {"email": "friend1@test.com", "status": "accepted", "direction": "outgoing"},
         {"email": "friend2@test.com", "status": "pending", "direction": "incoming"},
         {"email": "friend3@test.com", "status": "pending", "direction": "outgoing"},
     ]
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/friends/list",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="GET",
+        path="/friends/list",
+    )
 
     # Execute
     response = handler(event, mock_context)
 
     # Assert
     assert response['statusCode'] == 200
-    import json
     body = json.loads(response['body'])
+    assert body['email'] == 'test@example.com'
     assert body['acceptedCount'] == 1
     assert body['pendingCount'] == 1
     assert body['requestedCount'] == 1
     assert body['totalCount'] == 3
+    mock_list_friends.assert_called_once_with('test@example.com')
 
 
 @patch('lambdas.friends_list.handler.list_all_friends_for_user')
-def test_friends_list_empty(mock_list_friends, mock_context, api_gateway_event):
+def test_friends_list_empty(mock_list_friends, mock_context, authorized_event):
     """Test empty friends list"""
     # Setup
     mock_list_friends.return_value = []
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/friends/list",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="GET",
+        path="/friends/list",
+    )
 
     # Execute
     response = handler(event, mock_context)
 
     # Assert
     assert response['statusCode'] == 200
-    import json
     body = json.loads(response['body'])
     assert body['totalCount'] == 0
     assert body['acceptedCount'] == 0
 
 
 @patch('lambdas.friends_list.handler.list_all_friends_for_user')
-def test_friends_list_missing_email(mock_list_friends, mock_context, api_gateway_event):
-    """Test missing email parameter"""
-    # Setup
+def test_friends_list_missing_caller_identity(mock_list_friends, mock_context, api_gateway_event):
+    """No authorizer context AND no fallback email -> 401"""
     event = {
         **api_gateway_event,
         "httpMethod": "GET",
         "path": "/friends/list",
-        "queryStringParameters": {}
+        "queryStringParameters": {},
     }
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
-    assert response['statusCode'] == 400
+    assert response['statusCode'] == 401
+    body = json.loads(response['body'])
+    assert body['error']['field'] == 'email'
+    mock_list_friends.assert_not_called()
+
+
+@patch('lambdas.friends_list.handler.list_all_friends_for_user')
+def test_friends_list_fallback_to_query(mock_list_friends, mock_context, legacy_event):
+    """Legacy callers (no authorizer context) still resolve via query fallback"""
+    mock_list_friends.return_value = []
+    event = legacy_event(
+        email="legacy@example.com",
+        httpMethod="GET",
+        path="/friends/list",
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == 'legacy@example.com'
+    mock_list_friends.assert_called_once_with('legacy@example.com')

--- a/tests/test_friends_pending.py
+++ b/tests/test_friends_pending.py
@@ -1,0 +1,66 @@
+"""
+Tests for friends_pending lambda
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+from lambdas.friends_pending.handler import handler
+
+
+@patch('lambdas.friends_pending.handler.list_all_friends_for_user')
+def test_friends_pending_success(mock_list_friends, mock_context, authorized_event):
+    """Caller from context, returns only pending rows"""
+    mock_list_friends.return_value = [
+        {"email": "f1@x.com", "status": "pending"},
+        {"email": "f2@x.com", "status": "accepted"},
+        {"email": "f3@x.com", "status": "pending"},
+    ]
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="GET",
+        path="/friends/pending",
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == 'test@example.com'
+    assert body['pendingCount'] == 2
+    assert len(body['pending']) == 2
+    mock_list_friends.assert_called_once_with('test@example.com')
+
+
+@patch('lambdas.friends_pending.handler.list_all_friends_for_user')
+def test_friends_pending_empty(mock_list_friends, mock_context, authorized_event):
+    """No friends -> empty pending list"""
+    mock_list_friends.return_value = []
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="GET",
+        path="/friends/pending",
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['pendingCount'] == 0
+    assert body['pending'] == []
+
+
+@patch('lambdas.friends_pending.handler.list_all_friends_for_user')
+def test_friends_pending_missing_caller_identity(mock_list_friends, mock_context, api_gateway_event):
+    """No authorizer context AND no fallback email -> 401"""
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/friends/pending",
+        "queryStringParameters": {},
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_list_friends.assert_not_called()

--- a/tests/test_friends_reject.py
+++ b/tests/test_friends_reject.py
@@ -1,0 +1,59 @@
+"""
+Tests for friends_reject lambda
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+from lambdas.friends_reject.handler import handler
+
+
+@patch('lambdas.friends_reject.handler.delete_friends')
+def test_friends_reject_success(mock_delete, mock_context, authorized_event):
+    """Caller from context, target (requestEmail) from body"""
+    mock_delete.return_value = True
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="POST",
+        path="/friends/reject",
+        body=json.dumps({"requestEmail": "user2@example.com"}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['success'] is True
+    mock_delete.assert_called_once_with('user1@example.com', 'user2@example.com')
+
+
+@patch('lambdas.friends_reject.handler.delete_friends')
+def test_friends_reject_missing_target(mock_delete, mock_context, authorized_event):
+    """Caller in context but no requestEmail -> 400"""
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="POST",
+        path="/friends/reject",
+        body=json.dumps({}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_delete.assert_not_called()
+
+
+@patch('lambdas.friends_reject.handler.delete_friends')
+def test_friends_reject_missing_caller_identity(mock_delete, mock_context, api_gateway_event):
+    """No context, no body email -> 401"""
+    event = {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/friends/reject",
+        "body": json.dumps({"requestEmail": "user2@example.com"}),
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_delete.assert_not_called()

--- a/tests/test_friends_remove.py
+++ b/tests/test_friends_remove.py
@@ -1,0 +1,59 @@
+"""
+Tests for friends_remove lambda
+"""
+
+import json
+import pytest
+from unittest.mock import patch
+from lambdas.friends_remove.handler import handler
+
+
+@patch('lambdas.friends_remove.handler.delete_friends')
+def test_friends_remove_success(mock_delete, mock_context, authorized_event):
+    """Caller from context, target (friendEmail) from query"""
+    mock_delete.return_value = True
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="DELETE",
+        path="/friends/remove",
+        queryStringParameters={"friendEmail": "user2@example.com"},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['success'] is True
+    mock_delete.assert_called_once_with('user1@example.com', 'user2@example.com')
+
+
+@patch('lambdas.friends_remove.handler.delete_friends')
+def test_friends_remove_missing_target(mock_delete, mock_context, authorized_event):
+    """Caller in context but no friendEmail -> 400"""
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="DELETE",
+        path="/friends/remove",
+        queryStringParameters={},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_delete.assert_not_called()
+
+
+@patch('lambdas.friends_remove.handler.delete_friends')
+def test_friends_remove_missing_caller_identity(mock_delete, mock_context, api_gateway_event):
+    """No context, no query email -> 401 (target email present but caller is unresolved)"""
+    event = {
+        **api_gateway_event,
+        "httpMethod": "DELETE",
+        "path": "/friends/remove",
+        "queryStringParameters": {"friendEmail": "user2@example.com"},
+    }
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_delete.assert_not_called()

--- a/tests/test_friends_request.py
+++ b/tests/test_friends_request.py
@@ -2,31 +2,25 @@
 Tests for friends_request lambda
 """
 
-import pytest
 import json
+import pytest
 from unittest.mock import patch
 from lambdas.friends_request.handler import handler
 
 
 @patch('lambdas.friends_request.handler.send_friend_request')
-def test_friends_request_success(mock_send_request, mock_context, api_gateway_event):
-    """Test successful friend request"""
-    # Setup
+def test_friends_request_success(mock_send_request, mock_context, authorized_event):
+    """Caller from context, target (requestEmail) from body"""
     mock_send_request.return_value = True
-    event = {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/friends/request",
-        "body": json.dumps({
-            "email": "user1@example.com",
-            "requestEmail": "user2@example.com"
-        })
-    }
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="POST",
+        path="/friends/request",
+        body=json.dumps({"requestEmail": "user2@example.com"}),
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
     assert body['success'] is True
@@ -34,42 +28,69 @@ def test_friends_request_success(mock_send_request, mock_context, api_gateway_ev
 
 
 @patch('lambdas.friends_request.handler.send_friend_request')
-def test_friends_request_failure(mock_send_request, mock_context, api_gateway_event):
-    """Test failed friend request"""
-    # Setup
+def test_friends_request_failure(mock_send_request, mock_context, authorized_event):
+    """Downstream returns False -> success=false but still 200"""
     mock_send_request.return_value = False
-    event = {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/friends/request",
-        "body": json.dumps({
-            "email": "user1@example.com",
-            "requestEmail": "user2@example.com"
-        })
-    }
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="POST",
+        path="/friends/request",
+        body=json.dumps({"requestEmail": "user2@example.com"}),
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
     assert body['success'] is False
 
 
 @patch('lambdas.friends_request.handler.send_friend_request')
-def test_friends_request_missing_fields(mock_send_request, mock_context, api_gateway_event):
-    """Test missing required fields"""
-    # Setup
+def test_friends_request_missing_target(mock_send_request, mock_context, authorized_event):
+    """Caller in context, but no requestEmail in body -> 400 ValidationError"""
+    event = authorized_event(
+        email="user1@example.com",
+        httpMethod="POST",
+        path="/friends/request",
+        body=json.dumps({}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_send_request.assert_not_called()
+
+
+@patch('lambdas.friends_request.handler.send_friend_request')
+def test_friends_request_missing_caller_identity(mock_send_request, mock_context, api_gateway_event):
+    """No authorizer context AND no fallback email -> 401"""
     event = {
         **api_gateway_event,
         "httpMethod": "POST",
         "path": "/friends/request",
-        "body": json.dumps({"email": "user1@example.com"})
+        "body": json.dumps({"requestEmail": "user2@example.com"}),
     }
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
-    assert response['statusCode'] == 400
+    assert response['statusCode'] == 401
+    mock_send_request.assert_not_called()
+
+
+@patch('lambdas.friends_request.handler.send_friend_request')
+def test_friends_request_fallback_caller_in_body(mock_send_request, mock_context, legacy_event):
+    """Legacy: caller email in body alongside requestEmail still works via fallback"""
+    mock_send_request.return_value = True
+    event = legacy_event(
+        httpMethod="POST",
+        path="/friends/request",
+        body=json.dumps({
+            "email": "user1@example.com",
+            "requestEmail": "user2@example.com",
+        }),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_send_request.assert_called_once_with('user1@example.com', 'user2@example.com')


### PR DESCRIPTION
Closes #151

## Summary
- Migrate six of seven friends handlers (accept / list / pending / reject / remove / request) to read the caller's email from the per-user JWT authorizer context via `get_caller_email`, instead of trusting a request-supplied `email` query/body field.
- `friends_profile` is intentionally left unchanged — it never read a caller `email`; it only takes `friendEmail` (target). Per the migration rule (caller-only fields named `email` are moved; everything else stays), there is nothing to migrate here in this batch.
- Target identifiers (`requestEmail`, `friendEmail`) remain explicit request fields and continue to be validated via `require_fields`.
- Backwards compatible: `get_caller_email` falls back to `queryStringParameters`/body during the Track 0 -> Track 1 migration window so legacy static-token clients keep working. Track (1l) removes the fallback after burn-in.

## Caller-vs-target audit
| Handler | Caller (migrated) | Target (kept in request) |
| --- | --- | --- |
| `friends_accept` | body `email` -> ctx | body `requestEmail` |
| `friends_list` | query `email` -> ctx | — |
| `friends_pending` | query `email` -> ctx | — |
| `friends_profile` | (none — no-op) | query `friendEmail` |
| `friends_reject` | body `email` -> ctx | body `requestEmail` |
| `friends_remove` | query `email` -> ctx | query `friendEmail` |
| `friends_request` | body `email` -> ctx | body `requestEmail` |

## Test plan
- [x] Migrate existing `test_friends_list.py` and `test_friends_request.py` to `authorized_event` fixture
- [x] Add new test files for `friends_accept`, `friends_pending`, `friends_reject`, `friends_remove` (none existed before)
- [x] Each suite covers happy path, missing target field (400), missing caller identity (401)
- [x] `friends_list` and `friends_request` also exercise the legacy fallback path via `legacy_event`
- [x] `pytest tests/test_friends_*.py` -> 23 passed
- [x] Full suite: `pytest -x` -> 226 passed
- [ ] Post-deploy: confirm CloudWatch fallback WARN counts > 0 (expected; clients haven't migrated yet — that's what (1j)/(1k) addresses)

## Epic context
Sub-feature **(1a)** of [auth-identity-and-live-top-items](../blob/master/docs/features/auth-identity-and-live-top-items/PLAN.md). Stub: [`docs/features/backend-handler-migration-friends/PLAN.md`](../blob/master/docs/features/backend-handler-migration-friends/PLAN.md). Depends on (0c) which is now in `master`.