### PR TITLE
(1b) Migrate groups handlers (13) to caller-identity helper

### DIFF
--- a/lambdas/groups_add_member/handler.py
+++ b/lambdas/groups_add_member/handler.py
@@ -4,7 +4,12 @@ POST /groups/add-member - Add a member to group
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.group_members_dynamo import add_group_member
 from lambdas.common.dynamo_helpers import get_user_table_data
 
@@ -16,9 +21,9 @@ HANDLER = 'groups_add_member'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId', 'memberEmail')
+    require_fields(body, 'groupId', 'memberEmail')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     group_id = body.get('groupId')
     member_email = body.get('memberEmail')
 

--- a/lambdas/groups_add_song/handler.py
+++ b/lambdas/groups_add_song/handler.py
@@ -26,7 +26,12 @@ metadata is optional — a missing field just won't be persisted.
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.group_tracks_dynamo import add_track_to_group
 
 log = get_logger(__file__)
@@ -62,9 +67,9 @@ def _extract_track_fields(body: dict) -> tuple[str | None, str | None, str | Non
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId', 'trackId')
+    require_fields(body, 'groupId', 'trackId')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     group_id = body.get('groupId')
     track_id = body.get('trackId')
 

--- a/lambdas/groups_add_song_url/handler.py
+++ b/lambdas/groups_add_song_url/handler.py
@@ -7,7 +7,12 @@ import aiohttp
 import asyncio
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.group_tracks_dynamo import add_track_to_group
 from lambdas.common.spotify import Spotify
 
@@ -19,9 +24,9 @@ HANDLER = 'groups_add_song_url'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId', 'spotifyUrl')
+    require_fields(body, 'groupId', 'spotifyUrl')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     group_id = body.get('groupId')
     spotify_url = body.get('spotifyUrl')
 

--- a/lambdas/groups_create/handler.py
+++ b/lambdas/groups_create/handler.py
@@ -5,7 +5,12 @@ POST /groups/create - Create a new group
 import uuid
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.groups_dynamo import create_group
 from lambdas.common.group_members_dynamo import add_group_member
 
@@ -17,9 +22,9 @@ HANDLER = 'groups_create'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'name')
+    require_fields(body, 'name')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     name = body.get('name')
     description = body.get('description')
     image_url = body.get('imageUrl')

--- a/lambdas/groups_info/handler.py
+++ b/lambdas/groups_info/handler.py
@@ -6,7 +6,12 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.groups_dynamo import get_group
 from lambdas.common.group_members_dynamo import list_members_of_group
 from lambdas.common.group_tracks_dynamo import list_tracks_for_group
@@ -19,9 +24,9 @@ HANDLER = 'groups_info'
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email', 'groupId')
+    require_fields(params, 'groupId')
 
-    email = params.get('email')
+    email = get_caller_email(event)
     group_id = params.get('groupId')
 
     log.info(f"Getting Group {group_id} info, members and tracks. Called by {email}")

--- a/lambdas/groups_leave/handler.py
+++ b/lambdas/groups_leave/handler.py
@@ -4,7 +4,11 @@ POST /groups/leave - Leave a group
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.group_members_dynamo import remove_group_member
 
 log = get_logger(__file__)
@@ -15,9 +19,9 @@ HANDLER = 'groups_leave'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId')
+    require_fields(body, 'groupId')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     group_id = body.get('groupId')
 
     log.info(f"User {email} leaving group {group_id}")

--- a/lambdas/groups_list/handler.py
+++ b/lambdas/groups_list/handler.py
@@ -17,7 +17,7 @@ must never break /groups/list).
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.group_members_dynamo import list_groups_for_user, list_members_of_group
 from lambdas.common.groups_dynamo import batch_get_groups, update_group_member_count
 
@@ -28,10 +28,7 @@ HANDLER = 'groups_list'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, 'email')
-
-    email = params.get('email')
+    email = get_caller_email(event)
 
     log.info(f"Listing all groups for user {email}")
     memberships = list_groups_for_user(email)

--- a/lambdas/groups_mark_all_listened/handler.py
+++ b/lambdas/groups_mark_all_listened/handler.py
@@ -4,7 +4,12 @@ POST /groups/mark-all-listened - Mark all songs as listened for user
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.group_tracks_dynamo import list_tracks_for_group, mark_track_as_listened
 
 log = get_logger(__file__)
@@ -15,9 +20,9 @@ HANDLER = 'groups_mark_all_listened'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId')
+    require_fields(body, 'groupId')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     group_id = body.get('groupId')
 
     log.info(f"User {email} marking all songs as listened in group {group_id}")

--- a/lambdas/groups_remove/handler.py
+++ b/lambdas/groups_remove/handler.py
@@ -5,7 +5,12 @@ DELETE /groups/remove - Delete a group (owner only)
 import boto3
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.constants import GROUPS_TABLE_NAME
 from lambdas.common.group_members_dynamo import list_members_of_group
 
@@ -17,9 +22,9 @@ HANDLER = 'groups_remove'
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email', 'groupId')
+    require_fields(params, 'groupId')
 
-    email = params.get('email')
+    email = get_caller_email(event)
     group_id = params.get('groupId')
 
     # Verify user is owner

--- a/lambdas/groups_remove_member/handler.py
+++ b/lambdas/groups_remove_member/handler.py
@@ -4,7 +4,11 @@ DELETE /groups/remove-member - Remove a member from group
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.group_members_dynamo import remove_group_member
 
 log = get_logger(__file__)
@@ -15,9 +19,9 @@ HANDLER = 'groups_remove_member'
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email', 'groupId', 'memberEmail')
+    require_fields(params, 'groupId', 'memberEmail')
 
-    email = params.get('email')
+    email = get_caller_email(event)
     group_id = params.get('groupId')
     member_email = params.get('memberEmail')
 

--- a/lambdas/groups_remove_song/handler.py
+++ b/lambdas/groups_remove_song/handler.py
@@ -5,7 +5,11 @@ DELETE /groups/remove-song - Remove a song from group
 import boto3
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.constants import GROUP_TRACKS_TABLE_NAME
 
 log = get_logger(__file__)
@@ -16,9 +20,9 @@ HANDLER = 'groups_remove_song'
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email', 'groupId', 'songId')
+    require_fields(params, 'groupId', 'songId')
 
-    email = params.get('email')
+    email = get_caller_email(event)
     group_id = params.get('groupId')
     song_id = params.get('songId')  # This is the trackIdTimestamp (SK)
 

--- a/lambdas/groups_song_status/handler.py
+++ b/lambdas/groups_song_status/handler.py
@@ -5,7 +5,12 @@ PUT /groups/song-status - Update user's status on a song
 from datetime import datetime, timezone
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.group_tracks_dynamo import mark_track_as_listened
 
 log = get_logger(__file__)
@@ -20,9 +25,9 @@ def _get_timestamp() -> str:
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId', 'songId')
+    require_fields(body, 'groupId', 'songId')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     group_id = body.get('groupId')
     song_id = body.get('songId')  # This is the trackIdTimestamp (SK)
     listened = body.get('listened', False)

--- a/lambdas/groups_update/handler.py
+++ b/lambdas/groups_update/handler.py
@@ -5,7 +5,12 @@ PUT /groups/update - Update group details
 import boto3
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.constants import GROUPS_TABLE_NAME
 from lambdas.common.groups_dynamo import get_group
 from lambdas.common.group_members_dynamo import list_members_of_group
@@ -18,9 +23,9 @@ HANDLER = 'groups_update'
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'groupId')
+    require_fields(body, 'groupId')
 
-    email = body.get('email')
+    email = get_caller_email(event)
     group_id = body.get('groupId')
     name = body.get('name')
     description = body.get('description')

--- a/tests/test_groups_add_song.py
+++ b/tests/test_groups_add_song.py
@@ -5,7 +5,8 @@ The handler must accept BOTH request shapes:
   1. nested `track: {name, artists[{name}], album.images[{url}]}` (legacy)
   2. flat `{trackName, artistName, albumName, imageUrl}` (iOS client)
 
-email / groupId / trackId are always required.
+groupId / trackId are always required in the body. Caller email is sourced
+from the authorizer context via `authorized_event` (post Track 1 migration).
 """
 
 import json
@@ -14,20 +15,19 @@ from unittest.mock import patch
 from lambdas.groups_add_song.handler import handler
 
 
-def _event(api_gateway_event, body):
-    return {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/groups/add-song",
-        "body": json.dumps(body),
-    }
+def _event(authorized_event, email: str, body: dict) -> dict:
+    return authorized_event(
+        email=email,
+        httpMethod="POST",
+        path="/groups/add-song",
+        body=json.dumps(body),
+    )
 
 
 @patch('lambdas.groups_add_song.handler.add_track_to_group')
-def test_groups_add_song_flat_shape_ios(mock_add, mock_context, api_gateway_event):
+def test_groups_add_song_flat_shape_ios(mock_add, mock_context, authorized_event):
     """iOS sends flat top-level fields — no `track` object."""
     body = {
-        "email": "user@example.com",
         "groupId": "g1",
         "trackId": "spotify:track:1",
         "trackName": "Bohemian Rhapsody",
@@ -36,7 +36,7 @@ def test_groups_add_song_flat_shape_ios(mock_add, mock_context, api_gateway_even
         "imageUrl": "https://i.scdn.co/image/abc.jpg",
     }
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, "user@example.com", body), mock_context)
 
     assert response['statusCode'] == 200
     payload = json.loads(response['body'])
@@ -56,10 +56,9 @@ def test_groups_add_song_flat_shape_ios(mock_add, mock_context, api_gateway_even
 
 
 @patch('lambdas.groups_add_song.handler.add_track_to_group')
-def test_groups_add_song_nested_shape_legacy(mock_add, mock_context, api_gateway_event):
+def test_groups_add_song_nested_shape_legacy(mock_add, mock_context, authorized_event):
     """Legacy nested `track` object still works."""
     body = {
-        "email": "user@example.com",
         "groupId": "g1",
         "trackId": "spotify:track:1",
         "track": {
@@ -72,7 +71,7 @@ def test_groups_add_song_nested_shape_legacy(mock_add, mock_context, api_gateway
         },
     }
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, "user@example.com", body), mock_context)
 
     assert response['statusCode'] == 200
     payload = json.loads(response['body'])
@@ -88,15 +87,14 @@ def test_groups_add_song_nested_shape_legacy(mock_add, mock_context, api_gateway
 
 
 @patch('lambdas.groups_add_song.handler.add_track_to_group')
-def test_groups_add_song_missing_required_field(mock_add, mock_context, api_gateway_event):
+def test_groups_add_song_missing_required_field(mock_add, mock_context, authorized_event):
     """Missing trackId -> 400, and we don't touch Dynamo."""
     body = {
-        "email": "user@example.com",
         "groupId": "g1",
         "trackName": "Bohemian Rhapsody",
     }
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, "user@example.com", body), mock_context)
 
     assert response['statusCode'] == 400
     mock_add.assert_not_called()
@@ -104,16 +102,15 @@ def test_groups_add_song_missing_required_field(mock_add, mock_context, api_gate
 
 @patch('lambdas.groups_add_song.handler.add_track_to_group')
 def test_groups_add_song_flat_shape_tolerates_missing_metadata(
-    mock_add, mock_context, api_gateway_event
+    mock_add, mock_context, authorized_event
 ):
     """Only the three required keys are needed — track metadata is optional."""
     body = {
-        "email": "user@example.com",
         "groupId": "g1",
         "trackId": "spotify:track:1",
     }
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, "user@example.com", body), mock_context)
 
     assert response['statusCode'] == 200
     kwargs = mock_add.call_args.kwargs
@@ -124,11 +121,10 @@ def test_groups_add_song_flat_shape_tolerates_missing_metadata(
 
 @patch('lambdas.groups_add_song.handler.add_track_to_group')
 def test_groups_add_song_nested_shape_with_empty_arrays(
-    mock_add, mock_context, api_gateway_event
+    mock_add, mock_context, authorized_event
 ):
     """Nested shape with empty artists/images lists — should not crash."""
     body = {
-        "email": "user@example.com",
         "groupId": "g1",
         "trackId": "spotify:track:1",
         "track": {
@@ -138,10 +134,30 @@ def test_groups_add_song_nested_shape_with_empty_arrays(
         },
     }
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, "user@example.com", body), mock_context)
 
     assert response['statusCode'] == 200
     kwargs = mock_add.call_args.kwargs
     assert kwargs['track_name'] == 'Some Song'
     assert kwargs['artist_name'] is None
     assert kwargs['album_image_url'] is None
+
+
+@patch('lambdas.groups_add_song.handler.add_track_to_group')
+def test_groups_add_song_missing_caller_identity_returns_401(
+    mock_add, mock_context, legacy_event,
+):
+    """No authorizer context AND no caller email in body -> 401, no DDB writes."""
+    body = {
+        "groupId": "g1",
+        "trackId": "spotify:track:1",
+    }
+    event = legacy_event()
+    event["httpMethod"] = "POST"
+    event["path"] = "/groups/add-song"
+    event["body"] = json.dumps(body)
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_add.assert_not_called()

--- a/tests/test_groups_create.py
+++ b/tests/test_groups_create.py
@@ -3,19 +3,22 @@ Tests for groups_create lambda + create_group helper.
 
 Covers the memberCount seeding fix: create_group must seed 0 so that the
 follow-up add_group_member("owner") lands the count at 1, not 2.
+
+Caller email is sourced from the authorizer context via `authorized_event`
+(post Track 1 migration). Non-caller fields stay in the request body.
 """
 
 import json
 from unittest.mock import patch, MagicMock
 
 
-def _make_event(api_gateway_event, body: dict) -> dict:
-    return {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/groups/create",
-        "body": json.dumps(body)
-    }
+def _make_event(authorized_event, email: str, body: dict) -> dict:
+    return authorized_event(
+        email=email,
+        httpMethod="POST",
+        path="/groups/create",
+        body=json.dumps(body),
+    )
 
 
 @patch('lambdas.common.groups_dynamo.dynamodb')
@@ -39,13 +42,12 @@ def test_create_group_seeds_member_count_at_zero(mock_dynamodb):
 @patch('lambdas.groups_create.handler.add_group_member')
 @patch('lambdas.groups_create.handler.create_group')
 def test_groups_create_owner_results_in_member_count_of_one(
-    mock_create_group, mock_add_member, mock_context, api_gateway_event
+    mock_create_group, mock_add_member, mock_context, authorized_event
 ):
     """End-to-end: seed(0) + add_group_member(owner, +1) == 1."""
     from lambdas.groups_create.handler import handler
 
-    event = _make_event(api_gateway_event, {
-        "email": "owner@example.com",
+    event = _make_event(authorized_event, "owner@example.com", {
         "name": "New Group"
     })
 
@@ -64,13 +66,12 @@ def test_groups_create_owner_results_in_member_count_of_one(
 @patch('lambdas.groups_create.handler.add_group_member')
 @patch('lambdas.groups_create.handler.create_group')
 def test_groups_create_with_extra_members_counts_correctly(
-    mock_create_group, mock_add_member, mock_context, api_gateway_event
+    mock_create_group, mock_add_member, mock_context, authorized_event
 ):
     """Seed(0) + owner(+1) + N other members(+1 each) == N + 1."""
     from lambdas.groups_create.handler import handler
 
-    event = _make_event(api_gateway_event, {
-        "email": "owner@example.com",
+    event = _make_event(authorized_event, "owner@example.com", {
         "name": "Squad",
         "memberEmails": ["a@example.com", "b@example.com"]
     })
@@ -80,3 +81,23 @@ def test_groups_create_with_extra_members_counts_correctly(
 
     # 1 owner + 2 members = 3 add_group_member calls.
     assert mock_add_member.call_count == 3
+
+
+@patch('lambdas.groups_create.handler.add_group_member')
+@patch('lambdas.groups_create.handler.create_group')
+def test_groups_create_missing_caller_identity_returns_401(
+    mock_create_group, mock_add_member, mock_context, legacy_event
+):
+    """No authorizer context AND no caller email in query/body -> 401, no DDB writes."""
+    from lambdas.groups_create.handler import handler
+
+    event = legacy_event()  # no email / userId anywhere
+    event["httpMethod"] = "POST"
+    event["path"] = "/groups/create"
+    event["body"] = json.dumps({"name": "Anon"})
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_create_group.assert_not_called()
+    mock_add_member.assert_not_called()

--- a/tests/test_groups_list.py
+++ b/tests/test_groups_list.py
@@ -7,6 +7,9 @@ memberCount is always recomputed live from the membership GSI — the
 cached attribute on the GROUPS row has historically drifted (old seed
 set fresh 1-member groups to 2 until PR #136). The handler also issues
 a best-effort write-back to heal the stored value.
+
+Caller email is sourced from the authorizer context via `authorized_event`
+(post Track 1 migration). The handler takes no other request fields.
 """
 
 import json
@@ -15,13 +18,21 @@ from unittest.mock import patch
 from lambdas.groups_list.handler import handler
 
 
+def _event(authorized_event, email: str) -> dict:
+    return authorized_event(
+        email=email,
+        httpMethod="GET",
+        path="/groups/list",
+    )
+
+
 @patch('lambdas.groups_list.handler.update_group_member_count')
 @patch('lambdas.groups_list.handler.list_members_of_group')
 @patch('lambdas.groups_list.handler.batch_get_groups')
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_hydrates_membership_with_group_metadata(
     mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """Membership rows get merged with the full Group item so `name`,
     `createdBy`, `memberCount` end up on the wire."""
@@ -39,12 +50,7 @@ def test_groups_list_hydrates_membership_with_group_metadata(
         else [{"email": f"u{i}@example.com"} for i in range(7)]
     )
 
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/groups/list",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = _event(authorized_event, "test@example.com")
 
     response = handler(event, mock_context)
 
@@ -74,7 +80,7 @@ def test_groups_list_hydrates_membership_with_group_metadata(
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_drops_memberships_with_missing_group(
     mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """If the Groups table no longer has a row for a membership's groupId
     (e.g. the group was deleted but the membership wasn't cleaned up), the
@@ -91,12 +97,7 @@ def test_groups_list_drops_memberships_with_missing_group(
         {"email": "test@example.com"},
     ]
 
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/groups/list",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = _event(authorized_event, "test@example.com")
 
     response = handler(event, mock_context)
 
@@ -113,17 +114,12 @@ def test_groups_list_drops_memberships_with_missing_group(
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_empty(
     mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     mock_list_memberships.return_value = []
     mock_batch_get.return_value = []
 
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/groups/list",
-        "queryStringParameters": {"email": "test@example.com"}
-    }
+    event = _event(authorized_event, "test@example.com")
 
     response = handler(event, mock_context)
 
@@ -141,7 +137,7 @@ def test_groups_list_empty(
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_returns_live_member_count_when_cache_is_stale(
     mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """Regression test for the seed-bug leftover: cached memberCount=2 on a
     group that actually has 1 member. The response must carry the live count,
@@ -156,12 +152,7 @@ def test_groups_list_returns_live_member_count_when_cache_is_stale(
     # GSI shows the group truly has one member.
     mock_list_members.return_value = [{"email": "solo@example.com"}]
 
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/groups/list",
-        "queryStringParameters": {"email": "solo@example.com"}
-    }
+    event = _event(authorized_event, "solo@example.com")
 
     response = handler(event, mock_context)
 
@@ -181,7 +172,7 @@ def test_groups_list_returns_live_member_count_when_cache_is_stale(
 @patch('lambdas.groups_list.handler.list_groups_for_user')
 def test_groups_list_heal_failure_does_not_break_response(
     mock_list_memberships, mock_batch_get, mock_list_members, mock_update_count,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """A blow-up from the best-effort write-back must not fail the request."""
     mock_list_memberships.return_value = [
@@ -193,15 +184,25 @@ def test_groups_list_heal_failure_does_not_break_response(
     mock_list_members.return_value = [{"email": "solo@example.com"}]
     mock_update_count.side_effect = RuntimeError("DynamoDB threw")
 
-    event = {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/groups/list",
-        "queryStringParameters": {"email": "solo@example.com"}
-    }
+    event = _event(authorized_event, "solo@example.com")
 
     response = handler(event, mock_context)
 
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
     assert body['groups'][0]['memberCount'] == 1
+
+
+@patch('lambdas.groups_list.handler.list_groups_for_user')
+def test_groups_list_missing_caller_identity_returns_401(
+    mock_list_memberships, mock_context, legacy_event,
+):
+    """No authorizer context AND no caller email in query/body -> 401, no DDB reads."""
+    event = legacy_event()  # no email / userId anywhere
+    event["httpMethod"] = "GET"
+    event["path"] = "/groups/list"
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_list_memberships.assert_not_called()

--- a/tests/test_groups_update.py
+++ b/tests/test_groups_update.py
@@ -1,26 +1,29 @@
 """
 Tests for groups_update lambda — ensures updates use ExpressionAttributeNames
 to avoid the DynamoDB reserved keyword collision on `name`.
+
+Caller email is sourced from the authorizer context via `authorized_event`
+(post Track 1 migration). `groupId` and the updatable fields stay in body.
 """
 
 import json
 from unittest.mock import patch, MagicMock
 
 
-def _make_event(api_gateway_event, body: dict) -> dict:
-    return {
-        **api_gateway_event,
-        "httpMethod": "PUT",
-        "path": "/groups/update",
-        "body": json.dumps(body)
-    }
+def _make_event(authorized_event, email: str, body: dict) -> dict:
+    return authorized_event(
+        email=email,
+        httpMethod="PUT",
+        path="/groups/update",
+        body=json.dumps(body),
+    )
 
 
 @patch('lambdas.groups_update.handler.get_group')
 @patch('lambdas.groups_update.handler.boto3')
 @patch('lambdas.groups_update.handler.list_members_of_group')
 def test_groups_update_uses_expression_attribute_names_for_reserved_keyword(
-    mock_list_members, mock_boto3, mock_get_group, mock_context, api_gateway_event
+    mock_list_members, mock_boto3, mock_get_group, mock_context, authorized_event
 ):
     """`name` is a DynamoDB reserved word — the UpdateExpression must alias it via #name."""
     from lambdas.groups_update.handler import handler
@@ -40,8 +43,7 @@ def test_groups_update_uses_expression_attribute_names_for_reserved_keyword(
         "memberCount": 3
     }
 
-    event = _make_event(api_gateway_event, {
-        "email": "owner@example.com",
+    event = _make_event(authorized_event, "owner@example.com", {
         "groupId": "g1",
         "name": "New Name",
         "description": "new desc"
@@ -75,7 +77,7 @@ def test_groups_update_uses_expression_attribute_names_for_reserved_keyword(
 @patch('lambdas.groups_update.handler.boto3')
 @patch('lambdas.groups_update.handler.list_members_of_group')
 def test_groups_update_only_name_still_aliases_it(
-    mock_list_members, mock_boto3, mock_get_group, mock_context, api_gateway_event
+    mock_list_members, mock_boto3, mock_get_group, mock_context, authorized_event
 ):
     """When only `name` is updated, we still alias it (the whole point of the fix)."""
     from lambdas.groups_update.handler import handler
@@ -88,8 +90,7 @@ def test_groups_update_only_name_still_aliases_it(
     mock_boto3.resource.return_value.Table.return_value = mock_table
     mock_get_group.return_value = {"groupId": "g1", "name": "Renamed"}
 
-    event = _make_event(api_gateway_event, {
-        "email": "owner@example.com",
+    event = _make_event(authorized_event, "owner@example.com", {
         "groupId": "g1",
         "name": "Renamed"
     })
@@ -105,7 +106,7 @@ def test_groups_update_only_name_still_aliases_it(
 
 @patch('lambdas.groups_update.handler.list_members_of_group')
 def test_groups_update_rejects_non_owner(
-    mock_list_members, mock_context, api_gateway_event
+    mock_list_members, mock_context, authorized_event
 ):
     from lambdas.groups_update.handler import handler
 
@@ -113,11 +114,28 @@ def test_groups_update_rejects_non_owner(
         {"email": "member@example.com", "groupId": "g1", "role": "member"}
     ]
 
-    event = _make_event(api_gateway_event, {
-        "email": "member@example.com",
+    event = _make_event(authorized_event, "member@example.com", {
         "groupId": "g1",
         "name": "Hostile Rename"
     })
 
     response = handler(event, mock_context)
     assert response['statusCode'] == 400
+
+
+@patch('lambdas.groups_update.handler.list_members_of_group')
+def test_groups_update_missing_caller_identity_returns_401(
+    mock_list_members, mock_context, legacy_event,
+):
+    """No authorizer context AND no caller email in query/body -> 401, no DDB reads."""
+    from lambdas.groups_update.handler import handler
+
+    event = legacy_event()
+    event["httpMethod"] = "PUT"
+    event["path"] = "/groups/update"
+    event["body"] = json.dumps({"groupId": "g1", "name": "Anon Rename"})
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 401
+    mock_list_members.assert_not_called()


### PR DESCRIPTION
Closes #150

Sub-feature **(1b)** of the auth-identity epic.

- Canonical plan: `docs/features/auth-identity-and-live-top-items/PLAN.md`
- Stub: `docs/features/backend-handler-migration-groups/PLAN.md`

## Summary
- Migrate 13 groups handlers to read caller email from `get_caller_email(event)` (added in (0c) / #143) instead of the request body / query string.
- Helper retains its query/body fallback during the migration window. Existing static-token clients keep working; the trusted-context path is preferred when the per-user JWT populates `requestContext.authorizer.email`.
- Caller-vs-target audit: only the `email` field representing the caller was migrated. `groupId`, `memberEmail`, `songId`, `trackId`, `spotifyUrl`, etc. remain as explicit request fields.

## Handlers migrated
- `lambdas/groups_add_member/handler.py`
- `lambdas/groups_add_song/handler.py`
- `lambdas/groups_add_song_url/handler.py`
- `lambdas/groups_create/handler.py`
- `lambdas/groups_info/handler.py`
- `lambdas/groups_leave/handler.py`
- `lambdas/groups_list/handler.py`
- `lambdas/groups_mark_all_listened/handler.py`
- `lambdas/groups_remove/handler.py`
- `lambdas/groups_remove_member/handler.py`
- `lambdas/groups_remove_song/handler.py`
- `lambdas/groups_song_status/handler.py`
- `lambdas/groups_update/handler.py`

## Tests
- All four existing groups test files migrated to the `authorized_event` fixture for the caller. Non-caller params still flow through the body/query.
- Each file gained a new 401 test using `legacy_event` (no context, no fallback) to guard the `MissingCallerIdentityError` path.
- `pytest tests/test_groups_*.py` -> 20 passed.
- Full `pytest` suite -> 229 passed.

## Test plan
- [x] `pytest tests/test_groups_*.py` green
- [x] `pytest` (full suite) green
- [ ] Post-deploy: CloudWatch shows `auth_path=context` on requests from updated clients and `auth_path=fallback` only from legacy callers (expected non-zero until Tracks 1j/1k ship).

## Out of scope
- Removing the fallback in `get_caller_email` (Track 1l).
- Frontend / iOS sweeps to drop caller `email` (Tracks 1j / 1k).