### PR TITLE
fix(shares_react): coerce rating to Decimal (boto3 rejects float)

### DIFF
--- a/lambdas/shares_react/handler.py
+++ b/lambdas/shares_react/handler.py
@@ -25,6 +25,7 @@ Flow:
 from __future__ import annotations
 
 import json
+from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
 
 import boto3
@@ -56,17 +57,22 @@ QUEUE_THRESHOLD = 3
 _lambda_client = boto3.client("lambda", region_name="us-east-1")
 
 
-def _coerce_rating(raw: Any) -> float:
+def _coerce_rating(raw: Any) -> Decimal:
+    """Coerce the body's rating to a Decimal — boto3 DynamoDB rejects Python
+    floats outright (raises 'Float types are not supported'). Decimal works
+    for both integer and fractional star values."""
     try:
-        rating = float(raw)
-    except (TypeError, ValueError):
+        # str(raw) avoids the float-binary-imprecision warning Decimal raises
+        # when given a float directly.
+        rating = Decimal(str(raw))
+    except (TypeError, ValueError, InvalidOperation):
         raise ValidationError(
             message="rating must be a number between 1 and 5",
             handler=HANDLER,
             function="handler",
             field="rating",
         )
-    if rating < 1.0 or rating > 5.0:
+    if rating < Decimal("1") or rating > Decimal("5"):
         raise ValidationError(
             message="rating must be between 1 and 5",
             handler=HANDLER,
@@ -177,7 +183,7 @@ def handler(event, context):
     if action.startswith("un"):
         clear_reaction(share_id, email, action)
     else:
-        rating: Optional[float] = None
+        rating: Optional[Decimal] = None
         if action == "rated":
             rating = _coerce_rating(raw_rating)
         set_reaction(share_id, email, shared_by=shared_by, action=action, rating=rating)


### PR DESCRIPTION
## Bug
User reports "Ratings dont work/cant save on the posted songs" on the feed share cards.

## Root cause
\`shares_react._coerce_rating\` returned Python \`float\`, then passed it to \`set_reaction\` which writes to DynamoDB. **Boto3 DynamoDB rejects Python floats with the exception \`Float types are not supported. Use Decimal types instead.\`** — confirmed in CloudWatch:

\`\`\`
[ERROR] xomify.interactions_dynamo | Set Reaction failed: Float types are not supported. Use Decimal types instead.
[ERROR] xomify.errors | 💥 DynamoDBError in dynamo_helpers.set_reaction
[ERROR] xomify.errors |    Body: {'shareId': '15ad71cf-...', 'action': 'rated', 'rating': 4}
\`\`\`

The \`upsert_track_rating\` path also fails with the same error before \`set_reaction\` even runs.

## Fix
\`_coerce_rating\` returns \`Decimal\` (constructed via \`Decimal(str(raw))\` to avoid the float-binary-imprecision warning). Downstream type hints widened.

## Test plan
- [x] \`pytest tests/test_shares_react.py\` — 13/13 pass
- [ ] After deploy: rate a share via the feed card → no 500, optimistic UI sticks, CloudWatch shows successful update

## Note
The boto3 layer only catches floats at write time. The data layer should probably enforce this at module boundary too — there are likely other endpoints (\`ratings_publish\` etc.) with the same shape that quietly worked because they always sent ints. Out of scope for this hotfix.