### PR TITLE
(1d) Migrate invites handlers (4) to caller-identity helper

### DIFF
--- a/lambdas/invites_accept/handler.py
+++ b/lambdas/invites_accept/handler.py
@@ -14,7 +14,12 @@ from lambdas.common.errors import (
     XomifyError,
     DynamoDBError,
 )
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.invites_dynamo import get_invite, consume_invite
 from lambdas.common.friendships_dynamo import (
     list_all_friends_for_user,
@@ -50,9 +55,12 @@ def _is_already_friends(email: str, other_email: str) -> bool:
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, 'email', 'inviteCode')
+    require_fields(body, 'inviteCode')
 
-    email = body.get('email')
+    # Caller identity comes from the authorizer context (per-user JWT). During
+    # the Track 0 -> Track 1 migration window the helper falls back to the
+    # body/query-string `email` so legacy static-token clients still work.
+    email = get_caller_email(event)
     invite_code = body.get('inviteCode')
 
     log.info(f"User {email} accepting invite {invite_code}")

--- a/lambdas/invites_create/handler.py
+++ b/lambdas/invites_create/handler.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError, XomifyError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.invites_dynamo import (
     create_invite,
     generate_invite_code,
@@ -25,10 +25,10 @@ COLLISION_RETRY_LIMIT = 2
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    body = parse_body(event)
-    require_fields(body, 'email')
-
-    sender_email = body.get('email')
+    # Caller identity comes from the authorizer context (per-user JWT). During
+    # the Track 0 -> Track 1 migration window the helper falls back to the
+    # body/query-string `email` so legacy static-token clients still work.
+    sender_email = get_caller_email(event)
 
     # Rate limit — max 10 outstanding invites per sender
     outstanding = count_outstanding_invites_for_sender(sender_email)

--- a/lambdas/invites_decline/handler.py
+++ b/lambdas/invites_decline/handler.py
@@ -3,9 +3,12 @@ POST /invites/decline - Atomically decline (no-op consume) an invite code.
 
 Body:
     {
-        "email":      "decliner@...",  # who is declining
         "inviteCode": "<code>"
     }
+
+Caller identity (the decliner) is sourced from the authorizer context
+(per-user JWT). Falls back to body / query-string `email` during the Track 0
+-> Track 1 migration window so legacy static-token clients still work.
 
 Mirrors the invites_accept consume latch so a declined code cannot be
 accepted later, and an accepted code cannot be declined afterwards.
@@ -25,7 +28,12 @@ from lambdas.common.errors import (
     XomifyError,
     DynamoDBError,
 )
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.invites_dynamo import get_invite, decline_invite
 
 log = get_logger(__file__)
@@ -48,9 +56,12 @@ def _parse_iso(ts: str | None) -> datetime | None:
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, "email", "inviteCode")
+    require_fields(body, "inviteCode")
 
-    email = body.get("email")
+    # Caller identity comes from the authorizer context (per-user JWT). During
+    # the Track 0 -> Track 1 migration window the helper falls back to the
+    # body/query-string `email` so legacy static-token clients still work.
+    email = get_caller_email(event)
     invite_code = body.get("inviteCode")
 
     log.info(f"User {email} declining invite {invite_code}")

--- a/lambdas/invites_pending/handler.py
+++ b/lambdas/invites_pending/handler.py
@@ -8,8 +8,10 @@ the invite is still outstanding (not yet consumed, not yet expired). The
 iOS Friends screen uses this to show "your outstanding invites" so the user
 can manage / resend them.
 
-Query params:
-    email (required) - the caller's email, matched against senderEmail
+Caller identity:
+    Sourced from the authorizer context (per-user JWT). Falls back to
+    `queryStringParameters.email` during the Track 0 -> Track 1 migration
+    window so legacy static-token clients still work.
 
 Response:
     {
@@ -24,8 +26,7 @@ from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import (
     success_response,
-    get_query_params,
-    require_fields,
+    get_caller_email,
 )
 from lambdas.common.invites_dynamo import list_invites_by_sender
 from lambdas.common.constants import INVITE_URL_TEMPLATE
@@ -37,10 +38,10 @@ HANDLER = "invites_pending"
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    params = get_query_params(event)
-    require_fields(params, "email")
-
-    email = params.get("email")
+    # Caller identity comes from the authorizer context (per-user JWT). During
+    # the Track 0 -> Track 1 migration window the helper falls back to the
+    # query-string `email` so legacy static-token clients still work.
+    email = get_caller_email(event)
 
     log.info(f"Listing pending (outstanding) invites for {email}")
     invites = list_invites_by_sender(email, active_only=True)

--- a/tests/test_invites_create.py
+++ b/tests/test_invites_create.py
@@ -1,5 +1,10 @@
 """
-Tests for invites_create lambda
+Tests for invites_create lambda.
+
+Caller identity is sourced via `get_caller_email`, which prefers the per-user
+JWT context populated by the authorizer and falls back to the body-supplied
+`email` during the Track 0 -> Track 1 migration window. Both code paths are
+exercised below.
 """
 
 import json
@@ -10,20 +15,24 @@ from botocore.exceptions import ClientError
 from lambdas.invites_create.handler import handler
 
 
-def _event(api_gateway_event, body):
+def _post_event(base_event, body):
     return {
-        **api_gateway_event,
+        **base_event,
         "httpMethod": "POST",
         "path": "/invites/create",
         "body": json.dumps(body),
     }
 
 
+# ============================================
+# Trusted authorizer-context path (per-user JWT)
+# ============================================
+
 @patch('lambdas.invites_create.handler.create_invite')
 @patch('lambdas.invites_create.handler.generate_invite_code')
 @patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
-def test_invites_create_happy_path(
-    mock_count, mock_gen, mock_create, mock_context, api_gateway_event
+def test_invites_create_happy_path_context(
+    mock_count, mock_gen, mock_create, mock_context, authorized_event
 ):
     mock_count.return_value = 0
     mock_gen.return_value = "ABCDEFGH"
@@ -34,20 +43,54 @@ def test_invites_create_happy_path(
         "expiresAt": "2026-05-22T12:00:00+00:00",
     }
 
-    response = handler(_event(api_gateway_event, {"email": "user@example.com"}), mock_context)
+    event = _post_event(authorized_event(email="user@example.com"), {})
+    response = handler(event, mock_context)
 
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
     assert body['inviteCode'] == "ABCDEFGH"
     assert body['inviteUrl'].endswith("/invite/ABCDEFGH")
     assert body['expiresAt'] == "2026-05-22T12:00:00+00:00"
+    mock_count.assert_called_once_with("user@example.com")
 
+
+# ============================================
+# Legacy body-fallback path (pre-migration clients)
+# ============================================
+
+@patch('lambdas.invites_create.handler.create_invite')
+@patch('lambdas.invites_create.handler.generate_invite_code')
+@patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
+def test_invites_create_happy_path_fallback(
+    mock_count, mock_gen, mock_create, mock_context, legacy_event
+):
+    mock_count.return_value = 0
+    mock_gen.return_value = "ABCDEFGH"
+    mock_create.return_value = {
+        "inviteCode": "ABCDEFGH",
+        "senderEmail": "user@example.com",
+        "createdAt": "2026-04-22T12:00:00+00:00",
+        "expiresAt": "2026-05-22T12:00:00+00:00",
+    }
+
+    event = _post_event(legacy_event(), {"email": "user@example.com"})
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['inviteCode'] == "ABCDEFGH"
+    mock_count.assert_called_once_with("user@example.com")
+
+
+# ============================================
+# Code-collision retry (caller via context)
+# ============================================
 
 @patch('lambdas.invites_create.handler.create_invite')
 @patch('lambdas.invites_create.handler.generate_invite_code')
 @patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
 def test_invites_create_code_collision_retry(
-    mock_count, mock_gen, mock_create, mock_context, api_gateway_event
+    mock_count, mock_gen, mock_create, mock_context, authorized_event
 ):
     mock_count.return_value = 0
     mock_gen.side_effect = ["COLLIDE1", "SUCCEED2", "NEVER"]
@@ -67,7 +110,8 @@ def test_invites_create_code_collision_retry(
         },
     ]
 
-    response = handler(_event(api_gateway_event, {"email": "user@example.com"}), mock_context)
+    event = _post_event(authorized_event(email="user@example.com"), {})
+    response = handler(event, mock_context)
 
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
@@ -75,21 +119,31 @@ def test_invites_create_code_collision_retry(
     assert mock_create.call_count == 2
 
 
+# ============================================
+# Rate-limit cap (caller via context)
+# ============================================
+
 @patch('lambdas.invites_create.handler.create_invite')
 @patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
 def test_invites_create_rate_limit_exceeded(
-    mock_count, mock_create, mock_context, api_gateway_event
+    mock_count, mock_create, mock_context, authorized_event
 ):
     mock_count.return_value = 10
 
-    response = handler(_event(api_gateway_event, {"email": "user@example.com"}), mock_context)
+    event = _post_event(authorized_event(email="user@example.com"), {})
+    response = handler(event, mock_context)
 
     assert response['statusCode'] == 429
     mock_create.assert_not_called()
 
 
+# ============================================
+# Caller missing entirely -> 401 from helper
+# ============================================
+
 @patch('lambdas.invites_create.handler.count_outstanding_invites_for_sender')
-def test_invites_create_missing_email(mock_count, mock_context, api_gateway_event):
-    response = handler(_event(api_gateway_event, {}), mock_context)
-    assert response['statusCode'] == 400
+def test_invites_create_missing_caller(mock_count, mock_context, legacy_event):
+    event = _post_event(legacy_event(), {})
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 401
     mock_count.assert_not_called()

--- a/tests/test_invites_decline.py
+++ b/tests/test_invites_decline.py
@@ -1,5 +1,5 @@
 """
-Tests for invites_accept lambda.
+Tests for invites_decline lambda.
 
 Caller identity is sourced via `get_caller_email`, which prefers the per-user
 JWT context populated by the authorizer and falls back to the body-supplied
@@ -13,14 +13,14 @@ from unittest.mock import patch
 
 from botocore.exceptions import ClientError
 
-from lambdas.invites_accept.handler import handler
+from lambdas.invites_decline.handler import handler
 
 
 def _post_event(base_event, body):
     return {
         **base_event,
         "httpMethod": "POST",
-        "path": "/invites/accept",
+        "path": "/invites/decline",
         "body": json.dumps(body),
     }
 
@@ -37,21 +37,17 @@ def _past_iso(days: int = 1) -> str:
 # Trusted authorizer-context path (per-user JWT)
 # ============================================
 
-@patch('lambdas.invites_accept.handler.create_accepted_friendship')
-@patch('lambdas.invites_accept.handler.list_all_friends_for_user')
-@patch('lambdas.invites_accept.handler.consume_invite')
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_happy_path_context(
-    mock_get, mock_consume, mock_friends, mock_create_fs, mock_context, authorized_event
+@patch('lambdas.invites_decline.handler.decline_invite')
+@patch('lambdas.invites_decline.handler.get_invite')
+def test_invites_decline_happy_path_context(
+    mock_get, mock_decline, mock_context, authorized_event
 ):
     mock_get.return_value = {
         "inviteCode": "ABCDEFGH",
         "senderEmail": "alice@example.com",
         "expiresAt": _future_iso(),
     }
-    mock_friends.return_value = []
-    mock_consume.return_value = {"consumedAt": "2026-04-22T12:00:00+00:00"}
-    mock_create_fs.return_value = True
+    mock_decline.return_value = {"consumedAt": "2026-04-22T12:00:00+00:00"}
 
     event = _post_event(
         authorized_event(email="bob@example.com"),
@@ -63,28 +59,24 @@ def test_invites_accept_happy_path_context(
     body = json.loads(response['body'])
     assert body['ok'] is True
     assert body['senderEmail'] == "alice@example.com"
-    mock_create_fs.assert_called_once_with("alice@example.com", "bob@example.com")
+    mock_decline.assert_called_once_with("ABCDEFGH", "bob@example.com")
 
 
 # ============================================
 # Legacy body-fallback path (pre-migration clients)
 # ============================================
 
-@patch('lambdas.invites_accept.handler.create_accepted_friendship')
-@patch('lambdas.invites_accept.handler.list_all_friends_for_user')
-@patch('lambdas.invites_accept.handler.consume_invite')
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_happy_path_fallback(
-    mock_get, mock_consume, mock_friends, mock_create_fs, mock_context, legacy_event
+@patch('lambdas.invites_decline.handler.decline_invite')
+@patch('lambdas.invites_decline.handler.get_invite')
+def test_invites_decline_happy_path_fallback(
+    mock_get, mock_decline, mock_context, legacy_event
 ):
     mock_get.return_value = {
         "inviteCode": "ABCDEFGH",
         "senderEmail": "alice@example.com",
         "expiresAt": _future_iso(),
     }
-    mock_friends.return_value = []
-    mock_consume.return_value = {"consumedAt": "2026-04-22T12:00:00+00:00"}
-    mock_create_fs.return_value = True
+    mock_decline.return_value = {"consumedAt": "2026-04-22T12:00:00+00:00"}
 
     event = _post_event(
         legacy_event(),
@@ -95,25 +87,25 @@ def test_invites_accept_happy_path_fallback(
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
     assert body['ok'] is True
-    mock_create_fs.assert_called_once_with("alice@example.com", "bob@example.com")
+    mock_decline.assert_called_once_with("ABCDEFGH", "bob@example.com")
 
 
 # ============================================
 # Caller missing entirely -> 401 from helper
 # ============================================
 
-def test_invites_accept_missing_caller(mock_context, legacy_event):
+def test_invites_decline_missing_caller(mock_context, legacy_event):
     event = _post_event(legacy_event(), {"inviteCode": "ABCDEFGH"})
     response = handler(event, mock_context)
     assert response['statusCode'] == 401
 
 
 # ============================================
-# Domain-rule failure cases (caller via context)
+# Domain-rule failure cases
 # ============================================
 
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_not_found(mock_get, mock_context, authorized_event):
+@patch('lambdas.invites_decline.handler.get_invite')
+def test_invites_decline_not_found(mock_get, mock_context, authorized_event):
     mock_get.return_value = None
     event = _post_event(
         authorized_event(email="bob@example.com"),
@@ -123,14 +115,13 @@ def test_invites_accept_not_found(mock_get, mock_context, authorized_event):
     assert response['statusCode'] == 404
 
 
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_already_consumed(mock_get, mock_context, authorized_event):
+@patch('lambdas.invites_decline.handler.get_invite')
+def test_invites_decline_already_consumed(mock_get, mock_context, authorized_event):
     mock_get.return_value = {
         "inviteCode": "ABCDEFGH",
         "senderEmail": "alice@example.com",
         "expiresAt": _future_iso(),
         "consumedAt": "2026-04-21T10:00:00+00:00",
-        "consumedBy": "someone@example.com",
     }
     event = _post_event(
         authorized_event(email="bob@example.com"),
@@ -142,8 +133,8 @@ def test_invites_accept_already_consumed(mock_get, mock_context, authorized_even
     assert body['error']['error_code'] == "INVITE_CONSUMED"
 
 
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_expired(mock_get, mock_context, authorized_event):
+@patch('lambdas.invites_decline.handler.get_invite')
+def test_invites_decline_expired(mock_get, mock_context, authorized_event):
     mock_get.return_value = {
         "inviteCode": "ABCDEFGH",
         "senderEmail": "alice@example.com",
@@ -159,8 +150,8 @@ def test_invites_accept_expired(mock_get, mock_context, authorized_event):
     assert body['error']['error_code'] == "INVITE_EXPIRED"
 
 
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_self_invite(mock_get, mock_context, authorized_event):
+@patch('lambdas.invites_decline.handler.get_invite')
+def test_invites_decline_self_invite(mock_get, mock_context, authorized_event):
     mock_get.return_value = {
         "inviteCode": "ABCDEFGH",
         "senderEmail": "alice@example.com",
@@ -174,42 +165,17 @@ def test_invites_accept_self_invite(mock_get, mock_context, authorized_event):
     assert response['statusCode'] == 400
 
 
-@patch('lambdas.invites_accept.handler.list_all_friends_for_user')
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_already_friends(
-    mock_get, mock_friends, mock_context, authorized_event
+@patch('lambdas.invites_decline.handler.decline_invite')
+@patch('lambdas.invites_decline.handler.get_invite')
+def test_invites_decline_race_conditional_fail(
+    mock_get, mock_decline, mock_context, authorized_event
 ):
     mock_get.return_value = {
         "inviteCode": "ABCDEFGH",
         "senderEmail": "alice@example.com",
         "expiresAt": _future_iso(),
     }
-    mock_friends.return_value = [
-        {"friendEmail": "alice@example.com", "status": "accepted"},
-    ]
-    event = _post_event(
-        authorized_event(email="bob@example.com"),
-        {"inviteCode": "ABCDEFGH"},
-    )
-    response = handler(event, mock_context)
-    assert response['statusCode'] == 409
-    body = json.loads(response['body'])
-    assert body['error']['error_code'] == "ALREADY_FRIENDS"
-
-
-@patch('lambdas.invites_accept.handler.list_all_friends_for_user')
-@patch('lambdas.invites_accept.handler.consume_invite')
-@patch('lambdas.invites_accept.handler.get_invite')
-def test_invites_accept_race_conditional_fail(
-    mock_get, mock_consume, mock_friends, mock_context, authorized_event
-):
-    mock_get.return_value = {
-        "inviteCode": "ABCDEFGH",
-        "senderEmail": "alice@example.com",
-        "expiresAt": _future_iso(),
-    }
-    mock_friends.return_value = []
-    mock_consume.side_effect = ClientError(
+    mock_decline.side_effect = ClientError(
         {"Error": {"Code": "ConditionalCheckFailedException", "Message": "consumed"}},
         "UpdateItem",
     )
@@ -222,3 +188,9 @@ def test_invites_accept_race_conditional_fail(
     assert response['statusCode'] == 410
     body = json.loads(response['body'])
     assert body['error']['error_code'] == "INVITE_UNAVAILABLE"
+
+
+def test_invites_decline_missing_invite_code(mock_context, authorized_event):
+    event = _post_event(authorized_event(email="bob@example.com"), {})
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 400

--- a/tests/test_invites_pending.py
+++ b/tests/test_invites_pending.py
@@ -1,0 +1,100 @@
+"""
+Tests for invites_pending lambda.
+
+Caller identity is sourced via `get_caller_email`, which prefers the per-user
+JWT context populated by the authorizer and falls back to the query-string
+`email` during the Track 0 -> Track 1 migration window. Both code paths are
+exercised below.
+"""
+
+import json
+from unittest.mock import patch
+
+from lambdas.invites_pending.handler import handler
+
+
+def _get_event(base_event):
+    return {
+        **base_event,
+        "httpMethod": "GET",
+        "path": "/invites/pending",
+    }
+
+
+# ============================================
+# Trusted authorizer-context path (per-user JWT)
+# ============================================
+
+@patch('lambdas.invites_pending.handler.list_invites_by_sender')
+def test_invites_pending_happy_path_context(
+    mock_list, mock_context, authorized_event
+):
+    mock_list.return_value = [
+        {
+            "inviteCode": "ABCDEFGH",
+            "senderEmail": "user@example.com",
+            "createdAt": "2026-04-01T00:00:00+00:00",
+            "expiresAt": "2026-05-01T00:00:00+00:00",
+        }
+    ]
+
+    event = _get_event(authorized_event(email="user@example.com"))
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == "user@example.com"
+    assert body['count'] == 1
+    assert body['invites'][0]['inviteCode'] == "ABCDEFGH"
+    assert body['invites'][0]['inviteUrl'].endswith("/invite/ABCDEFGH")
+    mock_list.assert_called_once_with("user@example.com", active_only=True)
+
+
+# ============================================
+# Legacy query-string fallback path (pre-migration clients)
+# ============================================
+
+@patch('lambdas.invites_pending.handler.list_invites_by_sender')
+def test_invites_pending_happy_path_fallback(
+    mock_list, mock_context, legacy_event
+):
+    mock_list.return_value = []
+
+    event = _get_event(legacy_event(email="user@example.com"))
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['email'] == "user@example.com"
+    assert body['count'] == 0
+    assert body['invites'] == []
+    mock_list.assert_called_once_with("user@example.com", active_only=True)
+
+
+# ============================================
+# Caller missing entirely -> 401 from helper
+# ============================================
+
+@patch('lambdas.invites_pending.handler.list_invites_by_sender')
+def test_invites_pending_missing_caller(mock_list, mock_context, legacy_event):
+    event = _get_event(legacy_event())
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 401
+    mock_list.assert_not_called()
+
+
+# ============================================
+# Empty invites list (caller via context)
+# ============================================
+
+@patch('lambdas.invites_pending.handler.list_invites_by_sender')
+def test_invites_pending_empty_list(mock_list, mock_context, authorized_event):
+    mock_list.return_value = []
+
+    event = _get_event(authorized_event(email="user@example.com"))
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['count'] == 0
+    assert body['invites'] == []


### PR DESCRIPTION
Closes #149

Sub-feature **(1d)** of the auth-identity epic (Track 1 — caller identity migration). Each of the 4 invites handlers now reads the caller's email from the per-user JWT authorizer context via `get_caller_email` (added in #145), with body / query-string fallback preserved by the helper for the migration window.

## Handlers migrated

- `lambdas/invites_accept/handler.py`
- `lambdas/invites_create/handler.py`
- `lambdas/invites_decline/handler.py`
- `lambdas/invites_pending/handler.py`

## Caller-vs-target audit

| Handler  | Caller field migrated | Target fields kept |
|----------|-----------------------|--------------------|
| accept   | `email` (accepter)    | `inviteCode` (body) |
| create   | `email` (sender)      | none — server generates the code |
| decline  | `email` (decliner)    | `inviteCode` (body) |
| pending  | `email` (caller)      | none — lists caller's own invites |

`senderEmail` is server-side state on the invite row, never request-supplied. No `inviteeEmail` exists in this domain — the system is deep-link-based.

## Tests

- `test_invites_accept.py` and `test_invites_create.py` rewritten to exercise the trusted-context path (`authorized_event` fixture) on the happy path plus a `legacy_event` fallback test. The pre-existing `missing_email` assertions now expect HTTP 401 (from `MissingCallerIdentityError`) instead of 400.
- `test_invites_decline.py` and `test_invites_pending.py` added (no test files existed) with happy path + fallback + 401 + domain-rule failure coverage.

## Test plan

- [x] `python -m pytest tests/test_invites_*.py` — 27 passed
- [x] `python -m pytest` (full suite) — 241 passed (was 225 baseline; +16 new invite tests)
- [ ] CloudWatch fallback WARN counts > 0 expected once deployed (clients haven't migrated yet — that's (1j)/(1k))