### PR TITLE
feat: /likes/push lambda + route

### DIFF
--- a/lambdas/likes_push/handler.py
+++ b/lambdas/likes_push/handler.py
@@ -1,0 +1,212 @@
+"""
+POST /likes/push - Persist the caller's most-recent saved tracks.
+
+Body schema:
+    {
+        "email":  "<caller email>",
+        "total":  <int — caller-reported total saved-tracks count>,
+        "tracks": [
+            {
+                "trackId":   "<spotify track id>",
+                "addedAt":   "<ISO8601 timestamp>",
+                "name":      "<track name, optional>",
+                "artist":    "<artist name, optional>",
+                "albumArt":  "<image url, optional>"
+            },
+            ...
+        ]
+    }
+
+Behavior:
+- Caller identity (``email``) is resolved from the trusted authorizer
+  context with the standard body/query fallback. The ``email`` field in
+  the body MUST equal the resolved caller email — cross-user pushes are
+  rejected with 403.
+- ``tracks`` is capped server-side at ``MAX_LIKES_PAGE`` (200). This
+  matches the iOS-side cap; we enforce here as defense in depth so a
+  buggy / malicious client can't blow our write budget.
+- Throttle: if ``total`` matches the cached ``likes_count`` AND the
+  first track's ``addedAt`` matches the cached ``likes_updated_at``,
+  we assume nothing changed and skip the items write entirely (we still
+  refresh ``likes_updated_at`` so "I'm alive" is observable).
+- Otherwise: upsert the items, then write back the new
+  ``likes_count`` + ``likes_updated_at`` on the user record.
+
+Returns:
+    {
+        "throttled":  bool,
+        "written":    int,
+        "likesCount": int,
+        "likesUpdatedAt": str
+    }
+"""
+
+from __future__ import annotations
+
+from lambdas.common.errors import (
+    AuthorizationError,
+    ValidationError,
+    handle_errors,
+)
+from lambdas.common.logger import get_logger
+from lambdas.common.user_likes_dynamo import (
+    MAX_LIKES_PAGE,
+    get_likes_settings,
+    set_user_likes_count,
+    upsert_user_likes,
+)
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    parse_body,
+    require_fields,
+    success_response,
+)
+
+log = get_logger(__file__)
+
+HANDLER = "likes_push"
+
+
+def _coerce_int(raw, field: str) -> int:
+    """Coerce ``raw`` to ``int``, raising ValidationError on failure."""
+    if isinstance(raw, bool):
+        # bool is a subclass of int in Python — reject explicitly so
+        # `True` / `False` don't silently become 1 / 0.
+        raise ValidationError(
+            message=f"{field} must be an integer",
+            handler=HANDLER,
+            function="handler",
+            field=field,
+        )
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        raise ValidationError(
+            message=f"{field} must be an integer",
+            handler=HANDLER,
+            function="handler",
+            field=field,
+        )
+
+
+def _validate_tracks(raw) -> list[dict]:
+    """Normalize + validate the ``tracks`` payload.
+
+    Drops trailing entries past ``MAX_LIKES_PAGE`` and rejects malformed
+    rows. Returns the cleaned list (possibly empty — empty is allowed
+    so the client can push a "0 saved tracks" state).
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValidationError(
+            message="tracks must be a list",
+            handler=HANDLER,
+            function="handler",
+            field="tracks",
+        )
+
+    cleaned: list[dict] = []
+    for idx, entry in enumerate(raw[:MAX_LIKES_PAGE]):
+        if not isinstance(entry, dict):
+            raise ValidationError(
+                message=f"tracks[{idx}] must be an object",
+                handler=HANDLER,
+                function="handler",
+                field="tracks",
+            )
+        track_id = entry.get("trackId")
+        added_at = entry.get("addedAt")
+        if not isinstance(track_id, str) or not track_id.strip():
+            raise ValidationError(
+                message=f"tracks[{idx}].trackId is required",
+                handler=HANDLER,
+                function="handler",
+                field="tracks",
+            )
+        if not isinstance(added_at, str) or not added_at.strip():
+            raise ValidationError(
+                message=f"tracks[{idx}].addedAt is required",
+                handler=HANDLER,
+                function="handler",
+                field="tracks",
+            )
+        cleaned.append(entry)
+
+    return cleaned
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    body = parse_body(event)
+    require_fields(body, "email", "total", "tracks")
+
+    body_email = body.get("email")
+    caller_email = get_caller_email(event)
+
+    # Cross-user push is never allowed — caller can only push their own likes.
+    if not isinstance(body_email, str) or body_email != caller_email:
+        log.warning(
+            f"Cross-user push rejected: caller={caller_email} bodyEmail={body_email}"
+        )
+        raise AuthorizationError(
+            message="Not authorized to push likes for another user",
+            handler=HANDLER,
+            function="handler",
+        )
+
+    total = _coerce_int(body.get("total"), "total")
+    if total < 0:
+        raise ValidationError(
+            message="total must be >= 0",
+            handler=HANDLER,
+            function="handler",
+            field="total",
+        )
+
+    tracks = _validate_tracks(body.get("tracks"))
+
+    log.info(
+        f"likes_push: email={caller_email} total={total} trackCount={len(tracks)}"
+    )
+
+    # Throttle path — if the count matches AND the most-recent addedAt is
+    # the same as our cached updated_at, nothing has changed since the
+    # last sync. Skip the items write but still refresh the timestamp so
+    # we can observe "user opened the app today" downstream.
+    settings = get_likes_settings(caller_email)
+    cached_count = settings.get("likes_count", 0)
+    cached_updated_at = settings.get("likes_updated_at")
+
+    first_added_at = tracks[0].get("addedAt") if tracks else None
+    throttled = bool(
+        tracks
+        and total == cached_count
+        and cached_updated_at is not None
+        and first_added_at == cached_updated_at
+    )
+
+    written = 0
+    if throttled:
+        log.info(
+            f"likes_push throttled for {caller_email} "
+            f"(count={cached_count}, addedAt={cached_updated_at})"
+        )
+        new_updated_at = set_user_likes_count(
+            caller_email, total, updated_at=cached_updated_at
+        )
+    else:
+        if tracks:
+            written = upsert_user_likes(caller_email, tracks)
+        new_updated_at = set_user_likes_count(
+            caller_email, total, updated_at=first_added_at
+        )
+
+    return success_response(
+        {
+            "throttled": throttled,
+            "written": written,
+            "likesCount": total,
+            "likesUpdatedAt": new_updated_at,
+        }
+    )

--- a/tests/test_likes_push.py
+++ b/tests/test_likes_push.py
@@ -1,0 +1,280 @@
+"""
+Tests for the /likes/push lambda.
+
+Covers:
+- Happy path: items written, counter + timestamp updated.
+- Throttle path: count + first-addedAt match cache -> skip items write.
+- Auth-mismatch: body email != caller email -> 403.
+- Validation: missing fields, malformed tracks, oversize cap enforcement,
+  bad ``total`` types.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from lambdas.likes_push.handler import handler
+
+
+def _push_event(authorized_event, *, body: dict) -> dict:
+    """Build an authorized POST /likes/push event with a JSON body."""
+    return authorized_event(
+        email="user@example.com",
+        httpMethod="POST",
+        path="/likes/push",
+        body=json.dumps(body),
+    )
+
+
+# ---------------------------------------------------------------- Happy path
+@patch("lambdas.likes_push.handler.set_user_likes_count")
+@patch("lambdas.likes_push.handler.upsert_user_likes")
+@patch("lambdas.likes_push.handler.get_likes_settings")
+def test_likes_push_happy_path_writes_items_and_counter(
+    mock_get_settings, mock_upsert, mock_set_count, mock_context, authorized_event
+):
+    mock_get_settings.return_value = {
+        "likes_count": 0,
+        "likes_updated_at": None,
+        "likes_public": True,
+    }
+    mock_upsert.return_value = 2
+    mock_set_count.return_value = "2025-04-26T00:00:00Z"
+
+    event = _push_event(
+        authorized_event,
+        body={
+            "email": "user@example.com",
+            "total": 2,
+            "tracks": [
+                {"trackId": "t1", "addedAt": "2025-04-26T00:00:00Z", "name": "S1"},
+                {"trackId": "t2", "addedAt": "2025-04-25T00:00:00Z", "name": "S2"},
+            ],
+        },
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body == {
+        "throttled": False,
+        "written": 2,
+        "likesCount": 2,
+        "likesUpdatedAt": "2025-04-26T00:00:00Z",
+    }
+    mock_upsert.assert_called_once_with("user@example.com", event_tracks(event))
+    mock_set_count.assert_called_once_with(
+        "user@example.com", 2, updated_at="2025-04-26T00:00:00Z"
+    )
+
+
+def event_tracks(event: dict) -> list[dict]:
+    return json.loads(event["body"])["tracks"]
+
+
+# ---------------------------------------------------------------- Throttle path
+@patch("lambdas.likes_push.handler.set_user_likes_count")
+@patch("lambdas.likes_push.handler.upsert_user_likes")
+@patch("lambdas.likes_push.handler.get_likes_settings")
+def test_likes_push_throttled_when_total_and_first_added_match(
+    mock_get_settings, mock_upsert, mock_set_count, mock_context, authorized_event
+):
+    mock_get_settings.return_value = {
+        "likes_count": 5,
+        "likes_updated_at": "2025-04-26T00:00:00Z",
+        "likes_public": True,
+    }
+    mock_set_count.return_value = "2025-04-26T00:00:00Z"
+
+    event = _push_event(
+        authorized_event,
+        body={
+            "email": "user@example.com",
+            "total": 5,
+            "tracks": [
+                {"trackId": "t1", "addedAt": "2025-04-26T00:00:00Z"},
+                {"trackId": "t2", "addedAt": "2025-04-25T00:00:00Z"},
+            ],
+        },
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["throttled"] is True
+    assert body["written"] == 0
+    assert body["likesCount"] == 5
+    # Items write must be skipped on throttle.
+    mock_upsert.assert_not_called()
+    # Timestamp refresh still fires so "user is alive" remains observable.
+    mock_set_count.assert_called_once_with(
+        "user@example.com", 5, updated_at="2025-04-26T00:00:00Z"
+    )
+
+
+@patch("lambdas.likes_push.handler.set_user_likes_count")
+@patch("lambdas.likes_push.handler.upsert_user_likes")
+@patch("lambdas.likes_push.handler.get_likes_settings")
+def test_likes_push_not_throttled_when_count_matches_but_addedat_differs(
+    mock_get_settings, mock_upsert, mock_set_count, mock_context, authorized_event
+):
+    """Same count but the latest addedAt moved -> user added+removed, so write."""
+    mock_get_settings.return_value = {
+        "likes_count": 5,
+        "likes_updated_at": "2025-04-25T00:00:00Z",
+        "likes_public": True,
+    }
+    mock_upsert.return_value = 2
+    mock_set_count.return_value = "2025-04-26T00:00:00Z"
+
+    event = _push_event(
+        authorized_event,
+        body={
+            "email": "user@example.com",
+            "total": 5,
+            "tracks": [
+                {"trackId": "t1", "addedAt": "2025-04-26T00:00:00Z"},
+                {"trackId": "t2", "addedAt": "2025-04-25T00:00:00Z"},
+            ],
+        },
+    )
+
+    response = handler(event, mock_context)
+
+    body = json.loads(response["body"])
+    assert body["throttled"] is False
+    mock_upsert.assert_called_once()
+
+
+# ---------------------------------------------------------------- Auth gate
+@patch("lambdas.likes_push.handler.set_user_likes_count")
+@patch("lambdas.likes_push.handler.upsert_user_likes")
+@patch("lambdas.likes_push.handler.get_likes_settings")
+def test_likes_push_rejects_cross_user_push(
+    mock_get_settings, mock_upsert, mock_set_count, mock_context, authorized_event
+):
+    event = _push_event(
+        authorized_event,
+        body={
+            "email": "someone-else@example.com",
+            "total": 1,
+            "tracks": [{"trackId": "t1", "addedAt": "2025-04-26T00:00:00Z"}],
+        },
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 401  # Authorization error -> 401 by base class
+    mock_upsert.assert_not_called()
+    mock_set_count.assert_not_called()
+
+
+# ---------------------------------------------------------------- Validation
+def test_likes_push_missing_email_field(mock_context, authorized_event):
+    event = _push_event(
+        authorized_event,
+        body={"total": 0, "tracks": []},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_likes_push_missing_total(mock_context, authorized_event):
+    event = _push_event(
+        authorized_event,
+        body={"email": "user@example.com", "tracks": []},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_likes_push_missing_tracks(mock_context, authorized_event):
+    event = _push_event(
+        authorized_event,
+        body={"email": "user@example.com", "total": 0},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_likes_push_rejects_non_int_total(mock_context, authorized_event):
+    event = _push_event(
+        authorized_event,
+        body={"email": "user@example.com", "total": "lots", "tracks": []},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_likes_push_rejects_negative_total(mock_context, authorized_event):
+    event = _push_event(
+        authorized_event,
+        body={"email": "user@example.com", "total": -1, "tracks": []},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_likes_push_rejects_malformed_tracks(mock_context, authorized_event):
+    event = _push_event(
+        authorized_event,
+        body={
+            "email": "user@example.com",
+            "total": 1,
+            "tracks": [{"trackId": "t1"}],  # missing addedAt
+        },
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_likes_push_rejects_non_list_tracks(mock_context, authorized_event):
+    event = _push_event(
+        authorized_event,
+        body={"email": "user@example.com", "total": 0, "tracks": "nope"},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+@patch("lambdas.likes_push.handler.set_user_likes_count")
+@patch("lambdas.likes_push.handler.upsert_user_likes")
+@patch("lambdas.likes_push.handler.get_likes_settings")
+def test_likes_push_caps_oversized_payload_at_max(
+    mock_get_settings, mock_upsert, mock_set_count, mock_context, authorized_event
+):
+    """Oversize payloads are silently truncated to MAX_LIKES_PAGE."""
+    from lambdas.likes_push import handler as likes_push_handler
+
+    mock_get_settings.return_value = {
+        "likes_count": 0,
+        "likes_updated_at": None,
+        "likes_public": True,
+    }
+    mock_upsert.return_value = likes_push_handler.MAX_LIKES_PAGE
+    mock_set_count.return_value = "2025-04-26T00:00:00Z"
+
+    big_payload = [
+        {"trackId": f"t{i}", "addedAt": "2025-04-26T00:00:00Z"}
+        for i in range(likes_push_handler.MAX_LIKES_PAGE + 50)
+    ]
+    event = _push_event(
+        authorized_event,
+        body={
+            "email": "user@example.com",
+            "total": len(big_payload),
+            "tracks": big_payload,
+        },
+    )
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    args, _kwargs = mock_upsert.call_args
+    sent_tracks = args[1]
+    assert len(sent_tracks) == likes_push_handler.MAX_LIKES_PAGE


### PR DESCRIPTION
## Summary

Phase 2 of the **Social Library — Friend-Visible Likes** feature.
Plan: \`xomify-ios/docs/features/social-library-likes/PLAN.md\`.

New lambda \`lambdas/likes_push/\` exposing **POST /likes/push**. iOS will
fire-and-forget this on cold-open with the user's most-recent saved
tracks so friends can see counts/lists in subsequent phases.

## Behavior

**Body**:
\`\`\`
{
  \"email\":  \"<caller email>\",
  \"total\":  <int>,
  \"tracks\": [
    { \"trackId\": \"...\", \"addedAt\": \"<ISO8601>\",
      \"name\": \"...\", \"artist\": \"...\", \"albumArt\": \"...\" }
  ]
}
\`\`\`

- **Auth**: caller identity from authorizer context (with body/query
  fallback per existing pattern). \`body.email\` MUST equal the resolved
  caller email — cross-user pushes -> 401.
- **Cap**: \`tracks\` truncated server-side to 200 rows (matches the
  iOS-side cap). Defense in depth.
- **Throttle**: if \`total\` matches the cached \`likes_count\` AND the
  first track's \`addedAt\` matches the cached \`likes_updated_at\`, the
  items batch-write is skipped (timestamp still refreshes so \"is the
  user alive\" remains observable).
- **Persist**: \`upsert_user_likes\` -> batch-write items, then
  \`set_user_likes_count\` -> bump counter + timestamp on the user row.

**Response**:
\`\`\`
{
  \"throttled\":      bool,
  \"written\":        int,
  \"likesCount\":     int,
  \"likesUpdatedAt\": str
}
\`\`\`

## Tests (12, all green)

- Happy path — items written, counter bumped.
- Throttle path — count + first-addedAt match cache -> skip items write.
- Same count but addedAt drift -> NOT throttled (catches add+remove case).
- Cross-user push rejected (401).
- Missing email / total / tracks -> 400.
- Non-int total / negative total -> 400.
- Malformed track entries -> 400.
- Non-list tracks -> 400.
- Oversize payload silently capped at 200.

\`pytest tests/test_likes_push.py\` -> 12 / 12 pass.
Full suite -> 370 / 370 pass.

## Infra follow-up (xomify-infrastructure)

Routes/lambdas need wiring in Terraform:

1. **API Gateway route**: \`POST /likes/push\` -> new lambda
   \`xomify-likes-push\` (mirror auth/CORS settings of \`/shares/create\`).
2. **Lambda env vars** (must be set on \`xomify-likes-push\`):
   - \`USERS_TABLE_NAME\`
   - \`USER_LIKES_TABLE_NAME\` (new table from PR #169 follow-up)
   - \`USER_LIKES_EMAIL_ADDED_INDEX\` (default \`email-addedAt-index\`)
   - \`AWS_DEFAULT_REGION\`
3. **IAM**: read+write on \`xomify-users\` and the new \`xomify-user-likes\`
   table (incl. its GSI).

PR #169 already documents the table schema this depends on.

## Test plan

- [x] \`pytest tests/test_likes_push.py\` — 12 / 12 pass
- [x] Full suite — 370 / 370 pass (no regressions)