### PR TITLE
feat: friends_profile likesCount + users_set_likes_public lambda

### DIFF
--- a/lambdas/friends_profile/handler.py
+++ b/lambdas/friends_profile/handler.py
@@ -10,10 +10,16 @@ fails) still decodes — we just leave the count out instead of 500ing.
 import asyncio
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response, get_query_params, require_fields
+from lambdas.common.utility_helpers import (
+    success_response,
+    get_query_params,
+    require_fields,
+    get_caller_email,
+)
 from lambdas.common.dynamo_helpers import get_user_table_data
 from lambdas.common.friends_profile_helper import get_user_top_items, get_user_public_playlists
 from lambdas.common.shares_dynamo import count_shares_for_user
+from lambdas.common.user_likes_dynamo import get_likes_settings
 
 log = get_logger(__file__)
 
@@ -42,12 +48,41 @@ def _safe_share_count(friend_email: str) -> int | None:
         return None
 
 
+def _safe_likes_settings(friend_email: str) -> dict | None:
+    """Return ``{likes_count, likes_public}`` for friend, or None on failure.
+
+    Mirrors ``_safe_share_count`` semantics: failures degrade the field
+    to absent rather than 500ing the whole profile request.
+    """
+    try:
+        return get_likes_settings(friend_email)
+    except Exception as err:
+        log.warning(f"likesSettings lookup failed for {friend_email}: {err}")
+        return None
+
+
+def _safe_caller_email(event) -> str | None:
+    """Resolve the caller's email or return None if it can't be determined.
+
+    The friends_profile endpoint should not 401 just because we couldn't
+    resolve the caller — the privacy gate falls open to "treat as
+    non-self" (i.e. we honour ``likes_public``) which is the safer
+    default for a read-only profile lookup.
+    """
+    try:
+        return get_caller_email(event)
+    except Exception as err:
+        log.warning(f"caller-email resolution failed in friends_profile: {err}")
+        return None
+
+
 @handle_errors(HANDLER)
 def handler(event, context):
     params = get_query_params(event)
     require_fields(params, 'friendEmail')
 
     friend_email = params.get('friendEmail')
+    caller_email = _safe_caller_email(event)
 
     log.info(f"Getting friend's profile for user {friend_email}")
     friend_user = get_user_table_data(friend_email)
@@ -73,5 +108,17 @@ def handler(event, context):
     }
     if share_count is not None:
         payload['shareCount'] = share_count
+
+    # likesCount enrichment — honour the target's privacy flag. We only
+    # include the field when:
+    #   - the lookup succeeded, AND
+    #   - the target has likes_public=True OR the caller is the target.
+    # Otherwise the field is omitted (iOS treats absence as "unknown" and
+    # hides the chip, matching the contract for shareCount/playlistCount).
+    likes_settings = _safe_likes_settings(friend_email)
+    if likes_settings is not None:
+        is_self = caller_email is not None and caller_email == friend_email
+        if is_self or likes_settings.get('likes_public', True):
+            payload['likesCount'] = int(likes_settings.get('likes_count', 0))
 
     return success_response(payload)

--- a/lambdas/users_set_likes_public/handler.py
+++ b/lambdas/users_set_likes_public/handler.py
@@ -1,0 +1,80 @@
+"""
+POST /users/likes-public - Toggle the caller's "show my likes to friends" flag.
+
+Body:
+    { \"email\": \"<caller email>\", \"value\": <bool> }
+
+Authorization:
+- The body's ``email`` MUST equal the resolved caller email — users
+  can only flip their own flag.
+
+Returns:
+    { \"email\": str, \"likesPublic\": bool }
+"""
+
+from __future__ import annotations
+
+from lambdas.common.errors import (
+    AuthorizationError,
+    ValidationError,
+    handle_errors,
+)
+from lambdas.common.logger import get_logger
+from lambdas.common.user_likes_dynamo import set_likes_public
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    parse_body,
+    require_fields,
+    success_response,
+)
+
+log = get_logger(__file__)
+
+HANDLER = "users_set_likes_public"
+
+
+def _coerce_bool(raw, field: str) -> bool:
+    """Strict bool coercion. Accept the standard JSON literal or the
+    common stringy ``"true"`` / ``"false"`` forms iOS may send.
+    """
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise ValidationError(
+        message=f"{field} must be a boolean",
+        handler=HANDLER,
+        function="handler",
+        field=field,
+    )
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    body = parse_body(event)
+    require_fields(body, "email", "value")
+
+    body_email = body.get("email")
+    caller_email = get_caller_email(event)
+
+    if not isinstance(body_email, str) or body_email != caller_email:
+        log.warning(
+            f"Cross-user likes-public toggle rejected: "
+            f"caller={caller_email} bodyEmail={body_email}"
+        )
+        raise AuthorizationError(
+            message="Not authorized to update another user's settings",
+            handler=HANDLER,
+            function="handler",
+        )
+
+    value = _coerce_bool(body.get("value"), "value")
+
+    log.info(f"Setting likes_public={value} for {caller_email}")
+    persisted = set_likes_public(caller_email, value)
+
+    return success_response({"email": caller_email, "likesPublic": persisted})

--- a/tests/test_friends_profile.py
+++ b/tests/test_friends_profile.py
@@ -130,3 +130,134 @@ def test_friends_profile_share_count_failure_does_not_500(
     assert 'shareCount' not in body
     # playlistCount still present (derived from playlists list length).
     assert body['playlistCount'] == 0
+
+
+# --------------------------------------------------------------------
+# likesCount enrichment (Phase 4)
+# --------------------------------------------------------------------
+# Friends should see a target's likesCount when the target has
+# likes_public=True (default). Self always sees their own count.
+# Private targets cause the field to be omitted (iOS hides the chip).
+@patch('lambdas.friends_profile.handler.get_likes_settings')
+@patch('lambdas.friends_profile.handler.count_shares_for_user')
+@patch('lambdas.friends_profile.handler.get_user_public_playlists')
+@patch('lambdas.friends_profile.handler.get_user_top_items')
+@patch('lambdas.friends_profile.handler.get_user_table_data')
+def test_friends_profile_includes_likes_count_when_public(
+    mock_get_user, mock_get_top_items, mock_get_playlists, mock_count, mock_likes,
+    mock_context, authorized_event, sample_user, sample_top_items,
+):
+    mock_get_user.return_value = sample_user
+    mock_get_top_items.return_value = sample_top_items
+    mock_get_playlists.return_value = []
+    mock_count.return_value = 0
+    mock_likes.return_value = {
+        "likes_count": 42,
+        "likes_updated_at": "2025-04-26T00:00:00+00:00",
+        "likes_public": True,
+    }
+
+    event = authorized_event(
+        email="caller@example.com",
+        httpMethod="GET",
+        path="/friends/profile",
+        queryStringParameters={"friendEmail": "friend@example.com"},
+    )
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['likesCount'] == 42
+
+
+@patch('lambdas.friends_profile.handler.get_likes_settings')
+@patch('lambdas.friends_profile.handler.count_shares_for_user')
+@patch('lambdas.friends_profile.handler.get_user_public_playlists')
+@patch('lambdas.friends_profile.handler.get_user_top_items')
+@patch('lambdas.friends_profile.handler.get_user_table_data')
+def test_friends_profile_omits_likes_count_when_private_and_not_self(
+    mock_get_user, mock_get_top_items, mock_get_playlists, mock_count, mock_likes,
+    mock_context, authorized_event, sample_user, sample_top_items,
+):
+    mock_get_user.return_value = sample_user
+    mock_get_top_items.return_value = sample_top_items
+    mock_get_playlists.return_value = []
+    mock_count.return_value = 0
+    mock_likes.return_value = {
+        "likes_count": 42,
+        "likes_updated_at": "2025-04-26T00:00:00+00:00",
+        "likes_public": False,
+    }
+
+    event = authorized_event(
+        email="caller@example.com",
+        httpMethod="GET",
+        path="/friends/profile",
+        queryStringParameters={"friendEmail": "friend@example.com"},
+    )
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert 'likesCount' not in body
+
+
+@patch('lambdas.friends_profile.handler.get_likes_settings')
+@patch('lambdas.friends_profile.handler.count_shares_for_user')
+@patch('lambdas.friends_profile.handler.get_user_public_playlists')
+@patch('lambdas.friends_profile.handler.get_user_top_items')
+@patch('lambdas.friends_profile.handler.get_user_table_data')
+def test_friends_profile_includes_likes_count_for_self_even_if_private(
+    mock_get_user, mock_get_top_items, mock_get_playlists, mock_count, mock_likes,
+    mock_context, authorized_event, sample_user, sample_top_items,
+):
+    mock_get_user.return_value = sample_user
+    mock_get_top_items.return_value = sample_top_items
+    mock_get_playlists.return_value = []
+    mock_count.return_value = 0
+    mock_likes.return_value = {
+        "likes_count": 7,
+        "likes_updated_at": "ts",
+        "likes_public": False,
+    }
+
+    event = authorized_event(
+        email="me@example.com",
+        httpMethod="GET",
+        path="/friends/profile",
+        queryStringParameters={"friendEmail": "me@example.com"},
+    )
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert body['likesCount'] == 7
+
+
+@patch('lambdas.friends_profile.handler.get_likes_settings')
+@patch('lambdas.friends_profile.handler.count_shares_for_user')
+@patch('lambdas.friends_profile.handler.get_user_public_playlists')
+@patch('lambdas.friends_profile.handler.get_user_top_items')
+@patch('lambdas.friends_profile.handler.get_user_table_data')
+def test_friends_profile_likes_lookup_failure_does_not_500(
+    mock_get_user, mock_get_top_items, mock_get_playlists, mock_count, mock_likes,
+    mock_context, authorized_event, sample_user, sample_top_items,
+):
+    """A DDB hiccup on the likes lookup must not break the whole profile."""
+    mock_get_user.return_value = sample_user
+    mock_get_top_items.return_value = sample_top_items
+    mock_get_playlists.return_value = []
+    mock_count.return_value = 0
+    mock_likes.side_effect = RuntimeError("DDB throttled")
+
+    event = authorized_event(
+        email="caller@example.com",
+        httpMethod="GET",
+        path="/friends/profile",
+        queryStringParameters={"friendEmail": "friend@example.com"},
+    )
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    body = json.loads(response['body'])
+    assert 'likesCount' not in body

--- a/tests/test_users_set_likes_public.py
+++ b/tests/test_users_set_likes_public.py
@@ -1,0 +1,96 @@
+"""
+Tests for the /users/likes-public lambda.
+
+Covers:
+- Happy path: caller sets their own flag.
+- Cross-user toggle rejected with 401.
+- Missing fields -> 400.
+- Non-bool value -> 400.
+- Stringy bool ("true"/"false") accepted.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from lambdas.users_set_likes_public.handler import handler
+
+
+def _event(authorized_event, *, body: dict, caller="user@example.com"):
+    return authorized_event(
+        email=caller,
+        httpMethod="POST",
+        path="/users/likes-public",
+        body=json.dumps(body),
+    )
+
+
+@patch("lambdas.users_set_likes_public.handler.set_likes_public")
+def test_happy_path_sets_value(mock_set, mock_context, authorized_event):
+    mock_set.return_value = False
+    event = _event(authorized_event, body={"email": "user@example.com", "value": False})
+
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body == {"email": "user@example.com", "likesPublic": False}
+    mock_set.assert_called_once_with("user@example.com", False)
+
+
+@patch("lambdas.users_set_likes_public.handler.set_likes_public")
+def test_cross_user_toggle_rejected(mock_set, mock_context, authorized_event):
+    event = _event(
+        authorized_event,
+        body={"email": "someone-else@example.com", "value": True},
+    )
+    response = handler(event, mock_context)
+
+    assert response["statusCode"] == 401
+    mock_set.assert_not_called()
+
+
+def test_missing_email_field(mock_context, authorized_event):
+    event = _event(authorized_event, body={"value": True})
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_missing_value_field(mock_context, authorized_event):
+    event = _event(authorized_event, body={"email": "user@example.com"})
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+def test_rejects_non_bool_value(mock_context, authorized_event):
+    event = _event(
+        authorized_event,
+        body={"email": "user@example.com", "value": "maybe"},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 400
+
+
+@patch("lambdas.users_set_likes_public.handler.set_likes_public")
+def test_accepts_stringy_bool_true(mock_set, mock_context, authorized_event):
+    mock_set.return_value = True
+    event = _event(
+        authorized_event,
+        body={"email": "user@example.com", "value": "true"},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 200
+    mock_set.assert_called_once_with("user@example.com", True)
+
+
+@patch("lambdas.users_set_likes_public.handler.set_likes_public")
+def test_accepts_stringy_bool_false(mock_set, mock_context, authorized_event):
+    mock_set.return_value = False
+    event = _event(
+        authorized_event,
+        body={"email": "user@example.com", "value": "FALSE"},
+    )
+    response = handler(event, mock_context)
+    assert response["statusCode"] == 200
+    mock_set.assert_called_once_with("user@example.com", False)


### PR DESCRIPTION
## Summary

Phase 4 (final backend phase) of the **Social Library — Friend-Visible
Likes** feature. Plan: \`xomify-ios/docs/features/social-library-likes/PLAN.md\`.

Two changes in one PR:

1. **friends_profile enrichment** — \`/friends/profile\` now returns
   \`likesCount\` so the iOS profile header can render the Likes chip
   without a second round-trip.
2. **New /users/likes-public lambda** — POST endpoint to flip the
   privacy toggle backing the \"Show my likes to friends\" iOS setting.

## friends_profile changes

- New helper \`_safe_likes_settings(friend_email)\` mirrors the existing
  \`_safe_share_count\` pattern: failures degrade the field to absent
  rather than 500ing the whole profile.
- New helper \`_safe_caller_email(event)\` resolves the caller without
  forcing 401s if identity can't be determined — the gate falls open to
  \"treat as non-self\", honouring \`likes_public\`.
- \`likesCount\` is included in the response when:
  - the lookup succeeded, AND
  - the target's \`likes_public\` is True OR the caller is the target.
- Otherwise the field is omitted (iOS hides the chip when absent).

## /users/likes-public

**Body**: \`{ \"email\": \"<caller email>\", \"value\": <bool> }\`

- Caller identity from authorizer context (with body/query fallback).
- \`body.email\` MUST equal resolved caller -> cross-user toggle = 401.
- \`value\` is strictly bool-coerced (accepts JSON \`true\`/\`false\` or
  the stringy \`\"true\"\`/\`\"false\"\` iOS may send).
- Persists via \`set_likes_public\` from PR #169.

**Response**: \`{ \"email\": str, \"likesPublic\": bool }\`

## Tests (11 new, all green)

- \`test_friends_profile.py\` (4 new):
  - likesCount included when target.likes_public=True.
  - likesCount omitted when target.likes_public=False AND caller != target.
  - likesCount included when caller == target even if likes_public=False.
  - Lookup failure -> profile still returns 200 (likesCount omitted).
- \`test_users_set_likes_public.py\` (7 new):
  - Happy path.
  - Cross-user rejected (401).
  - Missing email / value -> 400.
  - Non-bool value -> 400.
  - Stringy \"true\" / \"FALSE\" accepted.

\`pytest tests/test_friends_profile.py tests/test_users_set_likes_public.py\`
-> 15 / 15 pass.
Full suite -> 395 / 395 pass (no regressions).

## Infra follow-up (xomify-infrastructure)

1. **API Gateway route** for the new lambda:
   - \`POST /users/likes-public\` -> \`xomify-users-set-likes-public\`.
2. **friends_profile lambda** needs an env-var update so the new likes
   read works in prod:
   - Add \`USER_LIKES_TABLE_NAME\` (already documented in PR #169).
   - Add \`USER_LIKES_EMAIL_ADDED_INDEX\` (default \`email-addedAt-index\`).
   - IAM: extend the existing \`xomify-users\` read perms to also cover
     the new \`xomify-user-likes\` table for \`get_likes_settings\`
     (which currently only reads the users table — but we still need
     the env var present so the helper module imports cleanly).

   Note: \`get_likes_settings\` only reads from \`xomify-users\` today, so
   no NEW IAM grant is needed for friends_profile in this PR — just the
   existing users-table read perm. Calling out anyway because the
   helper module will graceful-no-op if \`USER_LIKES_TABLE_NAME\` is
   unset, which would silently disable likes everywhere; safer to wire
   it up.
3. **users-set-likes-public lambda** env vars:
   - \`USERS_TABLE_NAME\`
   - \`AWS_DEFAULT_REGION\`
   - IAM: write on \`xomify-users\` (\`UpdateItem\`).

## Test plan

- [x] \`pytest tests/test_friends_profile.py tests/test_users_set_likes_public.py\` — 15 / 15 pass
- [x] Full suite — 395 / 395 pass (no regressions)