### PR TITLE
(2a) New /user/top-items endpoint with daily DDB cache

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -20,10 +20,11 @@ Each Lambda handles exactly ONE route or cron job:
 - `friends_reject` → POST /friends/reject
 - `friends_remove` → DELETE /friends/remove
 
-#### User API (3 lambdas)
+#### User API (4 lambdas)
 - `user_get` → GET /user/user-table
 - `user_update` → POST /user/user-table
 - `user_all` → GET /user/all
+- `user_top_items` → GET /user/top-items (live top tracks/artists/genres, daily DDB cache)
 
 #### Wrapped API (4 lambdas)
 - `wrapped_data_get` → GET /wrapped/data

--- a/lambdas/common/constants.py
+++ b/lambdas/common/constants.py
@@ -31,6 +31,7 @@ SHARE_COMMENTS_TABLE_NAME = os.environ.get('SHARE_COMMENTS_TABLE_NAME', '')
 SHARE_REACTIONS_TABLE_NAME = os.environ.get('SHARE_REACTIONS_TABLE_NAME', '')
 INVITES_TABLE_NAME = os.environ.get('INVITES_TABLE_NAME', '')
 DEVICE_TOKENS_TABLE_NAME = os.environ.get('DEVICE_TOKENS_TABLE_NAME', '')
+TOP_ITEMS_CACHE_TABLE_NAME = os.environ.get('TOP_ITEMS_CACHE_TABLE_NAME', '')
 
 # Cross-lambda invocation (backend-interactions-and-notifications sub-feature)
 NOTIFICATIONS_SEND_FUNCTION_NAME = os.environ.get('NOTIFICATIONS_SEND_FUNCTION_NAME', '')

--- a/lambdas/common/top_items_cache.py
+++ b/lambdas/common/top_items_cache.py
@@ -1,0 +1,161 @@
+"""
+Daily top-items cache helper.
+
+Backs the `/user/top-items` endpoint (epic Track 2 / sub-feature 2a). Spotify's
+`/me/top/*` is computed on a rolling daily window, so we cache one row per user
+per day to keep it to a single Spotify hit per user per UTC day (epic Q7).
+
+DDB native `TTL` eviction has up to 48h of lag, so we additionally gate on the
+`cachedAt` ISO timestamp inside `get_cached`. The `ttl` attribute is used purely
+as a janitor for inactive users — never as the freshness signal at read time.
+
+The underlying table is provisioned by sub-feature (2a-infra) in
+xomify-infrastructure. The constant `TOP_ITEMS_CACHE_TABLE_NAME` resolves the
+table name from the environment so this module is no-op-importable in tests
+even when no table exists.
+"""
+
+from datetime import datetime, time, timedelta, timezone
+from typing import Optional
+
+from boto3.dynamodb.conditions import Key  # noqa: F401  (kept for parity with other helpers)
+
+from lambdas.common.constants import TOP_ITEMS_CACHE_TABLE_NAME
+from lambdas.common.dynamo_helpers import dynamodb
+from lambdas.common.errors import DynamoDBError
+from lambdas.common.logger import get_logger
+
+log = get_logger(__file__)
+
+# Janitor TTL for inactive users — keep rows around for a week past the next
+# midnight boundary so a user who comes back the day after still benefits from
+# the previous-day cache being evicted *only* by the explicit handler-side
+# `cachedAt` gate, not by a race with TTL.
+_TTL_JANITOR_DAYS = 7
+
+
+def _today_utc_date():
+    """Return today's date in UTC. Indirected for ease of patching in tests."""
+    return datetime.now(timezone.utc).date()
+
+
+def _next_midnight_utc_epoch() -> int:
+    """Epoch seconds at the next UTC midnight from now."""
+    now = datetime.now(timezone.utc)
+    next_midnight = datetime.combine(
+        now.date() + timedelta(days=1), time.min, tzinfo=timezone.utc
+    )
+    return int(next_midnight.timestamp())
+
+
+def _parse_cached_at(value) -> Optional[datetime]:
+    """
+    Parse a stored cachedAt back into a tz-aware datetime, tolerating a
+    trailing 'Z' (which `datetime.fromisoformat` only accepts on >= 3.11) and
+    naive timestamps (assumed UTC).
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        normalized = value.rstrip("Z") if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def get_cached(email: str) -> Optional[dict]:
+    """
+    Return today's cached top items for `email`, or None on miss.
+
+    Returns the `{tracks, artists, genres}` payload exactly as it was stored
+    by `set_cached`. Returns None when:
+        - no row exists for the user
+        - the row exists but `cachedAt.date() < today_utc.date()`
+          (TTL hasn't fired yet but the row is stale by our day-bucket rule)
+        - the row exists but `cachedAt` is missing/malformed
+    """
+    if not email:
+        return None
+    try:
+        table = dynamodb.Table(TOP_ITEMS_CACHE_TABLE_NAME)
+        response = table.get_item(Key={"email": email})
+    except Exception as err:
+        log.error(f"top_items_cache.get_cached DDB error for {email}: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="get_cached",
+            table=TOP_ITEMS_CACHE_TABLE_NAME,
+        )
+
+    item = response.get("Item")
+    if not item:
+        log.info(f"top_items_cache miss email={email} reason=no_row")
+        return None
+
+    cached_at = _parse_cached_at(item.get("cachedAt"))
+    if cached_at is None:
+        log.info(f"top_items_cache miss email={email} reason=missing_cachedAt")
+        return None
+
+    if cached_at.date() < _today_utc_date():
+        log.info(
+            f"top_items_cache miss email={email} reason=stale "
+            f"cachedAt={cached_at.isoformat()}"
+        )
+        return None
+
+    payload = {
+        "tracks": item.get("tracks") or {},
+        "artists": item.get("artists") or {},
+        "genres": item.get("genres") or {},
+    }
+    log.info(f"top_items_cache hit email={email} cachedAt={cached_at.isoformat()}")
+    return payload
+
+
+def set_cached(email: str, top_items: dict) -> None:
+    """
+    Write `top_items` to the cache for `email`.
+
+    `top_items` is expected to be the `{tracks, artists, genres}` shape
+    returned by `Spotify.get_top_items_for_api()`. `cachedAt` is set to the
+    current UTC time; `ttl` is set to the next UTC-midnight boundary plus
+    `_TTL_JANITOR_DAYS` so DDB only purges the row well after our handler-side
+    freshness gate has stopped serving it.
+    """
+    if not email:
+        log.warning("top_items_cache.set_cached called with empty email; skipping")
+        return
+    if not isinstance(top_items, dict):
+        log.warning("top_items_cache.set_cached called with non-dict payload; skipping")
+        return
+
+    cached_at = datetime.now(timezone.utc).isoformat()
+    ttl_epoch = _next_midnight_utc_epoch() + (_TTL_JANITOR_DAYS * 24 * 3600)
+
+    item = {
+        "email": email,
+        "tracks": top_items.get("tracks") or {},
+        "artists": top_items.get("artists") or {},
+        "genres": top_items.get("genres") or {},
+        "cachedAt": cached_at,
+        "ttl": ttl_epoch,
+    }
+
+    try:
+        table = dynamodb.Table(TOP_ITEMS_CACHE_TABLE_NAME)
+        table.put_item(Item=item)
+    except Exception as err:
+        log.error(f"top_items_cache.set_cached DDB error for {email}: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="set_cached",
+            table=TOP_ITEMS_CACHE_TABLE_NAME,
+        )
+
+    log.info(
+        f"top_items_cache write email={email} cachedAt={cached_at} ttl={ttl_epoch}"
+    )

--- a/lambdas/user_top_items/handler.py
+++ b/lambdas/user_top_items/handler.py
@@ -1,0 +1,169 @@
+"""
+GET /user/top-items - Return the signed-in user's top tracks, artists, genres
+(live, daily-cached).
+
+Caller identity comes from the authorizer context (per-user JWT) — see
+`lambdas/common/utility_helpers.get_caller_email`. The endpoint is gated by the
+custom authorizer in production; if the email cannot be resolved the helper
+raises `MissingCallerIdentityError` (HTTP 401).
+
+Cache (sub-feature 2a):
+    - One DDB row per user keyed by email.
+    - Handler-side freshness gate is `cachedAt.date() == today_utc.date()`
+      (epic Q7) — DDB native TTL is a janitor only.
+    - On a hit we return immediately with no Spotify call.
+    - On a miss we fetch live from Spotify and write the cache only on a
+      *fully successful* response.
+
+Per-range partial failure:
+    Spotify can rate-limit or transiently fail any of the six (tracks +
+    artists) x (short_term, medium_term, long_term) calls. We isolate each
+    range so a single failure does not poison the whole response: the failing
+    range's value is `null` and the response carries `meta.failed_ranges` with
+    the union of failing range names. A partial response is NOT cached, so the
+    next call retries the failing ranges.
+"""
+
+import asyncio
+from typing import Any, Optional
+
+import aiohttp
+
+from lambdas.common.dynamo_helpers import get_user_table_data
+from lambdas.common.errors import handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.spotify import Spotify
+from lambdas.common.top_items_cache import get_cached, set_cached
+from lambdas.common.utility_helpers import get_caller_email, success_response
+
+log = get_logger(__file__)
+
+HANDLER = "user_top_items"
+
+_TIME_RANGES = ("short_term", "medium_term", "long_term")
+
+
+def _empty_top_items_skeleton() -> dict:
+    """Skeleton with every range present so the response shape is stable."""
+    return {
+        "tracks": {r: None for r in _TIME_RANGES},
+        "artists": {r: None for r in _TIME_RANGES},
+        "genres": {r: None for r in _TIME_RANGES},
+    }
+
+
+async def _safe_set_top_tracks(track_list) -> Optional[Exception]:
+    """Run `track_list.set_top_tracks()` and swallow the exception (return it)."""
+    try:
+        await track_list.set_top_tracks()
+        return None
+    except Exception as err:  # noqa: BLE001 - intentional per-range isolation
+        log.warning(
+            f"top_items per-range failure kind=tracks term={track_list.term} err={err}"
+        )
+        return err
+
+
+async def _safe_set_top_artists(artist_list) -> Optional[Exception]:
+    """Run `artist_list.set_top_artists()` and swallow the exception (return it)."""
+    try:
+        await artist_list.set_top_artists()
+        return None
+    except Exception as err:  # noqa: BLE001 - intentional per-range isolation
+        log.warning(
+            f"top_items per-range failure kind=artists term={artist_list.term} err={err}"
+        )
+        return err
+
+
+async def _fetch_top_items_with_partial_tolerance(user: dict) -> tuple[dict, list[str]]:
+    """
+    Fetch top items per-range, tolerating individual failures.
+
+    Returns:
+        (payload, failed_ranges)
+        - payload has the standard `{tracks, artists, genres}` shape with
+          `null` for any range that failed.
+        - failed_ranges is the union of failing range names across tracks
+          and artists (e.g. ["short_term", "medium_term"]). A failed
+          artists range also nulls out genres for that range, since genres
+          are derived from artists.
+    """
+    payload = _empty_top_items_skeleton()
+    failed_ranges: set[str] = set()
+
+    async with aiohttp.ClientSession() as session:
+        spotify = Spotify(user, session)
+        await spotify.aiohttp_initialize_top_items()
+
+        track_lists = {
+            "short_term": spotify.top_tracks_short,
+            "medium_term": spotify.top_tracks_medium,
+            "long_term": spotify.top_tracks_long,
+        }
+        artist_lists = {
+            "short_term": spotify.top_artists_short,
+            "medium_term": spotify.top_artists_medium,
+            "long_term": spotify.top_artists_long,
+        }
+
+        # Fire all six requests in parallel; ordering matches our terms tuples
+        # so we can map results back to range names.
+        track_tasks = [_safe_set_top_tracks(track_lists[r]) for r in _TIME_RANGES]
+        artist_tasks = [_safe_set_top_artists(artist_lists[r]) for r in _TIME_RANGES]
+        track_errors, artist_errors = await asyncio.gather(
+            asyncio.gather(*track_tasks),
+            asyncio.gather(*artist_tasks),
+        )
+
+        for term, err in zip(_TIME_RANGES, track_errors):
+            if err is None:
+                payload["tracks"][term] = track_lists[term].track_list
+            else:
+                failed_ranges.add(term)
+
+        for term, err in zip(_TIME_RANGES, artist_errors):
+            if err is None:
+                payload["artists"][term] = artist_lists[term].artist_list
+                payload["genres"][term] = artist_lists[term].top_genres
+            else:
+                failed_ranges.add(term)
+                # Genres are derived from artists, so null them too.
+
+    return payload, sorted(failed_ranges)
+
+
+@handle_errors(HANDLER)
+def handler(event: dict, context: Any) -> dict:
+    caller_email = get_caller_email(event)
+
+    cached = get_cached(caller_email)
+    if cached is not None:
+        log.info(f"user_top_items cache=hit email={caller_email}")
+        return success_response(cached)
+
+    log.info(f"user_top_items cache=miss email={caller_email}")
+    user = get_user_table_data(caller_email)
+
+    payload, failed_ranges = asyncio.run(
+        _fetch_top_items_with_partial_tolerance(user)
+    )
+
+    if not failed_ranges:
+        try:
+            set_cached(caller_email, payload)
+        except Exception as err:  # noqa: BLE001 - cache write failure must not 500
+            log.warning(
+                f"user_top_items cache write failed email={caller_email} err={err}"
+            )
+    else:
+        log.info(
+            f"user_top_items partial response email={caller_email} "
+            f"failed_ranges={failed_ranges} (skipping cache write)"
+        )
+
+    response_body: dict = dict(payload)
+    if failed_ranges:
+        response_body["meta"] = {"failed_ranges": failed_ranges}
+
+    return success_response(response_body)

--- a/tests/test_user_top_items.py
+++ b/tests/test_user_top_items.py
@@ -1,0 +1,410 @@
+"""
+Tests for user_top_items lambda.
+
+Covers (epic Track 2 / sub-feature 2a):
+- Cache hit short-circuits the Spotify call.
+- Cache miss + all-success fetches live, writes the cache, returns full data.
+- Cache miss + one-range failure returns a partial payload with
+  `meta.failed_ranges` and DOES NOT write the cache.
+- Missing caller identity (no JWT context, no fallback) returns structured 401.
+- TTL boundary on `cachedAt`:
+    - cachedAt today UTC -> hit
+    - cachedAt yesterday UTC -> miss
+- DDB cache table I/O is mocked (the table is provisioned by 2a-infra in a
+  separate repo and is not available locally).
+"""
+
+import asyncio
+import json
+from datetime import datetime, time, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lambdas.common import top_items_cache
+from lambdas.user_top_items.handler import (
+    _empty_top_items_skeleton,
+    _fetch_top_items_with_partial_tolerance,
+    handler,
+)
+
+
+# ============================================
+# Fixtures
+# ============================================
+
+
+@pytest.fixture
+def cached_payload():
+    return {
+        "tracks": {
+            "short_term": [{"id": "t1", "name": "Cached Song"}],
+            "medium_term": [],
+            "long_term": [],
+        },
+        "artists": {
+            "short_term": [{"id": "a1", "name": "Cached Artist"}],
+            "medium_term": [],
+            "long_term": [],
+        },
+        "genres": {
+            "short_term": {"pop": 5},
+            "medium_term": {},
+            "long_term": {},
+        },
+    }
+
+
+@pytest.fixture
+def live_payload():
+    """Mirror of what `Spotify.get_top_items_for_api()` returns on success."""
+    return {
+        "tracks": {
+            "short_term": [{"id": "ts", "name": "Live Short Song"}],
+            "medium_term": [{"id": "tm", "name": "Live Medium Song"}],
+            "long_term": [{"id": "tl", "name": "Live Long Song"}],
+        },
+        "artists": {
+            "short_term": [{"id": "as", "name": "Live Short Artist"}],
+            "medium_term": [{"id": "am", "name": "Live Medium Artist"}],
+            "long_term": [{"id": "al", "name": "Live Long Artist"}],
+        },
+        "genres": {
+            "short_term": {"pop": 10},
+            "medium_term": {"rock": 5},
+            "long_term": {"jazz": 3},
+        },
+    }
+
+
+# ============================================
+# Handler-level tests
+# ============================================
+
+
+@patch("lambdas.user_top_items.handler.set_cached")
+@patch("lambdas.user_top_items.handler._fetch_top_items_with_partial_tolerance")
+@patch("lambdas.user_top_items.handler.get_user_table_data")
+@patch("lambdas.user_top_items.handler.get_cached")
+def test_cache_hit_returns_cached_without_spotify_call(
+    mock_get_cached,
+    mock_get_user,
+    mock_fetch,
+    mock_set_cached,
+    authorized_event,
+    mock_context,
+    cached_payload,
+):
+    mock_get_cached.return_value = cached_payload
+
+    response = handler(authorized_event(), mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["tracks"]["short_term"][0]["name"] == "Cached Song"
+    assert "meta" not in body  # no failed ranges
+    mock_get_user.assert_not_called()
+    mock_fetch.assert_not_called()
+    mock_set_cached.assert_not_called()
+
+
+@patch("lambdas.user_top_items.handler.set_cached")
+@patch("lambdas.user_top_items.handler._fetch_top_items_with_partial_tolerance")
+@patch("lambdas.user_top_items.handler.get_user_table_data")
+@patch("lambdas.user_top_items.handler.get_cached")
+def test_cache_miss_full_success_writes_cache_and_returns_full(
+    mock_get_cached,
+    mock_get_user,
+    mock_fetch,
+    mock_set_cached,
+    authorized_event,
+    mock_context,
+    sample_user,
+    live_payload,
+):
+    mock_get_cached.return_value = None
+    mock_get_user.return_value = sample_user
+    mock_fetch.return_value = (live_payload, [])
+
+    response = handler(authorized_event(), mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["tracks"]["short_term"][0]["name"] == "Live Short Song"
+    assert body["artists"]["medium_term"][0]["name"] == "Live Medium Artist"
+    assert body["genres"]["long_term"]["jazz"] == 3
+    assert "meta" not in body
+
+    mock_get_user.assert_called_once_with("test@example.com")
+    mock_fetch.assert_called_once_with(sample_user)
+    mock_set_cached.assert_called_once_with("test@example.com", live_payload)
+
+
+@patch("lambdas.user_top_items.handler.set_cached")
+@patch("lambdas.user_top_items.handler._fetch_top_items_with_partial_tolerance")
+@patch("lambdas.user_top_items.handler.get_user_table_data")
+@patch("lambdas.user_top_items.handler.get_cached")
+def test_cache_miss_partial_failure_returns_meta_and_skips_cache_write(
+    mock_get_cached,
+    mock_get_user,
+    mock_fetch,
+    mock_set_cached,
+    authorized_event,
+    mock_context,
+    sample_user,
+):
+    mock_get_cached.return_value = None
+    mock_get_user.return_value = sample_user
+
+    partial_payload = {
+        "tracks": {
+            "short_term": None,
+            "medium_term": [{"id": "tm"}],
+            "long_term": [{"id": "tl"}],
+        },
+        "artists": {
+            "short_term": [{"id": "as"}],
+            "medium_term": [{"id": "am"}],
+            "long_term": [{"id": "al"}],
+        },
+        "genres": {
+            "short_term": {"pop": 1},
+            "medium_term": {"rock": 1},
+            "long_term": {"jazz": 1},
+        },
+    }
+    mock_fetch.return_value = (partial_payload, ["short_term"])
+
+    response = handler(authorized_event(), mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["tracks"]["short_term"] is None
+    assert body["tracks"]["medium_term"][0]["id"] == "tm"
+    assert body["meta"]["failed_ranges"] == ["short_term"]
+
+    # Critical: partial failure must NOT write to cache so a retry can fix it.
+    mock_set_cached.assert_not_called()
+
+
+def test_missing_caller_context_returns_401(api_gateway_event, mock_context):
+    """No authorizer context, no email in query/body -> structured 401."""
+    response = handler(api_gateway_event, mock_context)
+
+    assert response["statusCode"] == 401
+    body = json.loads(response["body"])
+    assert body["error"]["status"] == 401
+    assert body["error"].get("field") == "email"
+
+
+# ============================================
+# TTL boundary (cache freshness gate, epic Q7)
+# ============================================
+
+
+def _ddb_item_with_cached_at(cached_at_iso: str) -> dict:
+    return {
+        "email": "test@example.com",
+        "tracks": {"short_term": [], "medium_term": [], "long_term": []},
+        "artists": {"short_term": [], "medium_term": [], "long_term": []},
+        "genres": {"short_term": {}, "medium_term": {}, "long_term": {}},
+        "cachedAt": cached_at_iso,
+        "ttl": 9999999999,
+    }
+
+
+@patch("lambdas.common.top_items_cache.dynamodb")
+def test_get_cached_today_utc_is_hit(mock_dynamo):
+    today_iso = datetime.now(timezone.utc).isoformat()
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {"Item": _ddb_item_with_cached_at(today_iso)}
+    mock_dynamo.Table.return_value = mock_table
+
+    result = top_items_cache.get_cached("test@example.com")
+
+    assert result is not None
+    assert "tracks" in result and "artists" in result and "genres" in result
+
+
+@patch("lambdas.common.top_items_cache.dynamodb")
+def test_get_cached_yesterday_utc_is_miss(mock_dynamo):
+    """Even though the row exists, cachedAt < today_utc.date() must miss
+    so we never serve a stale day to the client (epic Q7)."""
+    yesterday_midday = datetime.combine(
+        datetime.now(timezone.utc).date() - timedelta(days=1),
+        time(hour=12),
+        tzinfo=timezone.utc,
+    )
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": _ddb_item_with_cached_at(yesterday_midday.isoformat())
+    }
+    mock_dynamo.Table.return_value = mock_table
+
+    result = top_items_cache.get_cached("test@example.com")
+
+    assert result is None
+
+
+@patch("lambdas.common.top_items_cache.dynamodb")
+def test_get_cached_no_row_is_miss(mock_dynamo):
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {}
+    mock_dynamo.Table.return_value = mock_table
+
+    assert top_items_cache.get_cached("test@example.com") is None
+
+
+@patch("lambdas.common.top_items_cache.dynamodb")
+def test_get_cached_missing_cached_at_is_miss(mock_dynamo):
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {
+            "email": "test@example.com",
+            "tracks": {},
+            "artists": {},
+            "genres": {},
+        }
+    }
+    mock_dynamo.Table.return_value = mock_table
+
+    assert top_items_cache.get_cached("test@example.com") is None
+
+
+@patch("lambdas.common.top_items_cache.dynamodb")
+def test_set_cached_writes_full_item_with_ttl_and_cached_at(mock_dynamo, live_payload):
+    mock_table = MagicMock()
+    mock_dynamo.Table.return_value = mock_table
+
+    top_items_cache.set_cached("test@example.com", live_payload)
+
+    mock_table.put_item.assert_called_once()
+    written_item = mock_table.put_item.call_args.kwargs["Item"]
+    assert written_item["email"] == "test@example.com"
+    assert written_item["tracks"] == live_payload["tracks"]
+    assert written_item["artists"] == live_payload["artists"]
+    assert written_item["genres"] == live_payload["genres"]
+    assert isinstance(written_item["cachedAt"], str) and written_item["cachedAt"]
+    # TTL is at least the next UTC midnight; sanity check it's in the future.
+    now_epoch = int(datetime.now(timezone.utc).timestamp())
+    assert written_item["ttl"] > now_epoch
+
+
+# ============================================
+# Per-range partial-tolerance unit tests
+# ============================================
+
+
+def _fake_track_list(term: str, items=None, raise_err: Exception | None = None):
+    """Build a stand-in for `TrackList` with the attributes the handler reads."""
+    fake = MagicMock()
+    fake.term = term
+    fake.track_list = items if items is not None else [{"id": f"track-{term}"}]
+    if raise_err is None:
+        fake.set_top_tracks = AsyncMock(return_value=None)
+    else:
+        fake.set_top_tracks = AsyncMock(side_effect=raise_err)
+    return fake
+
+
+def _fake_artist_list(
+    term: str, items=None, genres=None, raise_err: Exception | None = None
+):
+    fake = MagicMock()
+    fake.term = term
+    fake.artist_list = items if items is not None else [{"id": f"artist-{term}"}]
+    fake.top_genres = genres if genres is not None else {term: 1}
+    if raise_err is None:
+        fake.set_top_artists = AsyncMock(return_value=None)
+    else:
+        fake.set_top_artists = AsyncMock(side_effect=raise_err)
+    return fake
+
+
+def _build_fake_spotify(track_specs: dict, artist_specs: dict) -> MagicMock:
+    """track_specs / artist_specs map term -> Exception | None (None = success)."""
+    fake = MagicMock()
+    fake.aiohttp_initialize_top_items = AsyncMock(return_value=None)
+    fake.top_tracks_short = _fake_track_list("short_term", raise_err=track_specs.get("short_term"))
+    fake.top_tracks_medium = _fake_track_list("medium_term", raise_err=track_specs.get("medium_term"))
+    fake.top_tracks_long = _fake_track_list("long_term", raise_err=track_specs.get("long_term"))
+    fake.top_artists_short = _fake_artist_list("short_term", raise_err=artist_specs.get("short_term"))
+    fake.top_artists_medium = _fake_artist_list("medium_term", raise_err=artist_specs.get("medium_term"))
+    fake.top_artists_long = _fake_artist_list("long_term", raise_err=artist_specs.get("long_term"))
+    return fake
+
+
+@patch("lambdas.user_top_items.handler.aiohttp.ClientSession")
+@patch("lambdas.user_top_items.handler.Spotify")
+def test_fetch_full_success_returns_no_failed_ranges(mock_spotify_cls, mock_session_cls, sample_user):
+    mock_spotify_cls.return_value = _build_fake_spotify({}, {})
+    # aiohttp.ClientSession() is used as an async context manager.
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session_cls.return_value = mock_session
+
+    payload, failed = asyncio.run(_fetch_top_items_with_partial_tolerance(sample_user))
+
+    assert failed == []
+    for term in ("short_term", "medium_term", "long_term"):
+        assert payload["tracks"][term] is not None
+        assert payload["artists"][term] is not None
+        assert payload["genres"][term] is not None
+
+
+@patch("lambdas.user_top_items.handler.aiohttp.ClientSession")
+@patch("lambdas.user_top_items.handler.Spotify")
+def test_fetch_one_track_range_failure_records_only_that_range(
+    mock_spotify_cls, mock_session_cls, sample_user
+):
+    mock_spotify_cls.return_value = _build_fake_spotify(
+        {"short_term": RuntimeError("Spotify 429")}, {}
+    )
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session_cls.return_value = mock_session
+
+    payload, failed = asyncio.run(_fetch_top_items_with_partial_tolerance(sample_user))
+
+    assert failed == ["short_term"]
+    assert payload["tracks"]["short_term"] is None
+    assert payload["tracks"]["medium_term"] is not None
+    # Artists for short_term still succeeded -> populated; genres also populated.
+    assert payload["artists"]["short_term"] is not None
+    assert payload["genres"]["short_term"] is not None
+
+
+@patch("lambdas.user_top_items.handler.aiohttp.ClientSession")
+@patch("lambdas.user_top_items.handler.Spotify")
+def test_fetch_artist_failure_nulls_genres_for_that_range(
+    mock_spotify_cls, mock_session_cls, sample_user
+):
+    mock_spotify_cls.return_value = _build_fake_spotify(
+        {}, {"medium_term": RuntimeError("Spotify timeout")}
+    )
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session_cls.return_value = mock_session
+
+    payload, failed = asyncio.run(_fetch_top_items_with_partial_tolerance(sample_user))
+
+    assert failed == ["medium_term"]
+    assert payload["artists"]["medium_term"] is None
+    assert payload["genres"]["medium_term"] is None
+    assert payload["tracks"]["medium_term"] is not None  # tracks succeeded
+
+
+# ============================================
+# Skeleton sanity
+# ============================================
+
+
+def test_empty_top_items_skeleton_shape():
+    skeleton = _empty_top_items_skeleton()
+    assert set(skeleton.keys()) == {"tracks", "artists", "genres"}
+    for kind in ("tracks", "artists", "genres"):
+        assert set(skeleton[kind].keys()) == {"short_term", "medium_term", "long_term"}
+        assert all(v is None for v in skeleton[kind].values())


### PR DESCRIPTION
Closes #165

Sub-feature **(2a)** of the auth-identity-and-live-top-items epic.

## Summary
- New `GET /user/top-items` lambda that returns the signed-in user's top tracks, artists, and genres for all three Spotify time ranges, with a one-row-per-user-per-UTC-day DDB cache.
- Caller email is sourced from the trusted authorizer context via `get_caller_email` (no caller email accepted from the request).
- Per-range partial-failure tolerance: a Spotify rate-limit / network error on any of the six (tracks + artists) x (short_term, medium_term, long_term) calls returns the surviving ranges with the failed range as `null` and `meta.failed_ranges` listing the failure(s). Partial responses are NOT cached so a retry can heal them.
- DDB native TTL has up to 48h eviction lag, so `get_cached` additionally gates on `cachedAt.date() == today_utc.date()` (epic Q7). The `ttl` attribute is set to next UTC midnight + 7 days, used purely as a janitor for inactive users.

## Files changed
- `lambdas/common/top_items_cache.py` -- `get_cached` / `set_cached` helpers.
- `lambdas/user_top_items/handler.py` -- handler + per-range partial-tolerance fetcher.
- `lambdas/user_top_items/__init__.py` -- empty package marker.
- `lambdas/common/constants.py` -- adds `TOP_ITEMS_CACHE_TABLE_NAME`.
- `tests/test_user_top_items.py` -- 13 tests covering cache hit, cache miss with full success, cache miss with partial failure, missing-context 401, TTL boundary today vs yesterday, set/get DDB shape, and per-range tolerance combinations.
- `DEPLOYMENT_GUIDE.md` -- adds `user_top_items` to the User API list.

## Plans
- Epic plan: `docs/features/auth-identity-and-live-top-items/PLAN.md`
- Sub-feature stub: `docs/features/user-top-items-endpoint/PLAN.md`

## Important deploy note
This PR's deploy will fail at runtime until sub-feature **(2a-infra)** in `xomify-infrastructure` provisions the DDB table (`TOP_ITEMS_CACHE_TABLE_NAME`), the IAM policy, and the `/user/top-items` API Gateway route. That is expected: the lambda artifact is ready to ship but unreachable until the infra side lands. Do not merge until (2a-infra) is queued.

## Test plan
- [x] `pytest tests/test_user_top_items.py -xvs` -- 13 new tests pass locally.
- [x] `pytest -x` -- full suite passes (238 tests, +13 from baseline 225).
- [ ] After (2a-infra) apply: smoke `curl GET /user/top-items` with a per-user JWT in CloudWatch -- expect `cache=miss` then `cache=hit` on second call same UTC day.
- [ ] CloudWatch shows no fallback WARN logs from `get_caller_email` once iOS / web move to per-user JWTs.

## Out of scope
- DDB table, API Gateway route, IAM, lambda Terraform resource -- (2a-infra).
- iOS / Angular wire-up -- (2c) / (2b).