### PR TITLE
(1c) Migrate shares handlers (11) to caller-identity helper

### DIFF
--- a/lambdas/shares_comments_create/handler.py
+++ b/lambdas/shares_comments_create/handler.py
@@ -3,10 +3,13 @@ POST /shares/comments - Create a comment on a share.
 
 Body schema:
     {
-        "email":   "viewer@...",
         "shareId": "<uuid>",
         "body":    "comment text (<= 500 chars)"
     }
+
+Caller identity is sourced from `requestContext.authorizer.email` via
+`get_caller_email`; legacy callers may still send `email` in the body
+during the Track 0 -> Track 1 migration window (see auth-identity epic).
 
 Returns the persisted comment row, hydrated with displayName + avatar so
 the iOS client can render it without a follow-up profile fetch.
@@ -24,6 +27,7 @@ from lambdas.common.utility_helpers import (
     success_response,
     parse_body,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import get_share
 from lambdas.common.share_comments_dynamo import create_comment
@@ -39,9 +43,9 @@ BODY_MAX_LEN = 500
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, "email", "shareId", "body")
+    require_fields(body, "shareId", "body")
 
-    email: str = body.get("email")
+    email: str = get_caller_email(event)
     share_id: str = body.get("shareId")
     text: str = body.get("body")
 

--- a/lambdas/shares_comments_delete/handler.py
+++ b/lambdas/shares_comments_delete/handler.py
@@ -3,10 +3,12 @@ DELETE /shares/comments - Hard-delete a comment.
 
 Body schema:
     {
-        "email":     "viewer@...",
         "shareId":   "<uuid>",
         "commentId": "<uuid>"
     }
+
+Caller identity comes from `requestContext.authorizer.email`; the helper
+keeps a body/query fallback during the Track 0 -> Track 1 migration.
 
 Authorization:
 - Comment author OR share author may delete.
@@ -27,6 +29,7 @@ from lambdas.common.utility_helpers import (
     success_response,
     parse_body,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import get_share
 from lambdas.common.share_comments_dynamo import get_comment, delete_comment
@@ -39,9 +42,9 @@ HANDLER = "shares_comments_delete"
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, "email", "shareId", "commentId")
+    require_fields(body, "shareId", "commentId")
 
-    email: str = body.get("email")
+    email: str = get_caller_email(event)
     share_id: str = body.get("shareId")
     comment_id: str = body.get("commentId")
 

--- a/lambdas/shares_comments_list/handler.py
+++ b/lambdas/shares_comments_list/handler.py
@@ -2,10 +2,13 @@
 GET /shares/comments - Paginated list of comments on a share, newest first.
 
 Query params:
-    email    (required) - viewer email (used for visibility gate)
     shareId  (required) - parent share
     limit    (optional) - page size, default 20, capped at 100
     before   (optional) - ISO8601 createdAt cursor; only items strictly older
+
+Caller (viewer) email is sourced from `requestContext.authorizer.email`
+via `get_caller_email`; legacy callers may still pass `email` in the
+query string during the Track 0 -> Track 1 migration window.
 
 Response:
     {
@@ -29,6 +32,7 @@ from lambdas.common.utility_helpers import (
     success_response,
     get_query_params,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import get_share
 from lambdas.common.share_comments_dynamo import list_comments
@@ -74,9 +78,9 @@ def _parse_limit(raw):
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, "email", "shareId")
+    require_fields(params, "shareId")
 
-    viewer_email: str = params.get("email")
+    viewer_email: str = get_caller_email(event)
     share_id: str = params.get("shareId")
     limit = _parse_limit(params.get("limit"))
     before = params.get("before")

--- a/lambdas/shares_create/handler.py
+++ b/lambdas/shares_create/handler.py
@@ -13,7 +13,12 @@ Multi-target semantics (v2):
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError, AuthorizationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.shares_dynamo import create_share
 from lambdas.common.group_members_dynamo import is_member_of_group
 
@@ -88,7 +93,6 @@ def handler(event, context):
     body = parse_body(event)
     require_fields(
         body,
-        'email',
         'trackId',
         'trackUri',
         'trackName',
@@ -97,7 +101,7 @@ def handler(event, context):
         'albumArtUrl',
     )
 
-    email = body.get('email')
+    email = get_caller_email(event)
     track_id = body.get('trackId')
     track_uri = body.get('trackUri')
     track_name = body.get('trackName')

--- a/lambdas/shares_delete/handler.py
+++ b/lambdas/shares_delete/handler.py
@@ -1,11 +1,15 @@
 """
 /shares/delete - Delete a share by id (owner only).
 
-iOS posts a JSON body `{email, shareId, sharedAt}` even though the API
-Gateway route is wired as DELETE; we accept identifiers from either the
-request body or the query string so the lambda is robust to whichever
-shape API Gateway forwards. `sharedAt` is accepted for forward compat
-but unused — the shares table is keyed on shareId alone.
+iOS posts a JSON body `{shareId, sharedAt}` even though the API Gateway
+route is wired as DELETE; we accept `shareId` from either the body or
+the query string so the lambda is robust to whichever shape API Gateway
+forwards. `sharedAt` is accepted for forward compat but unused — the
+shares table is keyed on shareId alone.
+
+Caller identity is sourced from `requestContext.authorizer.email` via
+`get_caller_email`; legacy callers may still send `email` in the body
+or query during the Track 0 -> Track 1 migration window.
 """
 
 from lambdas.common.logger import get_logger
@@ -19,6 +23,7 @@ from lambdas.common.utility_helpers import (
     get_query_params,
     parse_body,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import get_share, delete_share
 
@@ -27,28 +32,28 @@ log = get_logger(__file__)
 HANDLER = 'shares_delete'
 
 
-def _extract_identifiers(event: dict) -> dict:
-    """Pull email + shareId from body, falling back to queryStringParameters.
+def _extract_share_id(event: dict) -> dict:
+    """Pull shareId from body, falling back to queryStringParameters.
 
-    The previous version read from query params only. iOS sends them in the
-    JSON body — so the lambda silently 400'd or ran with empty params,
-    which is what was reported as "delete returns OK but doesn't delete".
+    The previous version read from query params only. iOS sends shareId
+    in the JSON body — so the lambda silently 400'd or ran with empty
+    params, which is what was reported as "delete returns OK but doesn't
+    delete".
     """
     body = parse_body(event) or {}
     params = get_query_params(event) or {}
 
     return {
-        'email': body.get('email') or params.get('email'),
         'shareId': body.get('shareId') or params.get('shareId'),
     }
 
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    identifiers = _extract_identifiers(event)
-    require_fields(identifiers, 'email', 'shareId')
+    identifiers = _extract_share_id(event)
+    require_fields(identifiers, 'shareId')
 
-    email = identifiers['email']
+    email = get_caller_email(event)
     share_id = identifiers['shareId']
 
     log.info(f"User {email} requesting delete of share {share_id}")

--- a/lambdas/shares_detail/handler.py
+++ b/lambdas/shares_detail/handler.py
@@ -2,13 +2,15 @@
 GET /shares/detail - Full detail view for a single share.
 
 Query params:
-    email    (required) - viewer email (used for viewer-specific enrichment +
-                           scoping friendRatings to the viewer's friends)
     shareId  (required) - the share to load
     sharedAt (optional) - accepted for forward compat; unused, since the
                            shares table is keyed on shareId alone in v1
     sharedBy (optional) - accepted for forward compat; unused, since the
                            share row itself carries the author email
+
+Caller (viewer) email is sourced from `requestContext.authorizer.email`
+via `get_caller_email`; legacy callers may still pass `email` in the
+query string during the Track 0 -> Track 1 migration window.
 
 Response:
     {
@@ -43,6 +45,7 @@ from lambdas.common.utility_helpers import (
     success_response,
     get_query_params,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import get_share
 from lambdas.common.interactions_dynamo import (
@@ -192,9 +195,9 @@ def _enrich_share(share: dict[str, Any], viewer_email: str) -> dict[str, Any]:
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email', 'shareId')
+    require_fields(params, 'shareId')
 
-    viewer_email = params.get('email')
+    viewer_email = get_caller_email(event)
     share_id = params.get('shareId')
     # Accepted for forward compat with iOS payloads; not required because
     # the shares table is keyed on shareId alone and the row carries the

--- a/lambdas/shares_feed/handler.py
+++ b/lambdas/shares_feed/handler.py
@@ -14,7 +14,11 @@ Visibility rules (v2):
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    get_caller_email,
+)
 from lambdas.common.friendships_dynamo import list_all_friends_for_user
 from lambdas.common.group_members_dynamo import list_members_of_group
 from lambdas.common.shares_dynamo import query_feed_for_emails
@@ -99,9 +103,8 @@ def _enrich(share: dict, viewer_email: str) -> dict:
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, 'email')
 
-    email = params.get('email')
+    email = get_caller_email(event)
     group_id = params.get('groupId')
     limit = _parse_limit(params.get('limit'))
     before = params.get('before')

--- a/lambdas/shares_react/handler.py
+++ b/lambdas/shares_react/handler.py
@@ -3,11 +3,14 @@ POST /shares/react - React to a share.
 
 Body schema:
     {
-        "email":   "viewer@...",
         "shareId": "<uuid>",
         "action":  "queued" | "rated" | "unqueued" | "unrated",
         "rating":  1.0-5.0 (required when action == "rated")
     }
+
+Caller (viewer) email is sourced from `requestContext.authorizer.email`
+via `get_caller_email`; legacy callers may still send `email` in the
+body during the Track 0 -> Track 1 migration window.
 
 Flow:
     1. Validate body + look up parent share
@@ -28,7 +31,12 @@ import boto3
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, NotFoundError, ValidationError
-from lambdas.common.utility_helpers import success_response, parse_body, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    parse_body,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.constants import NOTIFICATIONS_SEND_FUNCTION_NAME
 from lambdas.common.interactions_dynamo import (
     VALID_ACTIONS,
@@ -111,9 +119,9 @@ def _invoke_threshold_push(
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, "email", "shareId", "action")
+    require_fields(body, "shareId", "action")
 
-    email = body.get("email")
+    email = get_caller_email(event)
     share_id = body.get("shareId")
     action = body.get("action")
     raw_rating = body.get("rating")

--- a/lambdas/shares_reactions_list/handler.py
+++ b/lambdas/shares_reactions_list/handler.py
@@ -2,8 +2,11 @@
 GET /shares/reactions - Per-emoji reaction counts + the viewer's own taps.
 
 Query params:
-    email    (required) - viewer email
     shareId  (required) - parent share
+
+Caller (viewer) email is sourced from `requestContext.authorizer.email`
+via `get_caller_email`; legacy callers may still send `email` in the
+query string during the Track 0 -> Track 1 migration window.
 
 Response:
     {
@@ -20,6 +23,7 @@ from lambdas.common.utility_helpers import (
     success_response,
     get_query_params,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import get_share
 from lambdas.common.share_reactions_dynamo import build_reaction_summary
@@ -33,9 +37,9 @@ HANDLER = "shares_reactions_list"
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    require_fields(params, "email", "shareId")
+    require_fields(params, "shareId")
 
-    viewer_email: str = params.get("email")
+    viewer_email: str = get_caller_email(event)
     share_id: str = params.get("shareId")
 
     share = get_share(share_id)

--- a/lambdas/shares_reactions_toggle/handler.py
+++ b/lambdas/shares_reactions_toggle/handler.py
@@ -3,10 +3,13 @@ POST /shares/reactions - Toggle an emoji reaction on a share.
 
 Body schema:
     {
-        "email":    "viewer@...",
         "shareId":  "<uuid>",
         "reaction": "fire" | "heart" | "laugh" | "mind_blown" | "sad" | "thumbs_up"
     }
+
+Caller (viewer) email is sourced from `requestContext.authorizer.email`
+via `get_caller_email`; legacy callers may still send `email` in the
+body during the Track 0 -> Track 1 migration window.
 
 Behavior:
 - If the (user, share, reaction) row exists -> delete it, return active=false.
@@ -39,6 +42,7 @@ from lambdas.common.utility_helpers import (
     success_response,
     parse_body,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import get_share
 from lambdas.common.share_reactions_dynamo import (
@@ -58,9 +62,9 @@ HANDLER = "shares_reactions_toggle"
 @handle_errors(HANDLER)
 def handler(event, context):
     body = parse_body(event)
-    require_fields(body, "email", "shareId", "reaction")
+    require_fields(body, "shareId", "reaction")
 
-    email: str = body.get("email")
+    email: str = get_caller_email(event)
     share_id: str = body.get("shareId")
     reaction = body.get("reaction")
 

--- a/lambdas/shares_user/handler.py
+++ b/lambdas/shares_user/handler.py
@@ -4,6 +4,13 @@ GET /shares/user - List shares authored by a specific user (no friendship gate i
 Profile view only surfaces PUBLIC shares — group-only shares stay scoped to
 their group feeds and are not leaked via the author's profile. Legacy rows
 (no `public` field) are treated as public so older data keeps flowing.
+
+Caller (requester) email is sourced from `requestContext.authorizer.email`
+via `get_caller_email`; legacy callers may still pass `email` in the
+query string during the Track 0 -> Track 1 migration window.
+
+`targetEmail` is the AUTHOR being viewed and stays as a query param —
+it is NOT the caller.
 """
 
 from lambdas.common.logger import get_logger
@@ -12,6 +19,7 @@ from lambdas.common.utility_helpers import (
     success_response,
     get_query_params,
     require_fields,
+    get_caller_email,
 )
 from lambdas.common.shares_dynamo import list_shares_for_user
 from lambdas.common.interactions_dynamo import build_enrichment
@@ -56,10 +64,10 @@ def _parse_limit(raw: str | None) -> int:
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
-    # email is the requester (kept for future friendship gating); targetEmail is the author
-    require_fields(params, 'email', 'targetEmail')
+    # targetEmail is the author whose profile is being viewed (NOT the caller).
+    require_fields(params, 'targetEmail')
 
-    email = params.get('email')
+    email = get_caller_email(event)
     target_email = params.get('targetEmail')
     limit = _parse_limit(params.get('limit'))
     before = params.get('before')

--- a/tests/test_shares_comments_create.py
+++ b/tests/test_shares_comments_create.py
@@ -7,6 +7,7 @@ Covers:
 - missing required fields -> 400
 - missing share -> 404
 - group-only share, viewer not a member -> 404
+- missing caller identity -> 401
 """
 
 from __future__ import annotations
@@ -17,13 +18,14 @@ from unittest.mock import patch
 from lambdas.shares_comments_create.handler import handler
 
 
-def _event(api_gateway_event, body):
-    return {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/shares/comments",
-        "body": json.dumps(body),
-    }
+def _event(authorized_event, body, email="bob@example.com"):
+    """Build an authorized event with the given JSON body."""
+    return authorized_event(
+        email=email,
+        httpMethod="POST",
+        path="/shares/comments",
+        body=json.dumps(body),
+    )
 
 
 def _share(share_id="share-1", author="alice@example.com", public=True, group_ids=None):
@@ -42,7 +44,7 @@ def _share(share_id="share-1", author="alice@example.com", public=True, group_id
 @patch("lambdas.shares_comments_create.handler.create_comment")
 @patch("lambdas.shares_comments_create.handler.get_share")
 def test_happy_path(
-    mock_get_share, mock_create, mock_users, mock_context, api_gateway_event
+    mock_get_share, mock_create, mock_users, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_create.return_value = {
@@ -61,8 +63,8 @@ def test_happy_path(
         }
     }
 
-    body = {"email": "bob@example.com", "shareId": "share-1", "body": "fire track"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "body": "fire track"}
+    response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
 
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
@@ -80,10 +82,10 @@ def test_happy_path(
 @patch("lambdas.shares_comments_create.handler.create_comment")
 @patch("lambdas.shares_comments_create.handler.get_share")
 def test_missing_required_fields(
-    mock_get_share, mock_create, mock_context, api_gateway_event
+    mock_get_share, mock_create, mock_context, authorized_event
 ):
-    body = {"email": "bob@example.com", "shareId": "share-1"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
     mock_get_share.assert_not_called()
     mock_create.assert_not_called()
@@ -92,10 +94,10 @@ def test_missing_required_fields(
 @patch("lambdas.shares_comments_create.handler.create_comment")
 @patch("lambdas.shares_comments_create.handler.get_share")
 def test_empty_body_rejected(
-    mock_get_share, mock_create, mock_context, api_gateway_event
+    mock_get_share, mock_create, mock_context, authorized_event
 ):
-    body = {"email": "bob@example.com", "shareId": "share-1", "body": "   "}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "body": "   "}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
     mock_create.assert_not_called()
 
@@ -103,14 +105,10 @@ def test_empty_body_rejected(
 @patch("lambdas.shares_comments_create.handler.create_comment")
 @patch("lambdas.shares_comments_create.handler.get_share")
 def test_body_too_long_rejected(
-    mock_get_share, mock_create, mock_context, api_gateway_event
+    mock_get_share, mock_create, mock_context, authorized_event
 ):
-    body = {
-        "email": "bob@example.com",
-        "shareId": "share-1",
-        "body": "a" * 501,
-    }
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "body": "a" * 501}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
     mock_create.assert_not_called()
 
@@ -119,11 +117,11 @@ def test_body_too_long_rejected(
 @patch("lambdas.shares_comments_create.handler.create_comment")
 @patch("lambdas.shares_comments_create.handler.get_share")
 def test_share_not_found(
-    mock_get_share, mock_create, mock_context, api_gateway_event
+    mock_get_share, mock_create, mock_context, authorized_event
 ):
     mock_get_share.return_value = None
-    body = {"email": "bob@example.com", "shareId": "missing", "body": "hi"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "missing", "body": "hi"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 404
     mock_create.assert_not_called()
 
@@ -132,17 +130,70 @@ def test_share_not_found(
 @patch("lambdas.shares_comments_create.handler.create_comment")
 @patch("lambdas.shares_comments_create.handler.get_share")
 def test_group_only_share_blocks_non_member(
-    mock_get_share, mock_create, mock_member, mock_context, api_gateway_event
+    mock_get_share, mock_create, mock_member, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share(public=False, group_ids=["g1"])
     mock_member.return_value = False
 
-    body = {
-        "email": "stranger@example.com",
-        "shareId": "share-1",
-        "body": "hi",
-    }
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "body": "hi"}
+    response = handler(
+        _event(authorized_event, body, email="stranger@example.com"), mock_context
+    )
     # Existence is hidden -> 404, not 403.
     assert response["statusCode"] == 404
     mock_create.assert_not_called()
+
+
+# ------------------------------------------------------------------ Auth
+@patch("lambdas.shares_comments_create.handler.create_comment")
+@patch("lambdas.shares_comments_create.handler.get_share")
+def test_missing_caller_identity_returns_401(
+    mock_get_share, mock_create, mock_context, api_gateway_event
+):
+    """No authorizer context AND no email in body -> 401 from helper."""
+    event = {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/shares/comments",
+        "body": json.dumps({"shareId": "share-1", "body": "fire"}),
+    }
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 401
+    mock_get_share.assert_not_called()
+    mock_create.assert_not_called()
+
+
+# ------------------------------------------------------------------ Legacy fallback
+@patch("lambdas.shares_comments_create.handler.batch_get_users")
+@patch("lambdas.shares_comments_create.handler.create_comment")
+@patch("lambdas.shares_comments_create.handler.get_share")
+def test_legacy_email_in_body_still_works(
+    mock_get_share, mock_create, mock_users, mock_context, legacy_event
+):
+    """During the migration window, callers without authorizer context can
+    still pass `email` in the body. Helper logs a WARN; handler proceeds."""
+    mock_get_share.return_value = _share()
+    mock_create.return_value = {
+        "shareId": "share-1",
+        "commentId": "c-1",
+        "email": "bob@example.com",
+        "body": "fire",
+        "createdAt": "2026-04-23T12:00:00+00:00",
+        "createdAtId": "2026-04-23T12:00:00+00:00#c-1",
+    }
+    mock_users.return_value = {}
+
+    event = legacy_event(
+        httpMethod="POST",
+        path="/shares/comments",
+        body=json.dumps({
+            "email": "bob@example.com",
+            "shareId": "share-1",
+            "body": "fire",
+        }),
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 200
+    mock_create.assert_called_once_with(
+        share_id="share-1", email="bob@example.com", body="fire"
+    )

--- a/tests/test_shares_comments_delete.py
+++ b/tests/test_shares_comments_delete.py
@@ -8,6 +8,7 @@ Covers:
 - missing share -> 404
 - missing comment -> 404
 - missing required fields -> 400
+- missing caller identity -> 401
 """
 
 from __future__ import annotations
@@ -18,13 +19,13 @@ from unittest.mock import patch
 from lambdas.shares_comments_delete.handler import handler
 
 
-def _event(api_gateway_event, body):
-    return {
-        **api_gateway_event,
-        "httpMethod": "DELETE",
-        "path": "/shares/comments",
-        "body": json.dumps(body),
-    }
+def _event(authorized_event, body, email="bob@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="DELETE",
+        path="/shares/comments",
+        body=json.dumps(body),
+    )
 
 
 def _share():
@@ -49,17 +50,15 @@ def _comment(author="bob@example.com"):
 @patch("lambdas.shares_comments_delete.handler.get_comment")
 @patch("lambdas.shares_comments_delete.handler.get_share")
 def test_comment_author_can_delete(
-    mock_get_share, mock_get_comment, mock_delete, mock_context, api_gateway_event
+    mock_get_share, mock_get_comment, mock_delete, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_get_comment.return_value = _comment()
 
-    body = {
-        "email": "bob@example.com",  # comment author
-        "shareId": "share-1",
-        "commentId": "c-1",
-    }
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "commentId": "c-1"}
+    response = handler(
+        _event(authorized_event, body, email="bob@example.com"), mock_context
+    )
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
     assert payload["deleted"] is True
@@ -71,17 +70,15 @@ def test_comment_author_can_delete(
 @patch("lambdas.shares_comments_delete.handler.get_comment")
 @patch("lambdas.shares_comments_delete.handler.get_share")
 def test_share_author_can_delete(
-    mock_get_share, mock_get_comment, mock_delete, mock_context, api_gateway_event
+    mock_get_share, mock_get_comment, mock_delete, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_get_comment.return_value = _comment()
 
-    body = {
-        "email": "alice@example.com",  # share author
-        "shareId": "share-1",
-        "commentId": "c-1",
-    }
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "commentId": "c-1"}
+    response = handler(
+        _event(authorized_event, body, email="alice@example.com"), mock_context
+    )
     assert response["statusCode"] == 200
     mock_delete.assert_called_once()
 
@@ -90,17 +87,15 @@ def test_share_author_can_delete(
 @patch("lambdas.shares_comments_delete.handler.get_comment")
 @patch("lambdas.shares_comments_delete.handler.get_share")
 def test_third_party_forbidden(
-    mock_get_share, mock_get_comment, mock_delete, mock_context, api_gateway_event
+    mock_get_share, mock_get_comment, mock_delete, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_get_comment.return_value = _comment()
 
-    body = {
-        "email": "stranger@example.com",
-        "shareId": "share-1",
-        "commentId": "c-1",
-    }
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "commentId": "c-1"}
+    response = handler(
+        _event(authorized_event, body, email="stranger@example.com"), mock_context
+    )
     # AuthorizationError -> 401 in this codebase.
     assert response["statusCode"] == 401
     mock_delete.assert_not_called()
@@ -110,11 +105,11 @@ def test_third_party_forbidden(
 @patch("lambdas.shares_comments_delete.handler.get_comment")
 @patch("lambdas.shares_comments_delete.handler.get_share")
 def test_missing_share(
-    mock_get_share, mock_get_comment, mock_delete, mock_context, api_gateway_event
+    mock_get_share, mock_get_comment, mock_delete, mock_context, authorized_event
 ):
     mock_get_share.return_value = None
-    body = {"email": "bob@example.com", "shareId": "missing", "commentId": "c-1"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "missing", "commentId": "c-1"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 404
     mock_get_comment.assert_not_called()
     mock_delete.assert_not_called()
@@ -124,12 +119,12 @@ def test_missing_share(
 @patch("lambdas.shares_comments_delete.handler.get_comment")
 @patch("lambdas.shares_comments_delete.handler.get_share")
 def test_missing_comment(
-    mock_get_share, mock_get_comment, mock_delete, mock_context, api_gateway_event
+    mock_get_share, mock_get_comment, mock_delete, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_get_comment.return_value = None
-    body = {"email": "bob@example.com", "shareId": "share-1", "commentId": "missing"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "commentId": "missing"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 404
     mock_delete.assert_not_called()
 
@@ -138,11 +133,31 @@ def test_missing_comment(
 @patch("lambdas.shares_comments_delete.handler.get_comment")
 @patch("lambdas.shares_comments_delete.handler.get_share")
 def test_missing_required_fields(
+    mock_get_share, mock_get_comment, mock_delete, mock_context, authorized_event
+):
+    body = {}
+    response = handler(_event(authorized_event, body), mock_context)
+    assert response["statusCode"] == 400
+    mock_get_share.assert_not_called()
+    mock_get_comment.assert_not_called()
+    mock_delete.assert_not_called()
+
+
+# ------------------------------------------------------------------ Auth
+@patch("lambdas.shares_comments_delete.handler.delete_comment")
+@patch("lambdas.shares_comments_delete.handler.get_comment")
+@patch("lambdas.shares_comments_delete.handler.get_share")
+def test_missing_caller_identity_returns_401(
     mock_get_share, mock_get_comment, mock_delete, mock_context, api_gateway_event
 ):
-    body = {"email": "bob@example.com"}
-    response = handler(_event(api_gateway_event, body), mock_context)
-    assert response["statusCode"] == 400
+    event = {
+        **api_gateway_event,
+        "httpMethod": "DELETE",
+        "path": "/shares/comments",
+        "body": json.dumps({"shareId": "share-1", "commentId": "c-1"}),
+    }
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 401
     mock_get_share.assert_not_called()
     mock_get_comment.assert_not_called()
     mock_delete.assert_not_called()

--- a/tests/test_shares_comments_list.py
+++ b/tests/test_shares_comments_list.py
@@ -6,6 +6,7 @@ Covers:
 - limit clamping / validation
 - missing share -> 404
 - group-only share, non-member -> 404
+- missing caller identity -> 401
 """
 
 from __future__ import annotations
@@ -16,13 +17,13 @@ from unittest.mock import patch
 from lambdas.shares_comments_list.handler import handler
 
 
-def _event(api_gateway_event, params):
-    return {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/shares/comments",
-        "queryStringParameters": params,
-    }
+def _event(authorized_event, params, email="viewer@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="GET",
+        path="/shares/comments",
+        queryStringParameters=params,
+    )
 
 
 def _share(public=True, group_ids=None):
@@ -41,7 +42,7 @@ def _share(public=True, group_ids=None):
 @patch("lambdas.shares_comments_list.handler.list_comments")
 @patch("lambdas.shares_comments_list.handler.get_share")
 def test_happy_path_with_profiles_and_cursor(
-    mock_get_share, mock_list, mock_users, mock_context, api_gateway_event
+    mock_get_share, mock_list, mock_users, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_list.return_value = (
@@ -71,8 +72,7 @@ def test_happy_path_with_profiles_and_cursor(
     }
 
     response = handler(
-        _event(api_gateway_event, {
-            "email": "viewer@example.com",
+        _event(authorized_event, {
             "shareId": "share-1",
             "limit": "2",
         }),
@@ -101,16 +101,13 @@ def test_happy_path_with_profiles_and_cursor(
 @patch("lambdas.shares_comments_list.handler.list_comments")
 @patch("lambdas.shares_comments_list.handler.get_share")
 def test_empty_thread_returns_empty_list_not_500(
-    mock_get_share, mock_list, mock_users, mock_context, api_gateway_event
+    mock_get_share, mock_list, mock_users, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_list.return_value = ([], None)
 
     response = handler(
-        _event(api_gateway_event, {
-            "email": "viewer@example.com",
-            "shareId": "share-1",
-        }),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
 
@@ -125,11 +122,10 @@ def test_empty_thread_returns_empty_list_not_500(
 @patch("lambdas.shares_comments_list.handler.list_comments")
 @patch("lambdas.shares_comments_list.handler.get_share")
 def test_limit_must_be_integer(
-    mock_get_share, mock_list, mock_context, api_gateway_event
+    mock_get_share, mock_list, mock_context, authorized_event
 ):
     response = handler(
-        _event(api_gateway_event, {
-            "email": "viewer@example.com",
+        _event(authorized_event, {
             "shareId": "share-1",
             "limit": "abc",
         }),
@@ -142,11 +138,10 @@ def test_limit_must_be_integer(
 @patch("lambdas.shares_comments_list.handler.list_comments")
 @patch("lambdas.shares_comments_list.handler.get_share")
 def test_limit_capped(
-    mock_get_share, mock_list, mock_context, api_gateway_event
+    mock_get_share, mock_list, mock_context, authorized_event
 ):
     response = handler(
-        _event(api_gateway_event, {
-            "email": "viewer@example.com",
+        _event(authorized_event, {
             "shareId": "share-1",
             "limit": "9999",
         }),
@@ -158,10 +153,10 @@ def test_limit_capped(
 @patch("lambdas.shares_comments_list.handler.list_comments")
 @patch("lambdas.shares_comments_list.handler.get_share")
 def test_missing_required_fields(
-    mock_get_share, mock_list, mock_context, api_gateway_event
+    mock_get_share, mock_list, mock_context, authorized_event
 ):
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com"}),
+        _event(authorized_event, {}),
         mock_context,
     )
     assert response["statusCode"] == 400
@@ -172,14 +167,11 @@ def test_missing_required_fields(
 @patch("lambdas.shares_comments_list.handler.list_comments")
 @patch("lambdas.shares_comments_list.handler.get_share")
 def test_share_not_found(
-    mock_get_share, mock_list, mock_context, api_gateway_event
+    mock_get_share, mock_list, mock_context, authorized_event
 ):
     mock_get_share.return_value = None
     response = handler(
-        _event(api_gateway_event, {
-            "email": "viewer@example.com",
-            "shareId": "missing",
-        }),
+        _event(authorized_event, {"shareId": "missing"}),
         mock_context,
     )
     assert response["statusCode"] == 404
@@ -190,16 +182,31 @@ def test_share_not_found(
 @patch("lambdas.shares_comments_list.handler.list_comments")
 @patch("lambdas.shares_comments_list.handler.get_share")
 def test_group_only_blocks_non_member(
-    mock_get_share, mock_list, mock_member, mock_context, api_gateway_event
+    mock_get_share, mock_list, mock_member, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share(public=False, group_ids=["g1"])
     mock_member.return_value = False
     response = handler(
-        _event(api_gateway_event, {
-            "email": "stranger@example.com",
-            "shareId": "share-1",
-        }),
+        _event(authorized_event, {"shareId": "share-1"}, email="stranger@example.com"),
         mock_context,
     )
     assert response["statusCode"] == 404
+    mock_list.assert_not_called()
+
+
+# ------------------------------------------------------------------ Auth
+@patch("lambdas.shares_comments_list.handler.list_comments")
+@patch("lambdas.shares_comments_list.handler.get_share")
+def test_missing_caller_identity_returns_401(
+    mock_get_share, mock_list, mock_context, api_gateway_event
+):
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/comments",
+        "queryStringParameters": {"shareId": "share-1"},
+    }
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 401
+    mock_get_share.assert_not_called()
     mock_list.assert_not_called()

--- a/tests/test_shares_create.py
+++ b/tests/test_shares_create.py
@@ -6,6 +6,7 @@ Covers legacy public-only behavior plus the v2 multi-target contract:
 - non-member groupIds rejected (403 AuthorizationError)
 - public=False with empty groupIds rejected (400 ValidationError)
 - dual / group-only persistence paths
+- caller identity migration: helper-sourced email + 401 on missing context
 """
 
 import json
@@ -15,7 +16,6 @@ from lambdas.shares_create.handler import handler
 
 
 VALID_BODY = {
-    "email": "user@example.com",
     "trackId": "spotify:track:1",
     "trackUri": "spotify:track:1",
     "trackName": "Song",
@@ -25,17 +25,17 @@ VALID_BODY = {
 }
 
 
-def _event(api_gateway_event, body):
-    return {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/shares/create",
-        "body": json.dumps(body),
-    }
+def _event(authorized_event, body, email="user@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="POST",
+        path="/shares/create",
+        body=json.dumps(body),
+    )
 
 
 @patch('lambdas.shares_create.handler.create_share')
-def test_shares_create_happy_path(mock_create, mock_context, api_gateway_event):
+def test_shares_create_happy_path(mock_create, mock_context, authorized_event):
     mock_create.return_value = {
         "shareId": "abc-123",
         "createdAt": "2026-04-22T12:00:00+00:00",
@@ -43,7 +43,7 @@ def test_shares_create_happy_path(mock_create, mock_context, api_gateway_event):
         "public": True,
     }
 
-    response = handler(_event(api_gateway_event, VALID_BODY), mock_context)
+    response = handler(_event(authorized_event, VALID_BODY), mock_context)
 
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
@@ -55,21 +55,23 @@ def test_shares_create_happy_path(mock_create, mock_context, api_gateway_event):
     kwargs = mock_create.call_args.kwargs
     assert kwargs['group_ids'] == []
     assert kwargs['public'] is True
+    # Caller email comes from authorizer context, not the body.
+    assert kwargs['email'] == "user@example.com"
 
 
 @patch('lambdas.shares_create.handler.create_share')
-def test_shares_create_missing_required_field(mock_create, mock_context, api_gateway_event):
+def test_shares_create_missing_required_field(mock_create, mock_context, authorized_event):
     incomplete = {k: v for k, v in VALID_BODY.items() if k != 'trackId'}
-    response = handler(_event(api_gateway_event, incomplete), mock_context)
+    response = handler(_event(authorized_event, incomplete), mock_context)
 
     assert response['statusCode'] == 400
     mock_create.assert_not_called()
 
 
 @patch('lambdas.shares_create.handler.create_share')
-def test_shares_create_caption_too_long(mock_create, mock_context, api_gateway_event):
+def test_shares_create_caption_too_long(mock_create, mock_context, authorized_event):
     body = {**VALID_BODY, "caption": "a" * 141}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 400
     assert 'caption' in json.loads(response['body'])['error']['message']
@@ -77,9 +79,9 @@ def test_shares_create_caption_too_long(mock_create, mock_context, api_gateway_e
 
 
 @patch('lambdas.shares_create.handler.create_share')
-def test_shares_create_invalid_mood_tag(mock_create, mock_context, api_gateway_event):
+def test_shares_create_invalid_mood_tag(mock_create, mock_context, authorized_event):
     body = {**VALID_BODY, "moodTag": "bogus"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 400
     assert 'moodTag' in json.loads(response['body'])['error']['message']
@@ -87,16 +89,16 @@ def test_shares_create_invalid_mood_tag(mock_create, mock_context, api_gateway_e
 
 
 @patch('lambdas.shares_create.handler.create_share')
-def test_shares_create_too_many_genre_tags(mock_create, mock_context, api_gateway_event):
+def test_shares_create_too_many_genre_tags(mock_create, mock_context, authorized_event):
     body = {**VALID_BODY, "genreTags": ["a", "b", "c", "d"]}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 400
     mock_create.assert_not_called()
 
 
 @patch('lambdas.shares_create.handler.create_share')
-def test_shares_create_valid_optional_fields(mock_create, mock_context, api_gateway_event):
+def test_shares_create_valid_optional_fields(mock_create, mock_context, authorized_event):
     mock_create.return_value = {
         "shareId": "x",
         "createdAt": "2026-04-22T12:00:00+00:00",
@@ -105,7 +107,7 @@ def test_shares_create_valid_optional_fields(mock_create, mock_context, api_gate
     }
     body = {**VALID_BODY, "caption": "nice", "moodTag": "hype", "genreTags": ["pop", "rock"]}
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 200
     kwargs = mock_create.call_args.kwargs
@@ -121,7 +123,7 @@ def test_shares_create_valid_optional_fields(mock_create, mock_context, api_gate
 @patch('lambdas.shares_create.handler.is_member_of_group')
 @patch('lambdas.shares_create.handler.create_share')
 def test_shares_create_dual_target_public_and_groups(
-    mock_create, mock_member, mock_context, api_gateway_event
+    mock_create, mock_member, mock_context, authorized_event
 ):
     """public=True with groupIds -> dual share, persisted with both fields."""
     mock_member.return_value = True
@@ -133,7 +135,7 @@ def test_shares_create_dual_target_public_and_groups(
     }
     body = {**VALID_BODY, "groupIds": ["g1", "g2"], "public": True}
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 200
     kwargs = mock_create.call_args.kwargs
@@ -147,7 +149,7 @@ def test_shares_create_dual_target_public_and_groups(
 @patch('lambdas.shares_create.handler.is_member_of_group')
 @patch('lambdas.shares_create.handler.create_share')
 def test_shares_create_group_only_share(
-    mock_create, mock_member, mock_context, api_gateway_event
+    mock_create, mock_member, mock_context, authorized_event
 ):
     """public=False with groupIds -> group-only share."""
     mock_member.return_value = True
@@ -159,7 +161,7 @@ def test_shares_create_group_only_share(
     }
     body = {**VALID_BODY, "groupIds": ["g1"], "public": False}
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 200
     kwargs = mock_create.call_args.kwargs
@@ -170,13 +172,13 @@ def test_shares_create_group_only_share(
 @patch('lambdas.shares_create.handler.is_member_of_group')
 @patch('lambdas.shares_create.handler.create_share')
 def test_shares_create_rejects_non_member_group(
-    mock_create, mock_member, mock_context, api_gateway_event
+    mock_create, mock_member, mock_context, authorized_event
 ):
     """Caller not a member of the requested group -> 401 AuthorizationError."""
     mock_member.side_effect = lambda email, gid: gid != "g-forbidden"
     body = {**VALID_BODY, "groupIds": ["g1", "g-forbidden"]}
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     # AuthorizationError.status == 401 (see lambdas/common/errors.py)
     assert response['statusCode'] == 401
@@ -187,12 +189,12 @@ def test_shares_create_rejects_non_member_group(
 @patch('lambdas.shares_create.handler.is_member_of_group')
 @patch('lambdas.shares_create.handler.create_share')
 def test_shares_create_rejects_private_with_no_targets(
-    mock_create, mock_member, mock_context, api_gateway_event
+    mock_create, mock_member, mock_context, authorized_event
 ):
     """public=False + empty groupIds -> 400."""
     body = {**VALID_BODY, "groupIds": [], "public": False}
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 400
     assert 'target' in json.loads(response['body'])['error']['message'].lower()
@@ -204,12 +206,54 @@ def test_shares_create_rejects_private_with_no_targets(
 @patch('lambdas.shares_create.handler.is_member_of_group')
 @patch('lambdas.shares_create.handler.create_share')
 def test_shares_create_group_ids_must_be_list(
-    mock_create, mock_member, mock_context, api_gateway_event
+    mock_create, mock_member, mock_context, authorized_event
 ):
     body = {**VALID_BODY, "groupIds": "g1"}
 
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body), mock_context)
 
     assert response['statusCode'] == 400
     mock_create.assert_not_called()
     mock_member.assert_not_called()
+
+
+# ------------------------------------------------------------
+# Caller-identity migration
+# ------------------------------------------------------------
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_missing_caller_identity_returns_401(
+    mock_create, mock_context, api_gateway_event
+):
+    """No authorizer context AND no email in body -> 401 from helper."""
+    event = {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/shares/create",
+        "body": json.dumps(VALID_BODY),
+    }
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 401
+    mock_create.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_legacy_email_in_body_still_works(
+    mock_create, mock_context, legacy_event
+):
+    """During the migration window, the helper falls back to body `email`."""
+    mock_create.return_value = {
+        "shareId": "legacy-1",
+        "createdAt": "2026-04-22T12:00:00+00:00",
+        "groupIds": [],
+        "public": True,
+    }
+    body_with_email = {**VALID_BODY, "email": "legacy@example.com"}
+    event = legacy_event(
+        httpMethod="POST",
+        path="/shares/create",
+        body=json.dumps(body_with_email),
+    )
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 200
+    assert mock_create.call_args.kwargs['email'] == "legacy@example.com"

--- a/tests/test_shares_delete.py
+++ b/tests/test_shares_delete.py
@@ -8,36 +8,36 @@ from unittest.mock import patch
 from lambdas.shares_delete.handler import handler
 
 
-def _event(api_gateway_event, params):
-    return {
-        **api_gateway_event,
-        "httpMethod": "DELETE",
-        "path": "/shares/delete",
-        "queryStringParameters": params,
-    }
+def _query_event(authorized_event, params, email="owner@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="DELETE",
+        path="/shares/delete",
+        queryStringParameters=params,
+    )
 
 
-def _body_event(api_gateway_event, body):
+def _body_event(authorized_event, body, email="owner@example.com"):
     """Mirror iOS: POST/DELETE with JSON body, no query string."""
-    return {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/shares/delete",
-        "queryStringParameters": None,
-        "body": json.dumps(body),
-    }
+    return authorized_event(
+        email=email,
+        httpMethod="POST",
+        path="/shares/delete",
+        queryStringParameters=None,
+        body=json.dumps(body),
+    )
 
 
 @patch('lambdas.shares_delete.handler.delete_share')
 @patch('lambdas.shares_delete.handler.get_share')
 def test_shares_delete_owner_success(
-    mock_get, mock_delete, mock_context, api_gateway_event
+    mock_get, mock_delete, mock_context, authorized_event
 ):
     mock_get.return_value = {"shareId": "s1", "email": "owner@example.com"}
     mock_delete.return_value = True
 
     response = handler(
-        _event(api_gateway_event, {"email": "owner@example.com", "shareId": "s1"}),
+        _query_event(authorized_event, {"shareId": "s1"}, email="owner@example.com"),
         mock_context,
     )
 
@@ -48,12 +48,12 @@ def test_shares_delete_owner_success(
 @patch('lambdas.shares_delete.handler.delete_share')
 @patch('lambdas.shares_delete.handler.get_share')
 def test_shares_delete_non_owner_forbidden(
-    mock_get, mock_delete, mock_context, api_gateway_event
+    mock_get, mock_delete, mock_context, authorized_event
 ):
     mock_get.return_value = {"shareId": "s1", "email": "owner@example.com"}
 
     response = handler(
-        _event(api_gateway_event, {"email": "stranger@example.com", "shareId": "s1"}),
+        _query_event(authorized_event, {"shareId": "s1"}, email="stranger@example.com"),
         mock_context,
     )
 
@@ -66,12 +66,12 @@ def test_shares_delete_non_owner_forbidden(
 @patch('lambdas.shares_delete.handler.delete_share')
 @patch('lambdas.shares_delete.handler.get_share')
 def test_shares_delete_not_found(
-    mock_get, mock_delete, mock_context, api_gateway_event
+    mock_get, mock_delete, mock_context, authorized_event
 ):
     mock_get.return_value = None
 
     response = handler(
-        _event(api_gateway_event, {"email": "owner@example.com", "shareId": "missing"}),
+        _query_event(authorized_event, {"shareId": "missing"}, email="owner@example.com"),
         mock_context,
     )
 
@@ -80,34 +80,33 @@ def test_shares_delete_not_found(
 
 
 @patch('lambdas.shares_delete.handler.get_share')
-def test_shares_delete_missing_fields(mock_get, mock_context, api_gateway_event):
+def test_shares_delete_missing_share_id(mock_get, mock_context, authorized_event):
     response = handler(
-        _event(api_gateway_event, {"email": "owner@example.com"}),
+        _query_event(authorized_event, {}),
         mock_context,
     )
     assert response['statusCode'] == 400
     mock_get.assert_not_called()
 
 
-# Bug regression: iOS POSTs `{email, shareId, sharedAt}` in the JSON body,
-# not the query string. The previous handler only read query params, so
-# the request silently failed validation (or — depending on API Gateway
-# routing — ran with empty identifiers and never actually deleted the
-# row). The handler now reads body OR query params.
+# Bug regression: iOS POSTs `{shareId, sharedAt}` in the JSON body, not the
+# query string. The previous handler only read query params, so the request
+# silently failed validation (or — depending on API Gateway routing — ran
+# with empty identifiers and never actually deleted the row). The handler
+# now reads body OR query params for shareId.
 @patch('lambdas.shares_delete.handler.delete_share')
 @patch('lambdas.shares_delete.handler.get_share')
 def test_shares_delete_accepts_body_payload(
-    mock_get, mock_delete, mock_context, api_gateway_event
+    mock_get, mock_delete, mock_context, authorized_event
 ):
     mock_get.return_value = {"shareId": "s1", "email": "owner@example.com"}
     mock_delete.return_value = True
 
     response = handler(
-        _body_event(api_gateway_event, {
-            "email": "owner@example.com",
+        _body_event(authorized_event, {
             "shareId": "s1",
             "sharedAt": "2026-04-23T12:00:00+00:00",
-        }),
+        }, email="owner@example.com"),
         mock_context,
     )
 
@@ -118,12 +117,30 @@ def test_shares_delete_accepts_body_payload(
 @patch('lambdas.shares_delete.handler.delete_share')
 @patch('lambdas.shares_delete.handler.get_share')
 def test_shares_delete_body_missing_share_id(
-    mock_get, mock_delete, mock_context, api_gateway_event
+    mock_get, mock_delete, mock_context, authorized_event
 ):
     response = handler(
-        _body_event(api_gateway_event, {"email": "owner@example.com"}),
+        _body_event(authorized_event, {}),
         mock_context,
     )
     assert response['statusCode'] == 400
+    mock_get.assert_not_called()
+    mock_delete.assert_not_called()
+
+
+# ------------------------------------------------------------------ Auth
+@patch('lambdas.shares_delete.handler.delete_share')
+@patch('lambdas.shares_delete.handler.get_share')
+def test_shares_delete_missing_caller_identity_returns_401(
+    mock_get, mock_delete, mock_context, api_gateway_event
+):
+    event = {
+        **api_gateway_event,
+        "httpMethod": "DELETE",
+        "path": "/shares/delete",
+        "queryStringParameters": {"shareId": "s1"},
+    }
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 401
     mock_get.assert_not_called()
     mock_delete.assert_not_called()

--- a/tests/test_shares_detail.py
+++ b/tests/test_shares_detail.py
@@ -8,6 +8,7 @@ Covers:
 - interactions dedupe on (email, action)
 - friendRatings filtered to the viewer's accepted friends + the author
 - enrichment failures do not drop the share
+- missing caller identity -> 401
 """
 
 from unittest.mock import patch
@@ -16,13 +17,13 @@ import json
 from lambdas.shares_detail.handler import handler
 
 
-def _event(api_gateway_event, params):
-    return {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/shares/detail",
-        "queryStringParameters": params,
-    }
+def _event(authorized_event, params, email="viewer@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="GET",
+        path="/shares/detail",
+        queryStringParameters=params,
+    )
 
 
 def _share():
@@ -58,7 +59,7 @@ def test_shares_detail_happy_path(
     mock_count_comments,
     mock_reaction_summary,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     mock_count_comments.return_value = 0
     mock_reaction_summary.return_value = {"counts": {}, "viewerReactions": []}
@@ -129,7 +130,7 @@ def test_shares_detail_happy_path(
     }
 
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}, email="viewer@example.com"),
         mock_context,
     )
 
@@ -176,11 +177,11 @@ def test_shares_detail_happy_path(
 
 @patch('lambdas.shares_detail.handler.get_share')
 def test_shares_detail_missing_share_returns_404(
-    mock_get_share, mock_context, api_gateway_event
+    mock_get_share, mock_context, authorized_event
 ):
     mock_get_share.return_value = None
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "missing"}),
+        _event(authorized_event, {"shareId": "missing"}),
         mock_context,
     )
     assert response['statusCode'] == 404
@@ -188,9 +189,9 @@ def test_shares_detail_missing_share_returns_404(
 
 @patch('lambdas.shares_detail.handler.get_share')
 def test_shares_detail_missing_required_fields_returns_400(
-    mock_get_share, mock_context, api_gateway_event
+    mock_get_share, mock_context, authorized_event
 ):
-    response = handler(_event(api_gateway_event, {"email": "viewer@example.com"}), mock_context)
+    response = handler(_event(authorized_event, {}), mock_context)
     assert response['statusCode'] == 400
     mock_get_share.assert_not_called()
 
@@ -206,7 +207,7 @@ def test_shares_detail_missing_required_fields_returns_400(
 def test_shares_detail_interactions_dedupe_by_email_action(
     mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
     mock_count_comments, mock_reaction_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """Single row with queued=True rated=True -> two events, not one merged."""
     mock_count_comments.return_value = 0
@@ -226,7 +227,7 @@ def test_shares_detail_interactions_dedupe_by_email_action(
     mock_batch_users.return_value = {}
 
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
     body = json.loads(response['body'])
@@ -248,7 +249,7 @@ def test_shares_detail_interactions_dedupe_by_email_action(
 def test_shares_detail_friend_ratings_scoped_to_accepted_friends_only(
     mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
     mock_count_comments, mock_reaction_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """Pending / blocked friends must NOT appear in friendRatings."""
     mock_count_comments.return_value = 0
@@ -269,7 +270,7 @@ def test_shares_detail_friend_ratings_scoped_to_accepted_friends_only(
     mock_batch_users.return_value = {}
 
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
     body = json.loads(response['body'])
@@ -285,7 +286,7 @@ def test_shares_detail_friend_ratings_scoped_to_accepted_friends_only(
 @patch('lambdas.shares_detail.handler.is_member_of_group')
 @patch('lambdas.shares_detail.handler.get_share')
 def test_shares_detail_group_only_share_blocked_for_non_member(
-    mock_get_share, mock_member, mock_context, api_gateway_event,
+    mock_get_share, mock_member, mock_context, authorized_event,
 ):
     """Group-only share (public=False) must 404 for a non-member viewer."""
     share = _share()
@@ -295,7 +296,7 @@ def test_shares_detail_group_only_share_blocked_for_non_member(
     mock_member.return_value = False
 
     response = handler(
-        _event(api_gateway_event, {"email": "stranger@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}, email="stranger@example.com"),
         mock_context,
     )
     assert response['statusCode'] == 404
@@ -315,7 +316,7 @@ def test_shares_detail_group_only_share_accessible_to_member(
     mock_get_share, mock_member, mock_enrich, mock_reactions,
     mock_friends, mock_ratings, mock_batch_users,
     mock_count_comments, mock_reaction_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """Group members must see group-only shares."""
     share = _share()
@@ -332,7 +333,7 @@ def test_shares_detail_group_only_share_accessible_to_member(
     mock_reaction_summary.return_value = {"counts": {}, "viewerReactions": []}
 
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
     assert response['statusCode'] == 200
@@ -353,7 +354,7 @@ def test_shares_detail_group_only_share_accessible_to_author(
     mock_get_share, mock_member, mock_enrich, mock_reactions,
     mock_friends, mock_ratings, mock_batch_users,
     mock_count_comments, mock_reaction_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """Author can always read their own share even if group-only."""
     share = _share()
@@ -370,7 +371,7 @@ def test_shares_detail_group_only_share_accessible_to_author(
 
     response = handler(
         # viewer == author (share fixture uses alice@example.com)
-        _event(api_gateway_event, {"email": "alice@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}, email="alice@example.com"),
         mock_context,
     )
     assert response['statusCode'] == 200
@@ -389,7 +390,7 @@ def test_shares_detail_group_only_share_accessible_to_author(
 def test_shares_detail_enrichment_failure_is_non_fatal(
     mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
     mock_count_comments, mock_reaction_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """If build_enrichment explodes, the share still comes back with defaults."""
     mock_get_share.return_value = _share()
@@ -402,7 +403,7 @@ def test_shares_detail_enrichment_failure_is_non_fatal(
     mock_reaction_summary.return_value = {"counts": {}, "viewerReactions": []}
 
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
 
@@ -424,7 +425,7 @@ def test_shares_detail_enrichment_failure_is_non_fatal(
 def test_shares_detail_includes_comment_and_reaction_enrichment(
     mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
     mock_count_comments, mock_reaction_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """commentCount + reactionCounts + viewerReactions land on the share payload."""
     mock_get_share.return_value = _share()
@@ -440,7 +441,7 @@ def test_shares_detail_includes_comment_and_reaction_enrichment(
     }
 
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
     assert response['statusCode'] == 200
@@ -464,7 +465,7 @@ def test_shares_detail_includes_comment_and_reaction_enrichment(
 def test_shares_detail_comment_reaction_failure_is_non_fatal(
     mock_get_share, mock_enrich, mock_reactions, mock_friends, mock_ratings, mock_batch_users,
     mock_count_comments, mock_reaction_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """If the new comment/reaction helpers explode, defaults still ship."""
     mock_get_share.return_value = _share()
@@ -477,7 +478,7 @@ def test_shares_detail_comment_reaction_failure_is_non_fatal(
     mock_reaction_summary.side_effect = RuntimeError("reactions table unreachable")
 
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com", "shareId": "share-1"}),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
     assert response['statusCode'] == 200
@@ -485,3 +486,19 @@ def test_shares_detail_comment_reaction_failure_is_non_fatal(
     assert share['commentCount'] == 0
     assert share['reactionCounts'] == {}
     assert share['viewerReactions'] == []
+
+
+# ------------------------------------------------------------------ Auth
+@patch('lambdas.shares_detail.handler.get_share')
+def test_shares_detail_missing_caller_identity_returns_401(
+    mock_get_share, mock_context, api_gateway_event
+):
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/detail",
+        "queryStringParameters": {"shareId": "share-1"},
+    }
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 401
+    mock_get_share.assert_not_called()

--- a/tests/test_shares_feed.py
+++ b/tests/test_shares_feed.py
@@ -8,18 +8,18 @@ from unittest.mock import patch
 from lambdas.shares_feed.handler import handler
 
 
-def _event(api_gateway_event, params):
-    return {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/shares/feed",
-        "queryStringParameters": params,
-    }
+def _event(authorized_event, params, email="me@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="GET",
+        path="/shares/feed",
+        queryStringParameters=params,
+    )
 
 
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
-def test_shares_feed_happy_path(mock_friends, mock_query, mock_context, api_gateway_event):
+def test_shares_feed_happy_path(mock_friends, mock_query, mock_context, authorized_event):
     mock_friends.return_value = [
         {"friendEmail": "alice@example.com", "status": "accepted"},
         {"friendEmail": "bob@example.com", "status": "accepted"},
@@ -30,7 +30,10 @@ def test_shares_feed_happy_path(mock_friends, mock_query, mock_context, api_gate
         {"shareId": "2", "email": "me@example.com", "createdAt": "2026-04-22T11:00:00+00:00"},
     ]
 
-    response = handler(_event(api_gateway_event, {"email": "me@example.com"}), mock_context)
+    response = handler(
+        _event(authorized_event, {}, email="me@example.com"),
+        mock_context,
+    )
 
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
@@ -45,11 +48,14 @@ def test_shares_feed_happy_path(mock_friends, mock_query, mock_context, api_gate
 
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
-def test_shares_feed_empty_friends(mock_friends, mock_query, mock_context, api_gateway_event):
+def test_shares_feed_empty_friends(mock_friends, mock_query, mock_context, authorized_event):
     mock_friends.return_value = []
     mock_query.return_value = []
 
-    response = handler(_event(api_gateway_event, {"email": "solo@example.com"}), mock_context)
+    response = handler(
+        _event(authorized_event, {}, email="solo@example.com"),
+        mock_context,
+    )
 
     assert response['statusCode'] == 200
     body = json.loads(response['body'])
@@ -63,7 +69,7 @@ def test_shares_feed_empty_friends(mock_friends, mock_query, mock_context, api_g
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
 def test_shares_feed_group_filter_intersects(
-    mock_friends, mock_query, mock_members, mock_context, api_gateway_event
+    mock_friends, mock_query, mock_members, mock_context, authorized_event
 ):
     mock_friends.return_value = [
         {"friendEmail": "alice@example.com", "status": "accepted"},
@@ -77,7 +83,7 @@ def test_shares_feed_group_filter_intersects(
     mock_query.return_value = []
 
     handler(
-        _event(api_gateway_event, {"email": "me@example.com", "groupId": "g1"}),
+        _event(authorized_event, {"groupId": "g1"}, email="me@example.com"),
         mock_context,
     )
 
@@ -93,7 +99,7 @@ def test_shares_feed_group_filter_intersects(
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
 def test_shares_feed_public_feed_excludes_group_only_rows(
-    mock_friends, mock_query, mock_context, api_gateway_event
+    mock_friends, mock_query, mock_context, authorized_event
 ):
     """Friends feed (no groupId) must hide rows with public=False."""
     mock_friends.return_value = [
@@ -114,7 +120,7 @@ def test_shares_feed_public_feed_excludes_group_only_rows(
     ]
 
     response = handler(
-        _event(api_gateway_event, {"email": "me@example.com"}),
+        _event(authorized_event, {}),
         mock_context,
     )
 
@@ -129,7 +135,7 @@ def test_shares_feed_public_feed_excludes_group_only_rows(
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
 def test_shares_feed_group_feed_includes_group_targeted_rows(
-    mock_friends, mock_query, mock_members, mock_context, api_gateway_event
+    mock_friends, mock_query, mock_members, mock_context, authorized_event
 ):
     """Group feed must include both group-only and dual shares targeted to that
     group, and must drop rows that don't list the group in groupIds."""
@@ -159,7 +165,7 @@ def test_shares_feed_group_feed_includes_group_targeted_rows(
     ]
 
     response = handler(
-        _event(api_gateway_event, {"email": "me@example.com", "groupId": "g1"}),
+        _event(authorized_event, {"groupId": "g1"}),
         mock_context,
     )
 
@@ -172,7 +178,7 @@ def test_shares_feed_group_feed_includes_group_targeted_rows(
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
 def test_shares_feed_legacy_rows_visible_on_public_feed(
-    mock_friends, mock_query, mock_context, api_gateway_event
+    mock_friends, mock_query, mock_context, authorized_event
 ):
     """Rows written before the multi-target rollout have no `public` field
     and must stay visible on the public feed."""
@@ -183,7 +189,7 @@ def test_shares_feed_legacy_rows_visible_on_public_feed(
     ]
 
     response = handler(
-        _event(api_gateway_event, {"email": "me@example.com"}),
+        _event(authorized_event, {}),
         mock_context,
     )
 
@@ -195,19 +201,28 @@ def test_shares_feed_legacy_rows_visible_on_public_feed(
 @patch('lambdas.shares_feed.handler.query_feed_for_emails')
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
 def test_shares_feed_limit_exceeds_max(
-    mock_friends, mock_query, mock_context, api_gateway_event
+    mock_friends, mock_query, mock_context, authorized_event
 ):
     mock_friends.return_value = []
     response = handler(
-        _event(api_gateway_event, {"email": "me@example.com", "limit": "500"}),
+        _event(authorized_event, {"limit": "500"}),
         mock_context,
     )
     assert response['statusCode'] == 400
     mock_query.assert_not_called()
 
 
+# ------------------------------------------------------------------ Auth
 @patch('lambdas.shares_feed.handler.list_all_friends_for_user')
-def test_shares_feed_missing_email(mock_friends, mock_context, api_gateway_event):
-    response = handler(_event(api_gateway_event, {}), mock_context)
-    assert response['statusCode'] == 400
+def test_shares_feed_missing_caller_identity_returns_401(
+    mock_friends, mock_context, api_gateway_event
+):
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/feed",
+        "queryStringParameters": {},
+    }
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 401
     mock_friends.assert_not_called()

--- a/tests/test_shares_react.py
+++ b/tests/test_shares_react.py
@@ -9,26 +9,25 @@ Critical coverage:
 - exactly-once push at the 3rd distinct reactor
 - idempotent under simulated concurrent 3rd-reactor arrivals
 - subsequent (4th, 5th, ...) reactors do NOT re-fire
+- missing caller identity -> 401
 """
 
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from lambdas.shares_react.handler import handler
 
 
 # ---------------------------------------------------------------------- Helpers
-def _event(api_gateway_event, body):
-    return {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/shares/react",
-        "body": json.dumps(body),
-    }
+def _event(authorized_event, body, email="bob@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="POST",
+        path="/shares/react",
+        body=json.dumps(body),
+    )
 
 
 def _share(share_id="share-1", author="alice@example.com"):
@@ -63,7 +62,7 @@ def test_shares_react_happy_queue(
     mock_enrich,
     mock_lambda,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     mock_get_share.return_value = _share()
     mock_count.return_value = 1
@@ -75,8 +74,8 @@ def test_shares_react_happy_queue(
         "sharerRating": None,
     }
 
-    body = {"email": "bob@example.com", "shareId": "share-1", "action": "queued"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "action": "queued"}
+    response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
 
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
@@ -107,7 +106,7 @@ def test_shares_react_happy_rate_upserts_canonical(
     mock_enrich,
     mock_lambda,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     mock_get_share.return_value = _share()
     mock_enrich.return_value = {
@@ -119,12 +118,11 @@ def test_shares_react_happy_rate_upserts_canonical(
     }
 
     body = {
-        "email": "bob@example.com",
         "shareId": "share-1",
         "action": "rated",
         "rating": 4.5,
     }
-    response = handler(_event(api_gateway_event, body), mock_context)
+    response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
 
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
@@ -157,7 +155,7 @@ def test_shares_react_toggle_unqueue_clears_only(
     mock_enrich,
     mock_lambda,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     mock_get_share.return_value = _share()
     mock_enrich.return_value = {
@@ -168,8 +166,8 @@ def test_shares_react_toggle_unqueue_clears_only(
         "sharerRating": None,
     }
 
-    body = {"email": "bob@example.com", "shareId": "share-1", "action": "unqueued"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "action": "unqueued"}
+    response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
 
     assert response["statusCode"] == 200
     mock_clear_reaction.assert_called_once_with("share-1", "bob@example.com", "unqueued")
@@ -179,43 +177,43 @@ def test_shares_react_toggle_unqueue_clears_only(
 
 # -------------------------------------------------------------- Validation errors
 @patch("lambdas.shares_react.handler.get_share")
-def test_shares_react_rejects_invalid_action(mock_get_share, mock_context, api_gateway_event):
-    body = {"email": "bob@example.com", "shareId": "share-1", "action": "bogus"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+def test_shares_react_rejects_invalid_action(mock_get_share, mock_context, authorized_event):
+    body = {"shareId": "share-1", "action": "bogus"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
     mock_get_share.assert_not_called()
 
 
 @patch("lambdas.shares_react.handler.upsert_track_rating")
 @patch("lambdas.shares_react.handler.get_share")
-def test_shares_react_rated_missing_rating(mock_get_share, mock_upsert, mock_context, api_gateway_event):
+def test_shares_react_rated_missing_rating(mock_get_share, mock_upsert, mock_context, authorized_event):
     mock_get_share.return_value = _share()
-    body = {"email": "bob@example.com", "shareId": "share-1", "action": "rated"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "action": "rated"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
 
 
 @patch("lambdas.shares_react.handler.upsert_track_rating")
 @patch("lambdas.shares_react.handler.get_share")
-def test_shares_react_rated_rating_out_of_range(mock_get_share, mock_upsert, mock_context, api_gateway_event):
+def test_shares_react_rated_rating_out_of_range(mock_get_share, mock_upsert, mock_context, authorized_event):
     mock_get_share.return_value = _share()
-    body = {"email": "bob@example.com", "shareId": "share-1", "action": "rated", "rating": 6}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "action": "rated", "rating": 6}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
 
 
 @patch("lambdas.shares_react.handler.get_share")
-def test_shares_react_share_not_found(mock_get_share, mock_context, api_gateway_event):
+def test_shares_react_share_not_found(mock_get_share, mock_context, authorized_event):
     mock_get_share.return_value = None
-    body = {"email": "bob@example.com", "shareId": "missing", "action": "queued"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "missing", "action": "queued"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 404
 
 
 @patch("lambdas.shares_react.handler.get_share")
-def test_shares_react_missing_required_fields(mock_get_share, mock_context, api_gateway_event):
-    body = {"email": "bob@example.com"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+def test_shares_react_missing_required_fields(mock_get_share, mock_context, authorized_event):
+    body = {}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
     mock_get_share.assert_not_called()
 
@@ -237,7 +235,7 @@ def test_shares_react_threshold_fires_once_at_third_reactor(
     mock_enrich,
     mock_lambda,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     mock_get_share.return_value = _share(author="alice@example.com")
     mock_count.return_value = 3
@@ -260,8 +258,8 @@ def test_shares_react_threshold_fires_once_at_third_reactor(
     original = sr_handler.NOTIFICATIONS_SEND_FUNCTION_NAME
     sr_handler.NOTIFICATIONS_SEND_FUNCTION_NAME = "xomify-notifications-send"
     try:
-        body = {"email": "bob@example.com", "shareId": "share-1", "action": "queued"}
-        response = handler(_event(api_gateway_event, body), mock_context)
+        body = {"shareId": "share-1", "action": "queued"}
+        response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
     finally:
         sr_handler.NOTIFICATIONS_SEND_FUNCTION_NAME = original
 
@@ -289,7 +287,7 @@ def test_shares_react_threshold_idempotent_under_concurrency(
     mock_enrich,
     mock_lambda,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     """
     Simulate three reactors hitting the handler simultaneously (all reading
@@ -316,8 +314,8 @@ def test_shares_react_threshold_idempotent_under_concurrency(
     try:
         reactors = ["bob@example.com", "carol@example.com", "dave@example.com"]
         for reactor in reactors:
-            body = {"email": reactor, "shareId": "share-1", "action": "queued"}
-            resp = handler(_event(api_gateway_event, body), mock_context)
+            body = {"shareId": "share-1", "action": "queued"}
+            resp = handler(_event(authorized_event, body, email=reactor), mock_context)
             assert resp["statusCode"] == 200
     finally:
         sr_handler.NOTIFICATIONS_SEND_FUNCTION_NAME = original
@@ -345,7 +343,7 @@ def test_shares_react_threshold_does_not_refire_past_third(
     mock_enrich,
     mock_lambda,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     mock_get_share.return_value = _share(author="alice@example.com")
     mock_count.return_value = 5  # well past the threshold
@@ -363,8 +361,8 @@ def test_shares_react_threshold_does_not_refire_past_third(
     original = sr_handler.NOTIFICATIONS_SEND_FUNCTION_NAME
     sr_handler.NOTIFICATIONS_SEND_FUNCTION_NAME = "xomify-notifications-send"
     try:
-        body = {"email": "eve@example.com", "shareId": "share-1", "action": "queued"}
-        response = handler(_event(api_gateway_event, body), mock_context)
+        body = {"shareId": "share-1", "action": "queued"}
+        response = handler(_event(authorized_event, body, email="eve@example.com"), mock_context)
     finally:
         sr_handler.NOTIFICATIONS_SEND_FUNCTION_NAME = original
 
@@ -387,7 +385,7 @@ def test_shares_react_self_react_does_not_trigger_push(
     mock_enrich,
     mock_lambda,
     mock_context,
-    api_gateway_event,
+    authorized_event,
 ):
     mock_get_share.return_value = _share(author="alice@example.com")
     mock_count.return_value = 3
@@ -400,11 +398,27 @@ def test_shares_react_self_react_does_not_trigger_push(
     }
 
     # Author reacts to their own share
-    body = {"email": "alice@example.com", "shareId": "share-1", "action": "queued"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "action": "queued"}
+    response = handler(_event(authorized_event, body, email="alice@example.com"), mock_context)
 
     assert response["statusCode"] == 200
     mock_mark_thresh.assert_not_called()
     mock_lambda.invoke.assert_not_called()
     # count_distinct_reactors must not even be queried in the self-react fast-path
     mock_count.assert_not_called()
+
+
+# ------------------------------------------------------------------ Auth
+@patch("lambdas.shares_react.handler.get_share")
+def test_shares_react_missing_caller_identity_returns_401(
+    mock_get_share, mock_context, api_gateway_event
+):
+    event = {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/shares/react",
+        "body": json.dumps({"shareId": "share-1", "action": "queued"}),
+    }
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 401
+    mock_get_share.assert_not_called()

--- a/tests/test_shares_reactions_list.py
+++ b/tests/test_shares_reactions_list.py
@@ -6,6 +6,7 @@ Covers:
 - missing share -> 404
 - missing required fields -> 400
 - group-only share, non-member -> 404
+- missing caller identity -> 401
 """
 
 from __future__ import annotations
@@ -16,13 +17,13 @@ from unittest.mock import patch
 from lambdas.shares_reactions_list.handler import handler
 
 
-def _event(api_gateway_event, params):
-    return {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/shares/reactions",
-        "queryStringParameters": params,
-    }
+def _event(authorized_event, params, email="viewer@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="GET",
+        path="/shares/reactions",
+        queryStringParameters=params,
+    )
 
 
 def _share(public=True, group_ids=None):
@@ -37,7 +38,7 @@ def _share(public=True, group_ids=None):
 @patch("lambdas.shares_reactions_list.handler.build_reaction_summary")
 @patch("lambdas.shares_reactions_list.handler.get_share")
 def test_happy_path(
-    mock_get_share, mock_summary, mock_context, api_gateway_event
+    mock_get_share, mock_summary, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share()
     mock_summary.return_value = {
@@ -45,10 +46,7 @@ def test_happy_path(
         "viewerReactions": ["fire"],
     }
     response = handler(
-        _event(api_gateway_event, {
-            "email": "viewer@example.com",
-            "shareId": "share-1",
-        }),
+        _event(authorized_event, {"shareId": "share-1"}),
         mock_context,
     )
     assert response["statusCode"] == 200
@@ -59,9 +57,9 @@ def test_happy_path(
 
 
 @patch("lambdas.shares_reactions_list.handler.get_share")
-def test_missing_required_fields(mock_get_share, mock_context, api_gateway_event):
+def test_missing_required_fields(mock_get_share, mock_context, authorized_event):
     response = handler(
-        _event(api_gateway_event, {"email": "viewer@example.com"}),
+        _event(authorized_event, {}),
         mock_context,
     )
     assert response["statusCode"] == 400
@@ -69,13 +67,10 @@ def test_missing_required_fields(mock_get_share, mock_context, api_gateway_event
 
 
 @patch("lambdas.shares_reactions_list.handler.get_share")
-def test_share_not_found(mock_get_share, mock_context, api_gateway_event):
+def test_share_not_found(mock_get_share, mock_context, authorized_event):
     mock_get_share.return_value = None
     response = handler(
-        _event(api_gateway_event, {
-            "email": "viewer@example.com",
-            "shareId": "missing",
-        }),
+        _event(authorized_event, {"shareId": "missing"}),
         mock_context,
     )
     assert response["statusCode"] == 404
@@ -85,16 +80,29 @@ def test_share_not_found(mock_get_share, mock_context, api_gateway_event):
 @patch("lambdas.shares_reactions_list.handler.build_reaction_summary")
 @patch("lambdas.shares_reactions_list.handler.get_share")
 def test_group_only_blocks_non_member(
-    mock_get_share, mock_summary, mock_member, mock_context, api_gateway_event
+    mock_get_share, mock_summary, mock_member, mock_context, authorized_event
 ):
     mock_get_share.return_value = _share(public=False, group_ids=["g1"])
     mock_member.return_value = False
     response = handler(
-        _event(api_gateway_event, {
-            "email": "stranger@example.com",
-            "shareId": "share-1",
-        }),
+        _event(authorized_event, {"shareId": "share-1"}, email="stranger@example.com"),
         mock_context,
     )
     assert response["statusCode"] == 404
     mock_summary.assert_not_called()
+
+
+# ------------------------------------------------------------------ Auth
+@patch("lambdas.shares_reactions_list.handler.get_share")
+def test_missing_caller_identity_returns_401(
+    mock_get_share, mock_context, api_gateway_event
+):
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/reactions",
+        "queryStringParameters": {"shareId": "share-1"},
+    }
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 401
+    mock_get_share.assert_not_called()

--- a/tests/test_shares_reactions_toggle.py
+++ b/tests/test_shares_reactions_toggle.py
@@ -8,6 +8,7 @@ Covers:
 - invalid emoji rejected -> 400
 - missing share -> 404
 - group-only share, non-member -> 404
+- missing caller identity -> 401
 """
 
 from __future__ import annotations
@@ -18,13 +19,13 @@ from unittest.mock import patch
 from lambdas.shares_reactions_toggle.handler import handler
 
 
-def _event(api_gateway_event, body):
-    return {
-        **api_gateway_event,
-        "httpMethod": "POST",
-        "path": "/shares/reactions",
-        "body": json.dumps(body),
-    }
+def _event(authorized_event, body, email="bob@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="POST",
+        path="/shares/reactions",
+        body=json.dumps(body),
+    )
 
 
 def _share(public=True, group_ids=None):
@@ -44,7 +45,7 @@ def _share(public=True, group_ids=None):
 @patch("lambdas.shares_reactions_toggle.handler.get_share")
 def test_toggle_on_inserts_when_missing(
     mock_get_share, mock_get_reaction, mock_remove, mock_add, mock_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     mock_get_share.return_value = _share()
     mock_get_reaction.return_value = None
@@ -53,8 +54,8 @@ def test_toggle_on_inserts_when_missing(
         "viewerReactions": ["fire"],
     }
 
-    body = {"email": "bob@example.com", "shareId": "share-1", "reaction": "fire"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "reaction": "fire"}
+    response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
     assert payload["active"] is True
@@ -73,7 +74,7 @@ def test_toggle_on_inserts_when_missing(
 @patch("lambdas.shares_reactions_toggle.handler.get_share")
 def test_toggle_off_deletes_when_present(
     mock_get_share, mock_get_reaction, mock_remove, mock_add, mock_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     mock_get_share.return_value = _share()
     mock_get_reaction.return_value = {
@@ -83,8 +84,8 @@ def test_toggle_off_deletes_when_present(
     }
     mock_summary.return_value = {"counts": {}, "viewerReactions": []}
 
-    body = {"email": "bob@example.com", "shareId": "share-1", "reaction": "fire"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "reaction": "fire"}
+    response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
     assert payload["active"] is False
@@ -100,7 +101,7 @@ def test_toggle_off_deletes_when_present(
 @patch("lambdas.shares_reactions_toggle.handler.get_share")
 def test_user_can_have_multiple_emoji_at_once(
     mock_get_share, mock_get_reaction, mock_remove, mock_add, mock_summary,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     """User has 'fire' set, taps 'heart' -> heart is inserted, fire untouched."""
     mock_get_share.return_value = _share()
@@ -112,8 +113,8 @@ def test_user_can_have_multiple_emoji_at_once(
         "viewerReactions": ["fire", "heart"],
     }
 
-    body = {"email": "bob@example.com", "shareId": "share-1", "reaction": "heart"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "reaction": "heart"}
+    response = handler(_event(authorized_event, body, email="bob@example.com"), mock_context)
     assert response["statusCode"] == 200
     payload = json.loads(response["body"])
     assert payload["active"] is True
@@ -125,27 +126,27 @@ def test_user_can_have_multiple_emoji_at_once(
 
 # ------------------------------------------------------------------ Validation
 @patch("lambdas.shares_reactions_toggle.handler.get_share")
-def test_invalid_emoji_rejected(mock_get_share, mock_context, api_gateway_event):
-    body = {"email": "bob@example.com", "shareId": "share-1", "reaction": "skull"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+def test_invalid_emoji_rejected(mock_get_share, mock_context, authorized_event):
+    body = {"shareId": "share-1", "reaction": "skull"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
     mock_get_share.assert_not_called()
 
 
 @patch("lambdas.shares_reactions_toggle.handler.get_share")
-def test_missing_required_fields(mock_get_share, mock_context, api_gateway_event):
-    body = {"email": "bob@example.com", "shareId": "share-1"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+def test_missing_required_fields(mock_get_share, mock_context, authorized_event):
+    body = {"shareId": "share-1"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 400
     mock_get_share.assert_not_called()
 
 
 # ------------------------------------------------------------------ 404 cases
 @patch("lambdas.shares_reactions_toggle.handler.get_share")
-def test_share_not_found(mock_get_share, mock_context, api_gateway_event):
+def test_share_not_found(mock_get_share, mock_context, authorized_event):
     mock_get_share.return_value = None
-    body = {"email": "bob@example.com", "shareId": "missing", "reaction": "fire"}
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "missing", "reaction": "fire"}
+    response = handler(_event(authorized_event, body), mock_context)
     assert response["statusCode"] == 404
 
 
@@ -155,16 +156,30 @@ def test_share_not_found(mock_get_share, mock_context, api_gateway_event):
 @patch("lambdas.shares_reactions_toggle.handler.get_share")
 def test_group_only_blocks_non_member(
     mock_get_share, mock_get_reaction, mock_add, mock_member,
-    mock_context, api_gateway_event,
+    mock_context, authorized_event,
 ):
     mock_get_share.return_value = _share(public=False, group_ids=["g1"])
     mock_member.return_value = False
-    body = {
-        "email": "stranger@example.com",
-        "shareId": "share-1",
-        "reaction": "fire",
-    }
-    response = handler(_event(api_gateway_event, body), mock_context)
+    body = {"shareId": "share-1", "reaction": "fire"}
+    response = handler(
+        _event(authorized_event, body, email="stranger@example.com"), mock_context
+    )
     assert response["statusCode"] == 404
     mock_get_reaction.assert_not_called()
     mock_add.assert_not_called()
+
+
+# ------------------------------------------------------------------ Auth
+@patch("lambdas.shares_reactions_toggle.handler.get_share")
+def test_missing_caller_identity_returns_401(
+    mock_get_share, mock_context, api_gateway_event
+):
+    event = {
+        **api_gateway_event,
+        "httpMethod": "POST",
+        "path": "/shares/reactions",
+        "body": json.dumps({"shareId": "share-1", "reaction": "fire"}),
+    }
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 401
+    mock_get_share.assert_not_called()

--- a/tests/test_shares_user.py
+++ b/tests/test_shares_user.py
@@ -1,5 +1,8 @@
 """
-Tests for shares_user lambda
+Tests for shares_user lambda.
+
+Note: caller identity (`email`) comes from the JWT authorizer context;
+`targetEmail` (the AUTHOR being viewed) stays a query param.
 """
 
 import json
@@ -8,17 +11,17 @@ from unittest.mock import patch
 from lambdas.shares_user.handler import handler
 
 
-def _event(api_gateway_event, params):
-    return {
-        **api_gateway_event,
-        "httpMethod": "GET",
-        "path": "/shares/user",
-        "queryStringParameters": params,
-    }
+def _event(authorized_event, params, email="me@example.com"):
+    return authorized_event(
+        email=email,
+        httpMethod="GET",
+        path="/shares/user",
+        queryStringParameters=params,
+    )
 
 
 @patch('lambdas.shares_user.handler.list_shares_for_user')
-def test_shares_user_happy_path(mock_list, mock_context, api_gateway_event):
+def test_shares_user_happy_path(mock_list, mock_context, authorized_event):
     mock_list.return_value = (
         [
             {"shareId": "1", "email": "target@example.com", "createdAt": "2026-04-22T12:00:00+00:00"},
@@ -28,7 +31,11 @@ def test_shares_user_happy_path(mock_list, mock_context, api_gateway_event):
     )
 
     response = handler(
-        _event(api_gateway_event, {"email": "me@example.com", "targetEmail": "target@example.com"}),
+        _event(
+            authorized_event,
+            {"targetEmail": "target@example.com"},
+            email="me@example.com",
+        ),
         mock_context,
     )
 
@@ -40,12 +47,11 @@ def test_shares_user_happy_path(mock_list, mock_context, api_gateway_event):
 
 
 @patch('lambdas.shares_user.handler.list_shares_for_user')
-def test_shares_user_pagination_cursor(mock_list, mock_context, api_gateway_event):
+def test_shares_user_pagination_cursor(mock_list, mock_context, authorized_event):
     mock_list.return_value = ([], "2026-04-20T00:00:00+00:00")
 
     response = handler(
-        _event(api_gateway_event, {
-            "email": "me@example.com",
+        _event(authorized_event, {
             "targetEmail": "target@example.com",
             "limit": "10",
             "before": "2026-04-22T00:00:00+00:00",
@@ -62,9 +68,9 @@ def test_shares_user_pagination_cursor(mock_list, mock_context, api_gateway_even
 
 
 @patch('lambdas.shares_user.handler.list_shares_for_user')
-def test_shares_user_missing_target(mock_list, mock_context, api_gateway_event):
+def test_shares_user_missing_target(mock_list, mock_context, authorized_event):
     response = handler(
-        _event(api_gateway_event, {"email": "me@example.com"}),
+        _event(authorized_event, {}),
         mock_context,
     )
     assert response['statusCode'] == 400
@@ -72,10 +78,9 @@ def test_shares_user_missing_target(mock_list, mock_context, api_gateway_event):
 
 
 @patch('lambdas.shares_user.handler.list_shares_for_user')
-def test_shares_user_limit_exceeds_max(mock_list, mock_context, api_gateway_event):
+def test_shares_user_limit_exceeds_max(mock_list, mock_context, authorized_event):
     response = handler(
-        _event(api_gateway_event, {
-            "email": "me@example.com",
+        _event(authorized_event, {
             "targetEmail": "target@example.com",
             "limit": "500",
         }),
@@ -88,7 +93,7 @@ def test_shares_user_limit_exceeds_max(mock_list, mock_context, api_gateway_even
 @patch('lambdas.shares_user.handler.build_enrichment')
 @patch('lambdas.shares_user.handler.list_shares_for_user')
 def test_shares_user_hides_group_only_shares(
-    mock_list, mock_enrich, mock_context, api_gateway_event
+    mock_list, mock_enrich, mock_context, authorized_event
 ):
     """Profile view only surfaces public shares — group-only rows stay scoped
     to their group feeds. Legacy rows (no `public` field) remain visible."""
@@ -114,9 +119,7 @@ def test_shares_user_hides_group_only_shares(
     )
 
     response = handler(
-        _event(api_gateway_event, {
-            "email": "me@example.com", "targetEmail": "target@example.com",
-        }),
+        _event(authorized_event, {"targetEmail": "target@example.com"}),
         mock_context,
     )
 
@@ -124,3 +127,21 @@ def test_shares_user_hides_group_only_shares(
     body = json.loads(response['body'])
     ids = {s['shareId'] for s in body['shares']}
     assert ids == {"legacy", "dual"}
+
+
+# ------------------------------------------------------------------ Auth
+@patch('lambdas.shares_user.handler.list_shares_for_user')
+def test_shares_user_missing_caller_identity_returns_401(
+    mock_list, mock_context, api_gateway_event
+):
+    """Caller is required (via authorizer or fallback) even though target is
+    a different field. Without either, we 401 — not 400."""
+    event = {
+        **api_gateway_event,
+        "httpMethod": "GET",
+        "path": "/shares/user",
+        "queryStringParameters": {"targetEmail": "target@example.com"},
+    }
+    response = handler(event, mock_context)
+    assert response['statusCode'] == 401
+    mock_list.assert_not_called()


### PR DESCRIPTION
Closes #148

## Summary
Sub-feature (1c) of the auth-identity epic. Migrates all 11 shares handlers to read caller email from `requestContext.authorizer.email` via the shared `get_caller_email` helper (introduced in #143). Target identifiers (`shareId`, `commentId`, `groupId`, `targetEmail`) stay as request fields — only the literal "who is calling" email moved.

## Handlers migrated
- `shares_comments_create`
- `shares_comments_delete`
- `shares_comments_list`
- `shares_create`
- `shares_delete` (also dropped `email` from `_extract_identifiers`)
- `shares_detail`
- `shares_feed` (also dropped `require_fields(params, 'email')`)
- `shares_react`
- `shares_reactions_list`
- `shares_reactions_toggle`
- `shares_user` (caller is `email`; target stays `targetEmail` — confirmed not the caller)

## Migration window
The helper keeps a query-string / body fallback during the Track 0 -> Track 1 migration window, so legacy static-token clients keep working. Sub-feature (1l) will strip the fallback after the burn-in.

## Tests
- All existing scenarios reworked to use the `authorized_event` fixture.
- New `missing_caller_identity_returns_401` case per handler covers the no-context-no-fallback path.
- Two handlers (`shares_create`, `shares_comments_create`) keep a `legacy_event` test that exercises the body/query fallback so we won't regress that path before (1l).

## Test plan
- [x] `python -m pytest tests/test_shares_*.py` -- 95 passed
- [x] `python -m pytest` (full suite) -- 237 passed
- [x] No emojis, no Co-Authored-By lines, type hints preserved
- [x] No new dependencies