### PR TITLE
(1i) Migrate user handlers to caller-identity helper

### DIFF
--- a/lambdas/user_all/handler.py
+++ b/lambdas/user_all/handler.py
@@ -1,25 +1,44 @@
 """
 GET /user/all - Get all users
 
-When called with `?email=<me>`, filters the caller out of the result so
-discovery UIs never show "add yourself" as an option.
+When the caller's identity is known (per-user JWT context, or query/body
+fallback during the Track-1 migration window), the caller's own row is
+filtered out so discovery UIs never show "add yourself" as an option.
+
+If caller identity is unknown (anonymous discovery — neither context nor
+fallback present), the unfiltered list is returned. This preserves the
+pre-migration behavior for callers that omit `?email=`.
 """
 
-from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params
 from lambdas.common.constants import USERS_TABLE_NAME
 from lambdas.common.dynamo_helpers import full_table_scan
+from lambdas.common.errors import MissingCallerIdentityError, handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    success_response,
+)
 
 log = get_logger(__file__)
 
 HANDLER = 'user_all'
 
 
+def _resolve_caller_email(event: dict) -> str:
+    """
+    Resolve the caller email if available. Returns an empty string when no
+    identity is present in context or fallback — anonymous callers are
+    intentionally tolerated for this endpoint (unfiltered list).
+    """
+    try:
+        return get_caller_email(event).strip().lower()
+    except MissingCallerIdentityError:
+        return ''
+
+
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    caller_email = (params.get('email') or '').strip().lower()
+    caller_email = _resolve_caller_email(event)
 
     users = full_table_scan(USERS_TABLE_NAME)
 

--- a/lambdas/user_data/handler.py
+++ b/lambdas/user_data/handler.py
@@ -1,11 +1,19 @@
 """
-GET /user/data - Get user data
+GET /user/data - Get the caller's user-table row.
+
+Caller identity comes from the trusted authorizer context (per-user JWT)
+when present, falling back to the query-string `email` during the
+Track-1 migration window. The endpoint returns the caller's own row only;
+there is no `friendEmail` / `targetEmail` for cross-user lookups.
 """
 
-from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
 from lambdas.common.dynamo_helpers import get_user_table_data
+from lambdas.common.errors import handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    success_response,
+)
 
 log = get_logger(__file__)
 
@@ -14,10 +22,9 @@ HANDLER = 'user_data'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
+    caller_email = get_caller_email(event)
 
-    response = get_user_table_data(params['email'])
-    log.info(f"Retrieved data for {params['email']}")
+    response = get_user_table_data(caller_email)
+    log.info(f"Retrieved data for {caller_email}")
 
     return success_response(response)

--- a/lambdas/user_update/handler.py
+++ b/lambdas/user_update/handler.py
@@ -1,11 +1,32 @@
 """
-POST /user/update - Update user (refresh token or enrollments)
+POST /user/update - Update the caller's row (refresh token or enrollments).
+
+Caller identity (`email`, `userId`) comes from the trusted authorizer
+context when present, falling back to the request body during the Track-1
+migration window. Profile data being persisted (`displayName`,
+`refreshToken`, `avatar`) and the enrollment flags (`wrappedEnrolled`,
+`releaseRadarEnrolled`) continue to live in the body — they are payload,
+not caller-identity claims.
+
+Branch detection:
+- Token-persistence path: body contains `refreshToken`. Caller `userId`
+  is also required for this path and is resolved from context (or body
+  fallback). Triggered post-Spotify-OAuth on iOS.
+- Enrollment path: body contains `wrappedEnrolled` or `releaseRadarEnrolled`.
 """
 
+from lambdas.common.dynamo_helpers import (
+    update_user_table_enrollments,
+    update_user_table_refresh_token,
+)
+from lambdas.common.errors import ValidationError, handle_errors
 from lambdas.common.logger import get_logger
-from lambdas.common.errors import handle_errors, ValidationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
-from lambdas.common.dynamo_helpers import update_user_table_refresh_token, update_user_table_enrollments
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    get_caller_user_id,
+    parse_body,
+    success_response,
+)
 
 log = get_logger(__file__)
 
@@ -15,40 +36,67 @@ HANDLER = 'user_update'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email')
+    caller_email = get_caller_email(event)
 
-    # Determine which update type based on fields present
     has_enrollment_fields = 'wrappedEnrolled' in body or 'releaseRadarEnrolled' in body
-    has_token_fields = 'refreshToken' in body and 'userId' in body
+    has_token_fields = 'refreshToken' in body
 
     if has_token_fields:
-        # Update refresh token (also returns current enrollment status)
+        # Token-persistence path. userId, displayName, refreshToken, avatar
+        # are all required for this branch. userId is caller identity (resolved
+        # via context, or fallback to body during migration); the rest are
+        # profile fields that live in the body.
+        caller_user_id = get_caller_user_id(event)
+        display_name = body.get('displayName')
+        refresh_token = body.get('refreshToken')
+        avatar = body.get('avatar')
+
+        missing = [
+            name for name, value in (
+                ('displayName', display_name),
+                ('refreshToken', refresh_token),
+                ('avatar', avatar),
+            )
+            if value is None
+        ]
+        if missing:
+            raise ValidationError(
+                message=f"Missing required fields: {', '.join(missing)}",
+                handler=HANDLER,
+                function='handler',
+                field=missing[0],
+            )
+
         response = update_user_table_refresh_token(
-            body['email'],
-            body['userId'],
-            body['displayName'],
-            body['refreshToken'],
-            body['avatar']
+            caller_email,
+            caller_user_id,
+            display_name,
+            refresh_token,
+            avatar,
         )
-        log.info(f"Updated refresh token for {body['email']}")
+        log.info(f"Updated refresh token for {caller_email}")
 
     elif has_enrollment_fields:
-        # Update enrollments
         wrapped = body.get('wrappedEnrolled', False)
         radar = body.get('releaseRadarEnrolled', False)
 
         response = update_user_table_enrollments(
-            body['email'],
+            caller_email,
             wrapped,
-            radar
+            radar,
         )
-        log.info(f"Updated enrollments for {body['email']}: wrapped={wrapped}, radar={radar}")
+        log.info(
+            f"Updated enrollments for {caller_email}: wrapped={wrapped}, radar={radar}"
+        )
 
     else:
         raise ValidationError(
-            message="Invalid request - must include either (refreshToken, userId) or (wrappedEnrolled/releaseRadarEnrolled)",
+            message=(
+                "Invalid request - must include either refreshToken (with "
+                "displayName + avatar) or wrappedEnrolled/releaseRadarEnrolled"
+            ),
             handler=HANDLER,
-            function="handler"
+            function='handler',
         )
 
     return success_response(response)

--- a/tests/test_user_all.py
+++ b/tests/test_user_all.py
@@ -9,8 +9,8 @@ from lambdas.user_all.handler import handler
 
 
 @patch('lambdas.user_all.handler.full_table_scan')
-def test_user_all_no_caller_returns_everyone(mock_scan, mock_context, api_gateway_event):
-    """Without an `email` query param, return all users (legacy behavior)."""
+def test_user_all_anonymous_returns_everyone(mock_scan, mock_context, api_gateway_event):
+    """Without any caller identity (no context, no fallback), return all users."""
     mock_scan.return_value = [
         {"email": "a@test.com", "displayName": "A", "refreshToken": "REDACT-ME"},
         {"email": "b@test.com", "displayName": "B"},
@@ -31,17 +31,13 @@ def test_user_all_no_caller_returns_everyone(mock_scan, mock_context, api_gatewa
 
 
 @patch('lambdas.user_all.handler.full_table_scan')
-def test_user_all_filters_caller(mock_scan, mock_context, api_gateway_event):
-    """With `?email=caller`, the caller's own row is omitted."""
+def test_user_all_filters_caller_via_context(mock_scan, mock_context, authorized_event):
+    """Trusted authorizer context: caller's own row is filtered out."""
     mock_scan.return_value = [
         {"email": "me@test.com", "displayName": "Me"},
         {"email": "friend@test.com", "displayName": "Friend"},
     ]
-    event = {
-        **api_gateway_event,
-        "path": "/user/all",
-        "queryStringParameters": {"email": "me@test.com"},
-    }
+    event = authorized_event(email="me@test.com", path="/user/all")
 
     response = handler(event, mock_context)
     body = json.loads(response['body'])
@@ -52,17 +48,30 @@ def test_user_all_filters_caller(mock_scan, mock_context, api_gateway_event):
 
 
 @patch('lambdas.user_all.handler.full_table_scan')
-def test_user_all_filter_is_case_insensitive(mock_scan, mock_context, api_gateway_event):
-    """Email casing shouldn't let the caller slip through."""
+def test_user_all_filters_caller_via_query_fallback(mock_scan, mock_context, legacy_event):
+    """Legacy `?email=` fallback still filters caller (migration window)."""
+    mock_scan.return_value = [
+        {"email": "me@test.com", "displayName": "Me"},
+        {"email": "friend@test.com", "displayName": "Friend"},
+    ]
+    event = legacy_event(email="me@test.com", path="/user/all")
+
+    response = handler(event, mock_context)
+    body = json.loads(response['body'])
+
+    assert response['statusCode'] == 200
+    assert len(body) == 1
+    assert body[0]['email'] == "friend@test.com"
+
+
+@patch('lambdas.user_all.handler.full_table_scan')
+def test_user_all_filter_is_case_insensitive(mock_scan, mock_context, authorized_event):
+    """Email casing in context shouldn't let the caller slip through."""
     mock_scan.return_value = [
         {"email": "Me@Test.com", "displayName": "Me"},
         {"email": "friend@test.com", "displayName": "Friend"},
     ]
-    event = {
-        **api_gateway_event,
-        "path": "/user/all",
-        "queryStringParameters": {"email": "ME@test.com"},
-    }
+    event = authorized_event(email="ME@test.com", path="/user/all")
 
     response = handler(event, mock_context)
     body = json.loads(response['body'])

--- a/tests/test_user_get.py
+++ b/tests/test_user_get.py
@@ -1,65 +1,77 @@
 """
-Tests for user_get lambda
+Tests for user_data lambda
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
+import json
+from unittest.mock import patch
+
 from lambdas.user_data.handler import handler
 
 
 @patch('lambdas.user_data.handler.get_user_table_data')
-def test_user_get_success(mock_get_user, mock_context, api_gateway_event, sample_user):
-    """Test successful user retrieval"""
-    # Setup
+def test_user_get_via_context(mock_get_user, mock_context, authorized_event, sample_user):
+    """Trusted authorizer context populates the caller email."""
     mock_get_user.return_value = sample_user
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/user/user-table",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="GET",
+        path="/user/user-table",
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
     mock_get_user.assert_called_once_with('test@example.com')
 
 
 @patch('lambdas.user_data.handler.get_user_table_data')
-def test_user_get_missing_email(mock_get_user, mock_context, api_gateway_event):
-    """Test missing email parameter"""
-    # Setup
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/user/user-table",
-        "queryStringParameters": {}
-    }
+def test_user_get_via_query_fallback(mock_get_user, mock_context, legacy_event, sample_user):
+    """Legacy `?email=` callers still resolve during the migration window."""
+    mock_get_user.return_value = sample_user
+    event = legacy_event(
+        email="legacy@example.com",
+        httpMethod="GET",
+        path="/user/user-table",
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
-    assert response['statusCode'] == 400
-    assert 'error' in response['body'].lower()
+    assert response['statusCode'] == 200
+    mock_get_user.assert_called_once_with('legacy@example.com')
 
 
 @patch('lambdas.user_data.handler.get_user_table_data')
-def test_user_get_not_found(mock_get_user, mock_context, api_gateway_event):
-    """Test user not found"""
-    # Setup
-    mock_get_user.side_effect = Exception("User not found")
+def test_user_get_missing_caller_identity_returns_401(
+    mock_get_user, mock_context, api_gateway_event,
+):
+    """No context, no fallback: helper raises a structured 401."""
     event = {
         **api_gateway_event,
         "httpMethod": "GET",
         "path": "/user/user-table",
-        "queryStringParameters": {"email": "notfound@example.com"}
+        "queryStringParameters": {},
     }
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
+    assert response['statusCode'] == 401
+    body = json.loads(response['body'])
+    assert body['error']['field'] == 'email'
+    mock_get_user.assert_not_called()
+
+
+@patch('lambdas.user_data.handler.get_user_table_data')
+def test_user_get_dynamo_failure_propagates_as_500(
+    mock_get_user, mock_context, authorized_event,
+):
+    """Underlying retrieval errors surface as a 500 via the error decorator."""
+    mock_get_user.side_effect = Exception("User not found")
+    event = authorized_event(
+        email="notfound@example.com",
+        httpMethod="GET",
+        path="/user/user-table",
+    )
+
+    response = handler(event, mock_context)
+
     assert response['statusCode'] == 500

--- a/tests/test_user_update.py
+++ b/tests/test_user_update.py
@@ -2,86 +2,183 @@
 Tests for user_update lambda
 """
 
-import pytest
 import json
 from unittest.mock import patch
+
 from lambdas.user_update.handler import handler
 
 
 @patch('lambdas.user_update.handler.update_user_table_refresh_token')
-def test_user_update_refresh_token(mock_update_token, mock_context, api_gateway_event):
-    """Test updating refresh token"""
-    # Setup
+def test_user_update_refresh_token_via_context(
+    mock_update_token, mock_context, authorized_event,
+):
+    """Token-persistence path with caller identity from authorizer context."""
     mock_update_token.return_value = {
         'email': 'test@example.com',
         'userId': 'spotify123',
-        'updated': True
+        'updated': True,
     }
-    event = {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/user/user-table",
-        "body": json.dumps({
-            "email": "test@example.com",
-            "userId": "spotify123",
+    event = authorized_event(
+        email="test@example.com",
+        user_id="spotify123",
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({
             "displayName": "Test User",
             "refreshToken": "new-token",
-            "avatar": "https://example.com/avatar.jpg"
-        })
-    }
+            "avatar": "https://example.com/avatar.jpg",
+        }),
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
-    mock_update_token.assert_called_once()
+    mock_update_token.assert_called_once_with(
+        'test@example.com',
+        'spotify123',
+        'Test User',
+        'new-token',
+        'https://example.com/avatar.jpg',
+    )
+
+
+@patch('lambdas.user_update.handler.update_user_table_refresh_token')
+def test_user_update_refresh_token_via_body_fallback(
+    mock_update_token, mock_context, legacy_event,
+):
+    """Legacy callers (no context) still send email/userId in the body."""
+    mock_update_token.return_value = {'email': 'legacy@example.com', 'updated': True}
+    event = legacy_event(
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({
+            "email": "legacy@example.com",
+            "userId": "spotifyLegacy",
+            "displayName": "Legacy User",
+            "refreshToken": "legacy-token",
+            "avatar": "https://example.com/legacy.jpg",
+        }),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_update_token.assert_called_once_with(
+        'legacy@example.com',
+        'spotifyLegacy',
+        'Legacy User',
+        'legacy-token',
+        'https://example.com/legacy.jpg',
+    )
+
+
+@patch('lambdas.user_update.handler.update_user_table_refresh_token')
+def test_user_update_refresh_token_missing_profile_field_is_400(
+    mock_update_token, mock_context, authorized_event,
+):
+    """Profile fields (displayName/refreshToken/avatar) are still required."""
+    event = authorized_event(
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({
+            "refreshToken": "new-token",
+            # displayName + avatar omitted
+        }),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+    mock_update_token.assert_not_called()
 
 
 @patch('lambdas.user_update.handler.update_user_table_enrollments')
-def test_user_update_enrollments(mock_update_enrollments, mock_context, api_gateway_event):
-    """Test updating enrollment status"""
-    # Setup
+def test_user_update_enrollments_via_context(
+    mock_update_enrollments, mock_context, authorized_event,
+):
+    """Enrollment path uses caller email from authorizer context."""
     mock_update_enrollments.return_value = {
         'email': 'test@example.com',
         'wrappedEnrolled': True,
-        'releaseRadarEnrolled': False
+        'releaseRadarEnrolled': False,
     }
-    event = {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/user/user-table",
-        "body": json.dumps({
-            "email": "test@example.com",
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({
             "wrappedEnrolled": True,
-            "releaseRadarEnrolled": False
-        })
-    }
+            "releaseRadarEnrolled": False,
+        }),
+    )
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
     assert response['statusCode'] == 200
     mock_update_enrollments.assert_called_once_with('test@example.com', True, False)
 
 
 @patch('lambdas.user_update.handler.update_user_table_refresh_token')
-def test_user_update_invalid_request(mock_update_token, mock_context, api_gateway_event):
-    """Test invalid update request"""
-    # Setup
+def test_user_update_invalid_request_returns_400(
+    mock_update_token, mock_context, authorized_event,
+):
+    """Body with neither token nor enrollment fields is a 400."""
+    event = authorized_event(
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 400
+
+
+@patch('lambdas.user_update.handler.update_user_table_refresh_token')
+def test_user_update_missing_caller_identity_returns_401(
+    mock_update_token, mock_context, api_gateway_event,
+):
+    """No context, no body fallback for caller email: structured 401."""
     event = {
         **api_gateway_event,
         "httpMethod": "POST",
         "path": "/user/user-table",
         "body": json.dumps({
-            "email": "test@example.com"
-            # Missing both token and enrollment fields
-        })
+            "displayName": "X",
+            "refreshToken": "Y",
+            "avatar": "Z",
+        }),
     }
 
-    # Execute
     response = handler(event, mock_context)
 
-    # Assert
-    assert response['statusCode'] == 400
+    assert response['statusCode'] == 401
+    body = json.loads(response['body'])
+    assert body['error']['field'] == 'email'
+    mock_update_token.assert_not_called()
+
+
+@patch('lambdas.user_update.handler.update_user_table_refresh_token')
+def test_user_update_token_path_missing_user_id_returns_401(
+    mock_update_token, mock_context, legacy_event,
+):
+    """Body has email but no userId: helper raises 401 on userId resolution."""
+    event = legacy_event(
+        email="legacy@example.com",
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({
+            "email": "legacy@example.com",
+            # userId omitted
+            "displayName": "X",
+            "refreshToken": "Y",
+            "avatar": "Z",
+        }),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    body = json.loads(response['body'])
+    assert body['error']['field'] == 'userId'
+    mock_update_token.assert_not_called()


### PR DESCRIPTION
Closes #155.

Track 1 sub-feature (1i) of the auth-identity epic. Migrates the 3 authorized user handlers (`user_all`, `user_data`, `user_update`) to read caller identity from the trusted authorizer context via `get_caller_email` / `get_caller_user_id`, while keeping the query-string / body fallback active during the migration window.

## Summary
- `user_all`: caller email now comes from the helper. Anonymous calls (no context, no fallback) tolerated explicitly so the unfiltered discovery list still returns.
- `user_data`: caller email now comes from the helper. Endpoint returns the caller's own row only.
- `user_update`: caller email AND userId now come from the helpers. `displayName`, `refreshToken`, `avatar`, `wrappedEnrolled`, `releaseRadarEnrolled` continue to live in the body. Token-path branch detection switched from `userId in body` to `refreshToken in body`.

## API contract changes — please review

### `user_data` (GET /user/data)
**Before**: `?email=<X>` returned the row at `<X>` — any caller could pass any email and read that user's row.
**After**: returns the caller's own row. The `?email=` query param is now a fallback identifier for the caller (used during the migration window for legacy static-token clients), not a target lookup field.

If iOS or web ever fetched another user's row via `/user/data?email=<friend>`, they will now receive their own row instead. This is exactly the security gap the epic exists to close, so the change is intentional — but flagging for an explicit ack before merging.

If cross-user lookup is needed, that should be a separate endpoint (e.g. `/friends/profile`) with explicit `targetEmail` semantics. Out of scope for this batch.

### `user_update` (POST /user/update)
**Before**: `email` (always) and `userId` (token path) were required body fields.
**After**:
- `email` is no longer read from the body for the path that goes through `get_caller_email` (context-first, body-as-fallback). The body field is still consulted as a fallback during the migration window so legacy callers don't break.
- `userId` is no longer read from the body for the token-persistence branch — same context-first, body-as-fallback pattern via `get_caller_user_id`.
- Token-path branch detection now keys off `refreshToken in body` (was `'refreshToken' in body and 'userId' in body`). For correctly-formed callers the behavior is unchanged.

This is the lambda iOS hits right after Spotify OAuth to persist the refresh token. Today iOS still passes everything in the body, so the body-fallback path keeps it working through the migration. After (0d) ships and iOS sends a per-user JWT, identity comes from context.

### `user_all` (GET /user/all)
No contract change beyond the new identity sourcing. Anonymous (no caller identity at all) still returns the unfiltered list.

## Tests
- `tests/test_user_all.py`: anonymous, trusted-context, legacy `?email=` fallback, case-insensitive caller filter.
- `tests/test_user_get.py`: trusted-context, legacy fallback, 401-on-missing-identity, 500 propagation from the data layer.
- `tests/test_user_update.py`: trusted-context (token path), body fallback (token path), missing profile field 400, enrollment via context, no-fields 400, 401 on missing email, 401 on missing userId for the token branch.

Full suite: 231 passed.

## Test plan
- [x] `pytest tests/test_user_*.py -xvs`
- [x] `pytest -x` (full suite)
- [ ] Post-deploy: confirm CloudWatch logs show both `auth_path=context` (new clients post-(0d)/(0e)) and `auth_path=fallback` (legacy callers) flowing through the helper.

## Out of scope
- Removing the body/query fallback (that's (1l)).
- Adding a separate `targetEmail` endpoint for cross-user data (not part of this epic).

## Parent epic
`docs/features/auth-identity-and-live-top-items/PLAN.md` (issue #140)