### PR TITLE
(1h) Migrate wrapped handlers to caller-identity helper

### DIFF
--- a/lambdas/wrapped_all/handler.py
+++ b/lambdas/wrapped_all/handler.py
@@ -4,7 +4,7 @@ GET /wrapped/all - Get user's wrapped data and history
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.wrapped_data import get_wrapped_data
 
 log = get_logger(__file__)
@@ -13,11 +13,8 @@ HANDLER = 'wrapped_all'
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
-
-    email = params.get('email')
+def handler(event: dict, context: object) -> dict:
+    email: str = get_caller_email(event)
     data = get_wrapped_data(email)
 
     return success_response(data)

--- a/lambdas/wrapped_month/handler.py
+++ b/lambdas/wrapped_month/handler.py
@@ -4,7 +4,12 @@ GET /wrapped/month - Get specific month's wrapped data
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, NotFoundError
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.wrapped_data import get_wrapped_month
 
 log = get_logger(__file__)
@@ -13,12 +18,12 @@ HANDLER = 'wrapped_month'
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
+def handler(event: dict, context: object) -> dict:
     params = get_query_params(event)
-    require_fields(params, 'email', 'monthKey')
+    require_fields(params, 'monthKey')
 
-    email = params.get('email')
-    month_key = params.get('monthKey')
+    email: str = get_caller_email(event)
+    month_key: str = params.get('monthKey')
 
     wrap = get_wrapped_month(email, month_key)
 

--- a/lambdas/wrapped_update/handler.py
+++ b/lambdas/wrapped_update/handler.py
@@ -4,7 +4,12 @@ POST /wrapped/update - Update user's wrapped enrollment
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.wrapped_data import update_wrapped_data
 
 log = get_logger(__file__)
@@ -13,9 +18,15 @@ HANDLER = 'wrapped_update'
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
+def handler(event: dict, context: object) -> dict:
     body = parse_body(event)
-    require_fields(body, 'email', 'userId', 'refreshToken', 'active')
+    require_fields(body, 'userId', 'refreshToken', 'active')
+
+    # Caller email comes from the trusted authorizer context (with query/body
+    # fallback during the Track 1 migration window). Overwrites any
+    # client-supplied `email` in the body so the persisted row is keyed on the
+    # authenticated caller.
+    body['email'] = get_caller_email(event)
 
     message = update_wrapped_data(body)
 

--- a/lambdas/wrapped_year/handler.py
+++ b/lambdas/wrapped_year/handler.py
@@ -4,7 +4,12 @@ GET /wrapped/year - Get all wrapped data for a specific year
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.wrapped_data import get_wrapped_year
 
 log = get_logger(__file__)
@@ -13,12 +18,12 @@ HANDLER = 'wrapped_year'
 
 
 @handle_errors(HANDLER)
-def handler(event, context):
+def handler(event: dict, context: object) -> dict:
     params = get_query_params(event)
-    require_fields(params, 'email', 'year')
+    require_fields(params, 'year')
 
-    email = params.get('email')
-    year = params.get('year')
+    email: str = get_caller_email(event)
+    year: str = params.get('year')
 
     wraps = get_wrapped_year(email, year)
 

--- a/tests/test_wrapped_data_get.py
+++ b/tests/test_wrapped_data_get.py
@@ -1,83 +1,87 @@
 """
-Tests for wrapped_data_get lambda
+Tests for wrapped_all (GET /wrapped/all) lambda.
 """
 
-import pytest
 import json
 from unittest.mock import patch
+
 from lambdas.wrapped_all.handler import handler
 
 
 @patch('lambdas.wrapped_all.handler.get_wrapped_data')
-def test_wrapped_data_get_success(mock_get_wrapped, mock_context, api_gateway_event):
-    """Test successful wrapped data retrieval"""
-    # Setup
+def test_wrapped_all_success_via_authorizer_context(
+    mock_get_wrapped, mock_context, authorized_event
+):
+    """Caller email is read from `requestContext.authorizer` (no query param)."""
     mock_get_wrapped.return_value = {
         'active': True,
         'activeWrapped': True,
         'activeReleaseRadar': False,
         'wraps': [
             {'monthKey': '2024-01', 'trackCount': 25},
-            {'monthKey': '2024-02', 'trackCount': 30}
-        ]
+            {'monthKey': '2024-02', 'trackCount': 30},
+        ],
     }
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/wrapped/data",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = authorized_event(
+        email="caller@example.com",
+        httpMethod="GET",
+        path="/wrapped/all",
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
     assert body['active'] is True
     assert body['activeWrapped'] is True
     assert len(body['wraps']) == 2
+    mock_get_wrapped.assert_called_once_with("caller@example.com")
 
 
 @patch('lambdas.wrapped_all.handler.get_wrapped_data')
-def test_wrapped_data_get_no_history(mock_get_wrapped, mock_context, api_gateway_event):
-    """Test user with no wrapped history"""
-    # Setup
+def test_wrapped_all_no_history(mock_get_wrapped, mock_context, authorized_event):
+    """Empty wraps list still returns 200."""
     mock_get_wrapped.return_value = {
         'active': True,
         'activeWrapped': True,
         'activeReleaseRadar': False,
-        'wraps': []
+        'wraps': [],
     }
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/wrapped/data",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = authorized_event(httpMethod="GET", path="/wrapped/all")
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
-    assert len(body['wraps']) == 0
+    assert body['wraps'] == []
 
 
 @patch('lambdas.wrapped_all.handler.get_wrapped_data')
-def test_wrapped_data_get_missing_email(mock_get_wrapped, mock_context, api_gateway_event):
-    """Test missing email parameter"""
-    # Setup
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/wrapped/data",
-        "queryStringParameters": {}
-    }
+def test_wrapped_all_legacy_query_fallback(
+    mock_get_wrapped, mock_context, legacy_event
+):
+    """During the migration window, a query-string `email` is still accepted."""
+    mock_get_wrapped.return_value = {'wraps': []}
+    event = legacy_event(email="legacy@example.com")
+    event['httpMethod'] = "GET"
+    event['path'] = "/wrapped/all"
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
-    assert response['statusCode'] == 400
+    assert response['statusCode'] == 200
+    mock_get_wrapped.assert_called_once_with("legacy@example.com")
+
+
+@patch('lambdas.wrapped_all.handler.get_wrapped_data')
+def test_wrapped_all_missing_caller_identity(
+    mock_get_wrapped, mock_context, legacy_event
+):
+    """No authorizer context AND no query/body email -> 401."""
+    event = legacy_event()  # no email anywhere
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    body = json.loads(response['body'])
+    assert 'email' in body['error']['message']
+    mock_get_wrapped.assert_not_called()

--- a/tests/test_wrapped_month.py
+++ b/tests/test_wrapped_month.py
@@ -1,0 +1,73 @@
+"""
+Tests for wrapped_month (GET /wrapped/month) lambda.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.wrapped_month.handler import handler
+
+
+@patch('lambdas.wrapped_month.handler.get_wrapped_month')
+def test_wrapped_month_success_via_authorizer_context(
+    mock_get, mock_context, authorized_event
+):
+    """Caller email comes from authorizer; `monthKey` stays in query."""
+    mock_get.return_value = {'monthKey': '2024-03', 'trackCount': 42}
+    event = authorized_event(
+        email="caller@example.com",
+        httpMethod="GET",
+        path="/wrapped/month",
+        queryStringParameters={'monthKey': '2024-03'},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['monthKey'] == '2024-03'
+    mock_get.assert_called_once_with("caller@example.com", "2024-03")
+
+
+@patch('lambdas.wrapped_month.handler.get_wrapped_month')
+def test_wrapped_month_not_found(mock_get, mock_context, authorized_event):
+    """Missing wrap data -> 404."""
+    mock_get.return_value = None
+    event = authorized_event(
+        httpMethod="GET",
+        path="/wrapped/month",
+        queryStringParameters={'monthKey': '1999-12'},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 404
+
+
+@patch('lambdas.wrapped_month.handler.get_wrapped_month')
+def test_wrapped_month_missing_month_key(mock_get, mock_context, authorized_event):
+    """Missing required `monthKey` -> 400."""
+    event = authorized_event(
+        httpMethod="GET",
+        path="/wrapped/month",
+        queryStringParameters={},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_get.assert_not_called()
+
+
+@patch('lambdas.wrapped_month.handler.get_wrapped_month')
+def test_wrapped_month_missing_caller_identity(
+    mock_get, mock_context, legacy_event
+):
+    """No authorizer context, no query/body email -> 401."""
+    event = legacy_event()
+    event['queryStringParameters'] = {'monthKey': '2024-03'}
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_get.assert_not_called()

--- a/tests/test_wrapped_update.py
+++ b/tests/test_wrapped_update.py
@@ -1,0 +1,120 @@
+"""
+Tests for wrapped_update (POST /wrapped/update) lambda.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.wrapped_update.handler import handler
+
+
+def _body(**overrides) -> str:
+    payload = {
+        'userId': 'spotify123',
+        'refreshToken': 'mock-refresh-token',
+        'active': True,
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+@patch('lambdas.wrapped_update.handler.update_wrapped_data')
+def test_wrapped_update_success_via_authorizer_context(
+    mock_update, mock_context, authorized_event
+):
+    """Caller email comes from authorizer; other body fields stay."""
+    mock_update.return_value = 'User opted into Monthly Wrapped successfully.'
+    event = authorized_event(
+        email="caller@example.com",
+        httpMethod="POST",
+        path="/wrapped/update",
+        body=_body(),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert 'message' in body
+    # update_wrapped_data is called with a dict whose `email` is the caller,
+    # plus the other payload fields untouched.
+    mock_update.assert_called_once()
+    persisted_data = mock_update.call_args[0][0]
+    assert persisted_data['email'] == 'caller@example.com'
+    assert persisted_data['userId'] == 'spotify123'
+    assert persisted_data['refreshToken'] == 'mock-refresh-token'
+    assert persisted_data['active'] is True
+
+
+@patch('lambdas.wrapped_update.handler.update_wrapped_data')
+def test_wrapped_update_authorizer_overrides_body_email(
+    mock_update, mock_context, authorized_event
+):
+    """If the client sends an `email` in the body, the trusted caller value wins."""
+    mock_update.return_value = 'ok'
+    event = authorized_event(
+        email="trusted@example.com",
+        httpMethod="POST",
+        path="/wrapped/update",
+        body=_body(email="spoofed@example.com"),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    persisted_data = mock_update.call_args[0][0]
+    assert persisted_data['email'] == 'trusted@example.com'
+
+
+@patch('lambdas.wrapped_update.handler.update_wrapped_data')
+def test_wrapped_update_legacy_body_fallback(
+    mock_update, mock_context, legacy_event
+):
+    """Legacy clients can still send `email` in the POST body during migration."""
+    mock_update.return_value = 'ok'
+    event = legacy_event()
+    event['httpMethod'] = "POST"
+    event['path'] = "/wrapped/update"
+    event['body'] = _body(email="legacy@example.com")
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    persisted_data = mock_update.call_args[0][0]
+    assert persisted_data['email'] == 'legacy@example.com'
+
+
+@patch('lambdas.wrapped_update.handler.update_wrapped_data')
+def test_wrapped_update_missing_required_body_field(
+    mock_update, mock_context, authorized_event
+):
+    """Missing `userId` -> 400."""
+    event = authorized_event(
+        httpMethod="POST",
+        path="/wrapped/update",
+        body=json.dumps({
+            'refreshToken': 'mock-refresh-token',
+            'active': True,
+        }),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_update.assert_not_called()
+
+
+@patch('lambdas.wrapped_update.handler.update_wrapped_data')
+def test_wrapped_update_missing_caller_identity(
+    mock_update, mock_context, legacy_event
+):
+    """No authorizer context AND no fallback `email` -> 401."""
+    event = legacy_event()
+    event['httpMethod'] = "POST"
+    event['path'] = "/wrapped/update"
+    event['body'] = _body()  # no `email` field
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_update.assert_not_called()

--- a/tests/test_wrapped_year.py
+++ b/tests/test_wrapped_year.py
@@ -1,0 +1,82 @@
+"""
+Tests for wrapped_year (GET /wrapped/year) lambda.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.wrapped_year.handler import handler
+
+
+@patch('lambdas.wrapped_year.handler.get_wrapped_year')
+def test_wrapped_year_success_via_authorizer_context(
+    mock_get, mock_context, authorized_event
+):
+    """Caller email comes from authorizer; `year` stays in query."""
+    mock_get.return_value = [
+        {'monthKey': '2024-01'},
+        {'monthKey': '2024-02'},
+        {'monthKey': '2024-03'},
+    ]
+    event = authorized_event(
+        email="caller@example.com",
+        httpMethod="GET",
+        path="/wrapped/year",
+        queryStringParameters={'year': '2024'},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == 'caller@example.com'
+    assert body['year'] == '2024'
+    assert body['count'] == 3
+    assert len(body['wraps']) == 3
+    mock_get.assert_called_once_with("caller@example.com", "2024")
+
+
+@patch('lambdas.wrapped_year.handler.get_wrapped_year')
+def test_wrapped_year_empty(mock_get, mock_context, authorized_event):
+    """Empty list still returns 200 with count=0."""
+    mock_get.return_value = []
+    event = authorized_event(
+        httpMethod="GET",
+        path="/wrapped/year",
+        queryStringParameters={'year': '2099'},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['count'] == 0
+
+
+@patch('lambdas.wrapped_year.handler.get_wrapped_year')
+def test_wrapped_year_missing_year(mock_get, mock_context, authorized_event):
+    """Missing required `year` -> 400."""
+    event = authorized_event(
+        httpMethod="GET",
+        path="/wrapped/year",
+        queryStringParameters={},
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_get.assert_not_called()
+
+
+@patch('lambdas.wrapped_year.handler.get_wrapped_year')
+def test_wrapped_year_missing_caller_identity(
+    mock_get, mock_context, legacy_event
+):
+    """No authorizer context, no query/body email -> 401."""
+    event = legacy_event()
+    event['queryStringParameters'] = {'year': '2024'}
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_get.assert_not_called()


### PR DESCRIPTION
Closes #156

Sub-feature **(1h)** of the auth-identity-and-live-top-items epic — Track 1 backend handler migration. Read-only, low-risk batch (4 wrapped handlers).

## Changes

| Handler | Method | Caller field migrated | Target fields kept |
|---|---|---|---|
| `wrapped_all` | GET | query `email` -> `get_caller_email(event)` | (none) |
| `wrapped_month` | GET | query `email` -> `get_caller_email(event)` | query `monthKey` |
| `wrapped_year` | GET | query `email` -> `get_caller_email(event)` | query `year` |
| `wrapped_update` | POST | body `email` -> `get_caller_email(event)` (overwrites any spoofed client value) | body `userId`, `refreshToken`, `active` |

The query/body-`email` fallback in `get_caller_email` is intentionally retained during the migration window (epic Track 1 design — fallback is removed in (1l) once the burn-in criterion is met).

`cron_wrapped` and `cron_wrapped_email` are NOT behind the authorizer and are intentionally out of scope.

## Tests

- `tests/test_wrapped_data_get.py` rewritten to use the `authorized_event` fixture; covers legacy query fallback and missing-identity 401.
- New `tests/test_wrapped_month.py`, `tests/test_wrapped_year.py`, `tests/test_wrapped_update.py` — happy path via context, 400 on missing required field, 401 on missing caller identity, and an authorizer-overrides-spoofed-body test for `wrapped_update`.

```
pytest tests/test_wrapped*.py  -> 17 passed
pytest                          -> 239 passed (was 225)
```

## Parent epic
[`docs/features/auth-identity-and-live-top-items/PLAN.md`](docs/features/auth-identity-and-live-top-items/PLAN.md)

## Stub
[`docs/features/backend-handler-migration-wrapped/PLAN.md`](docs/features/backend-handler-migration-wrapped/PLAN.md)

## Test plan
- [x] `pytest tests/test_wrapped*.py` green
- [x] Full `pytest` green (239 passed)
- [ ] Post-deploy: smoke `GET /wrapped/all`, `GET /wrapped/month?monthKey=...`, `GET /wrapped/year?year=...`, `POST /wrapped/update` from a client still sending the legacy query/body `email` (fallback path) -> 200 + WARN log
- [ ] Post-deploy: smoke the same endpoints once (0d/0e) ship per-user JWTs -> 200 + DEBUG `auth_path=context`