### PR TITLE
feat: /likes/by-user lambda + route

### DIFF
--- a/lambdas/common/friendships_dynamo.py
+++ b/lambdas/common/friendships_dynamo.py
@@ -195,6 +195,41 @@ def delete_friends(email: str, request_email: str):
 
 
 # ============================================
+# Are Two Users Accepted Friends?
+# ============================================
+def are_users_friends(email: str, other_email: str) -> bool:
+    """Return True iff ``email`` and ``other_email`` have an accepted friendship.
+
+    Uses a direct GetItem on the base table (PK=email, SK=friendEmail) so
+    this stays cheap — no scan, no extra GSI round-trip. We intentionally
+    only check the caller's row: rows are written symmetrically by
+    ``accept_friend_request`` / ``create_accepted_friendship`` so a single
+    read is sufficient. If the caller's row is missing or not in the
+    ``accepted`` state, the relationship doesn't count for visibility
+    gates.
+
+    Returns False on the same-email case (callers should special-case
+    self-access before calling this).
+    """
+    if not email or not other_email or email == other_email:
+        return False
+    try:
+        table = dynamodb.Table(FRIENDSHIPS_TABLE_NAME)
+        res = table.get_item(Key={"email": email, "friendEmail": other_email})
+        item = res.get("Item")
+        if not item:
+            return False
+        return item.get("status") == "accepted"
+    except Exception as err:
+        log.error(f"are_users_friends failed for {email}/{other_email}: {err}")
+        raise DynamoDBError(
+            message=str(err),
+            function="are_users_friends",
+            table=FRIENDSHIPS_TABLE_NAME,
+        )
+
+
+# ============================================
 # Create Accepted Friendship (from invite flow)
 # ============================================
 def create_accepted_friendship(sender_email: str, recipient_email: str):

--- a/lambdas/likes_by_user/handler.py
+++ b/lambdas/likes_by_user/handler.py
@@ -1,0 +1,146 @@
+"""
+GET /likes/by-user - Friend-scoped paginated read of saved tracks.
+
+Query string:
+    email        - caller email (resolved via authorizer context fallback)
+    targetEmail  - the user whose likes to fetch
+    limit        - page size, default 50, max 200
+    offset       - skip N items, default 0
+
+Authorization:
+- Self-access (caller == targetEmail) is always allowed.
+- Otherwise, caller must have an *accepted* friendship with the target.
+- Even when the friendship gate passes, the target's ``likes_public``
+  flag must be true. If the target has flipped it off, we 403.
+
+Response:
+    {
+        \"tracks\": [...],   # newest-first
+        \"total\":  N,
+        \"hasMore\": bool,
+        \"likesPublic\": bool   # echoed for the iOS settings sync
+    }
+"""
+
+from __future__ import annotations
+
+from lambdas.common.errors import (
+    AuthorizationError,
+    ValidationError,
+    handle_errors,
+)
+from lambdas.common.friendships_dynamo import are_users_friends
+from lambdas.common.logger import get_logger
+from lambdas.common.user_likes_dynamo import (
+    MAX_LIKES_PAGE,
+    get_likes_settings,
+    query_user_likes,
+)
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    get_query_params,
+    require_fields,
+    success_response,
+)
+
+log = get_logger(__file__)
+
+HANDLER = "likes_by_user"
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = MAX_LIKES_PAGE  # 200 — matches the push cap
+
+
+def _parse_int(raw, field: str, default: int, *, minimum: int, maximum: int | None) -> int:
+    """Parse an integer query-param with bounds checks."""
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ValidationError(
+            message=f"{field} must be an integer",
+            handler=HANDLER,
+            function="handler",
+            field=field,
+        )
+    if value < minimum:
+        raise ValidationError(
+            message=f"{field} must be >= {minimum}",
+            handler=HANDLER,
+            function="handler",
+            field=field,
+        )
+    if maximum is not None and value > maximum:
+        raise ValidationError(
+            message=f"{field} cannot exceed {maximum}",
+            handler=HANDLER,
+            function="handler",
+            field=field,
+        )
+    return value
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    params = get_query_params(event)
+    require_fields(params, "targetEmail")
+
+    target_email = params.get("targetEmail")
+    caller_email = get_caller_email(event)
+
+    limit = _parse_int(
+        params.get("limit"), "limit", DEFAULT_LIMIT, minimum=1, maximum=MAX_LIMIT
+    )
+    offset = _parse_int(
+        params.get("offset"), "offset", 0, minimum=0, maximum=None
+    )
+
+    is_self = caller_email == target_email
+
+    # Visibility gate. We always read the target's likes settings because we
+    # need ``likes_public`` for the privacy check AND we want to echo it
+    # back to the client (so the iOS settings toggle stays in sync without
+    # a second round-trip).
+    settings = get_likes_settings(target_email)
+    likes_public = bool(settings.get("likes_public", True))
+
+    if not is_self:
+        # Friend gate first — non-friends never even hit the privacy check
+        # (avoids leaking that a private user exists by way of a 403 vs 404).
+        if not are_users_friends(caller_email, target_email):
+            log.warning(
+                f"likes_by_user: non-friend access blocked "
+                f"caller={caller_email} target={target_email}"
+            )
+            raise AuthorizationError(
+                message="Not authorized to view this user's likes",
+                handler=HANDLER,
+                function="handler",
+            )
+        if not likes_public:
+            log.info(
+                f"likes_by_user: privacy gate blocked "
+                f"caller={caller_email} target={target_email}"
+            )
+            raise AuthorizationError(
+                message="Target user has hidden their likes",
+                handler=HANDLER,
+                function="handler",
+            )
+
+    log.info(
+        f"likes_by_user: caller={caller_email} target={target_email} "
+        f"limit={limit} offset={offset} self={is_self}"
+    )
+
+    page = query_user_likes(target_email, limit=limit, offset=offset)
+
+    return success_response(
+        {
+            "tracks": page.get("tracks", []),
+            "total": page.get("total", 0),
+            "hasMore": bool(page.get("hasMore", False)),
+            "likesPublic": likes_public,
+        }
+    )

--- a/tests/test_friendships_dynamo_are_friends.py
+++ b/tests/test_friendships_dynamo_are_friends.py
@@ -1,0 +1,78 @@
+"""
+Tests for the are_users_friends helper added to friendships_dynamo.
+
+The helper backs friend-visibility gates (e.g. /likes/by-user) and must
+stay cheap (single GetItem) and forgiving (returns False for the missing
+or non-accepted case rather than throwing).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lambdas.common import friendships_dynamo
+from lambdas.common.errors import DynamoDBError
+
+
+@patch("lambdas.common.friendships_dynamo.dynamodb")
+def test_returns_true_for_accepted_friendship(mock_ddb):
+    table = MagicMock()
+    table.get_item.return_value = {
+        "Item": {
+            "email": "a@example.com",
+            "friendEmail": "b@example.com",
+            "status": "accepted",
+        }
+    }
+    mock_ddb.Table.return_value = table
+
+    assert friendships_dynamo.are_users_friends("a@example.com", "b@example.com") is True
+    table.get_item.assert_called_once_with(
+        Key={"email": "a@example.com", "friendEmail": "b@example.com"}
+    )
+
+
+@patch("lambdas.common.friendships_dynamo.dynamodb")
+def test_returns_false_for_pending_friendship(mock_ddb):
+    table = MagicMock()
+    table.get_item.return_value = {
+        "Item": {
+            "email": "a@example.com",
+            "friendEmail": "b@example.com",
+            "status": "pending",
+        }
+    }
+    mock_ddb.Table.return_value = table
+
+    assert friendships_dynamo.are_users_friends("a@example.com", "b@example.com") is False
+
+
+@patch("lambdas.common.friendships_dynamo.dynamodb")
+def test_returns_false_for_missing_row(mock_ddb):
+    table = MagicMock()
+    table.get_item.return_value = {}
+    mock_ddb.Table.return_value = table
+
+    assert friendships_dynamo.are_users_friends("a@example.com", "b@example.com") is False
+
+
+def test_same_email_short_circuits_to_false():
+    """Self-edge has no friendship row; callers should special-case self-access."""
+    assert friendships_dynamo.are_users_friends("a@example.com", "a@example.com") is False
+
+
+def test_empty_inputs_short_circuit_to_false():
+    assert friendships_dynamo.are_users_friends("", "b@example.com") is False
+    assert friendships_dynamo.are_users_friends("a@example.com", "") is False
+
+
+@patch("lambdas.common.friendships_dynamo.dynamodb")
+def test_ddb_error_is_wrapped(mock_ddb):
+    table = MagicMock()
+    table.get_item.side_effect = RuntimeError("DDB throttled")
+    mock_ddb.Table.return_value = table
+
+    with pytest.raises(DynamoDBError):
+        friendships_dynamo.are_users_friends("a@example.com", "b@example.com")

--- a/tests/test_likes_by_user.py
+++ b/tests/test_likes_by_user.py
@@ -1,0 +1,179 @@
+"""
+Tests for the /likes/by-user lambda.
+
+Covers:
+- Friend access -> 200 with paginated rows.
+- Self access -> bypasses friendship check.
+- Non-friend access -> 403/401.
+- Privacy gate: friend reading a target with likes_public=false -> 403/401.
+- Self can read their own likes regardless of likes_public.
+- Pagination params: limit/offset bounds enforced.
+- Missing targetEmail -> 400.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from lambdas.likes_by_user.handler import handler
+
+
+def _get_event(authorized_event, *, caller="me@example.com", target="friend@example.com", **qs):
+    qsp = {"targetEmail": target}
+    qsp.update({k: str(v) for k, v in qs.items()})
+    return authorized_event(
+        email=caller,
+        httpMethod="GET",
+        path="/likes/by-user",
+        queryStringParameters=qsp,
+    )
+
+
+# ---------------------------------------------------------------- Friend success
+@patch("lambdas.likes_by_user.handler.query_user_likes")
+@patch("lambdas.likes_by_user.handler.are_users_friends")
+@patch("lambdas.likes_by_user.handler.get_likes_settings")
+def test_friend_can_read_paginated_likes(
+    mock_settings, mock_friends, mock_query, mock_context, authorized_event
+):
+    mock_settings.return_value = {"likes_count": 5, "likes_updated_at": "ts", "likes_public": True}
+    mock_friends.return_value = True
+    mock_query.return_value = {
+        "tracks": [
+            {"trackId": "t1", "addedAt": "2025-04-26T00:00:00Z", "trackName": "S1"},
+            {"trackId": "t2", "addedAt": "2025-04-25T00:00:00Z", "trackName": "S2"},
+        ],
+        "total": 5,
+        "hasMore": True,
+    }
+
+    event = _get_event(authorized_event, limit=2, offset=0)
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["total"] == 5
+    assert body["hasMore"] is True
+    assert body["likesPublic"] is True
+    assert len(body["tracks"]) == 2
+    mock_query.assert_called_once_with("friend@example.com", limit=2, offset=0)
+
+
+# ---------------------------------------------------------------- Self bypass
+@patch("lambdas.likes_by_user.handler.query_user_likes")
+@patch("lambdas.likes_by_user.handler.are_users_friends")
+@patch("lambdas.likes_by_user.handler.get_likes_settings")
+def test_self_access_bypasses_friendship_check(
+    mock_settings, mock_friends, mock_query, mock_context, authorized_event
+):
+    mock_settings.return_value = {"likes_count": 1, "likes_updated_at": "ts", "likes_public": False}
+    mock_query.return_value = {"tracks": [], "total": 0, "hasMore": False}
+
+    event = _get_event(authorized_event, caller="me@example.com", target="me@example.com")
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    # Self can see their own likes regardless of public flag.
+    assert body["likesPublic"] is False
+    # Friendship lookup must be skipped on self-access.
+    mock_friends.assert_not_called()
+
+
+# ---------------------------------------------------------------- Non-friend gate
+@patch("lambdas.likes_by_user.handler.query_user_likes")
+@patch("lambdas.likes_by_user.handler.are_users_friends")
+@patch("lambdas.likes_by_user.handler.get_likes_settings")
+def test_non_friend_access_rejected(
+    mock_settings, mock_friends, mock_query, mock_context, authorized_event
+):
+    mock_settings.return_value = {"likes_count": 5, "likes_updated_at": "ts", "likes_public": True}
+    mock_friends.return_value = False
+
+    event = _get_event(authorized_event)
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 401  # AuthorizationError -> 401
+    mock_query.assert_not_called()
+
+
+# ---------------------------------------------------------------- Privacy gate
+@patch("lambdas.likes_by_user.handler.query_user_likes")
+@patch("lambdas.likes_by_user.handler.are_users_friends")
+@patch("lambdas.likes_by_user.handler.get_likes_settings")
+def test_friend_blocked_when_target_likes_private(
+    mock_settings, mock_friends, mock_query, mock_context, authorized_event
+):
+    mock_settings.return_value = {"likes_count": 5, "likes_updated_at": "ts", "likes_public": False}
+    mock_friends.return_value = True
+
+    event = _get_event(authorized_event)
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 401  # privacy block surfaces as auth error
+    mock_query.assert_not_called()
+
+
+# ---------------------------------------------------------------- Validation
+def test_missing_target_email_400(mock_context, authorized_event):
+    event = authorized_event(
+        httpMethod="GET",
+        path="/likes/by-user",
+        queryStringParameters={},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+@patch("lambdas.likes_by_user.handler.query_user_likes")
+@patch("lambdas.likes_by_user.handler.are_users_friends")
+@patch("lambdas.likes_by_user.handler.get_likes_settings")
+def test_limit_bounds_enforced(
+    mock_settings, mock_friends, mock_query, mock_context, authorized_event
+):
+    mock_settings.return_value = {"likes_count": 1, "likes_updated_at": "ts", "likes_public": True}
+    mock_friends.return_value = True
+
+    event = _get_event(authorized_event, limit=0)
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+    event = _get_event(authorized_event, limit=999)
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+@patch("lambdas.likes_by_user.handler.query_user_likes")
+@patch("lambdas.likes_by_user.handler.are_users_friends")
+@patch("lambdas.likes_by_user.handler.get_likes_settings")
+def test_offset_must_be_non_negative(
+    mock_settings, mock_friends, mock_query, mock_context, authorized_event
+):
+    mock_settings.return_value = {"likes_count": 1, "likes_updated_at": "ts", "likes_public": True}
+    mock_friends.return_value = True
+
+    event = _get_event(authorized_event, offset=-1)
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+@patch("lambdas.likes_by_user.handler.query_user_likes")
+@patch("lambdas.likes_by_user.handler.are_users_friends")
+@patch("lambdas.likes_by_user.handler.get_likes_settings")
+def test_paginated_offset_passed_through(
+    mock_settings, mock_friends, mock_query, mock_context, authorized_event
+):
+    mock_settings.return_value = {"likes_count": 4, "likes_updated_at": "ts", "likes_public": True}
+    mock_friends.return_value = True
+    mock_query.return_value = {
+        "tracks": [{"trackId": "t3", "addedAt": "ts"}],
+        "total": 4,
+        "hasMore": False,
+    }
+
+    event = _get_event(authorized_event, limit=1, offset=3)
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    mock_query.assert_called_once_with("friend@example.com", limit=1, offset=3)


### PR DESCRIPTION
## Summary

Phase 3 of the **Social Library — Friend-Visible Likes** feature.
Plan: \`xomify-ios/docs/features/social-library-likes/PLAN.md\`.

New lambda \`lambdas/likes_by_user/\` exposing **GET /likes/by-user**.
Powers the friend-scoped Likes page on iOS.

## Behavior

**Query string**:
- \`targetEmail\` (required) — whose likes to fetch.
- \`limit\` (default 50, max 200) — page size.
- \`offset\` (default 0) — skip N items.
- \`email\` (optional, falls through caller-identity helper) — caller email.

**Authorization**:
1. Self-access (caller == target) is always allowed (bypasses both the
   friend gate AND the privacy flag — you can always see your own likes).
2. Otherwise, caller must have an \`accepted\` friendship row with target.
3. Even with an accepted friendship, the target's \`likes_public\` must
   be true. Private targets -> 401.

The friend gate runs **before** the privacy gate so we don't leak
\"a private user exists\" via a distinguishable response code.

**Response**:
\`\`\`
{
  \"tracks\":      [...],   // newest-first, paginated slice
  \"total\":       int,
  \"hasMore\":     bool,
  \"likesPublic\": bool     // echoed for iOS settings sync
}
\`\`\`

## Helper added

\`lambdas/common/friendships_dynamo.are_users_friends(email, other_email)\`
— single GetItem against the friendships table; returns False on missing
row or non-\`accepted\` status; short-circuits to False for empty / same-email
inputs (callers should special-case self-access). Wraps DDB exceptions in
\`DynamoDBError\` for consistency.

## Tests (14, all green)

- \`test_likes_by_user.py\`
  - Friend access -> 200 paginated.
  - Self bypasses friendship + privacy.
  - Non-friend -> 401.
  - Friend blocked when target.likes_public=false.
  - Missing targetEmail -> 400.
  - Limit bounds (0, >200) enforced.
  - Negative offset -> 400.
  - Pagination params passed through.
- \`test_friendships_dynamo_are_friends.py\`
  - accepted -> True.
  - pending -> False.
  - missing row -> False.
  - same-email -> False.
  - empty inputs -> False.
  - DDB error wrapped in DynamoDBError.

\`pytest tests/test_likes_by_user.py tests/test_friendships_dynamo_are_friends.py\`
-> 14 / 14 pass.
Full suite -> 384 / 384 pass (no regressions).

## Infra follow-up (xomify-infrastructure)

1. **API Gateway route**: \`GET /likes/by-user\` -> new lambda
   \`xomify-likes-by-user\` (mirror auth/CORS settings of
   \`/friends/profile\`).
2. **Lambda env vars** on \`xomify-likes-by-user\`:
   - \`USERS_TABLE_NAME\`
   - \`USER_LIKES_TABLE_NAME\`
   - \`USER_LIKES_EMAIL_ADDED_INDEX\` (default \`email-addedAt-index\`)
   - \`FRIENDSHIPS_TABLE_NAME\`
   - \`AWS_DEFAULT_REGION\`
3. **IAM**: read-only on \`xomify-users\`, \`xomify-friendships\`, and the
   \`xomify-user-likes\` table (incl. its GSI).

## Test plan

- [x] \`pytest tests/test_likes_by_user.py tests/test_friendships_dynamo_are_friends.py\` — 14 / 14 pass
- [x] Full suite — 384 / 384 pass (no regressions)