### PR TITLE
feat: rate-on-share — attach 1-5 star rating at share composition time

### DIFF
--- a/lambdas/shares_create/handler.py
+++ b/lambdas/shares_create/handler.py
@@ -9,6 +9,13 @@ Multi-target semantics (v2):
 - `public=False` with an empty `groupIds` is invalid (no target) -> 400.
 - Every entry in `groupIds` must reference a group the caller is a member
   of; non-members get a 403.
+
+Rate-on-share (v3):
+- Callers may include an optional `rating` field (int, 1-5) in the request
+  body. When present and in range, the rating is written to the track
+  ratings table after the share row is created. The rating write is
+  best-effort: failures are logged at WARN and do NOT fail the share.
+  Values outside 1-5 are silently ignored (no error).
 """
 
 from lambdas.common.logger import get_logger
@@ -21,6 +28,7 @@ from lambdas.common.utility_helpers import (
 )
 from lambdas.common.shares_dynamo import create_share
 from lambdas.common.group_members_dynamo import is_member_of_group
+from lambdas.common.track_ratings_dynamo import upsert_track_rating
 
 log = get_logger(__file__)
 
@@ -111,6 +119,7 @@ def handler(event, context):
     caption = body.get('caption')
     mood_tag = body.get('moodTag')
     genre_tags = body.get('genreTags')
+    raw_rating = body.get('rating')
 
     # Multi-target fields — default to legacy "public only" share.
     public = _coerce_public(body.get('public', True))
@@ -179,4 +188,29 @@ def handler(event, context):
     )
 
     log.info(f"Share {result['shareId']} created successfully")
+
+    # Best-effort rating write. Only attempted when rating is a valid int 1-5.
+    # Values outside that range are silently ignored. Failures are logged at
+    # WARN but do NOT fail the share response.
+    if isinstance(raw_rating, int) and 1 <= raw_rating <= 5:
+        try:
+            upsert_track_rating(
+                email=email,
+                track_id=track_id,
+                rating=raw_rating,
+                track_name=track_name,
+                artist_name=artist_name,
+                album_art=album_art_url or "",
+                album_name=album_name,
+                rating_context="share",
+            )
+            log.info(
+                f"Rate-on-share: wrote rating {raw_rating} for track {track_id} "
+                f"(share {result['shareId']})"
+            )
+        except Exception as exc:
+            log.warning(
+                f"Rate-on-share: failed to write rating for share {result['shareId']}: {exc}"
+            )
+
     return success_response(result)

--- a/tests/test_shares_create.py
+++ b/tests/test_shares_create.py
@@ -257,3 +257,56 @@ def test_shares_create_legacy_email_in_body_still_works(
     response = handler(event, mock_context)
     assert response['statusCode'] == 200
     assert mock_create.call_args.kwargs['email'] == "legacy@example.com"
+
+
+# ------------------------------------------------------------
+# Rate-on-share
+# ------------------------------------------------------------
+
+SHARE_RESULT = {
+    "shareId": "share-ros-1",
+    "createdAt": "2026-04-26T12:00:00+00:00",
+    "groupIds": [],
+    "public": True,
+}
+
+
+@patch('lambdas.shares_create.handler.upsert_track_rating')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_without_rating_does_not_call_upsert(
+    mock_create, mock_upsert, mock_context, authorized_event
+):
+    """Share without `rating` field still works; upsert is never called."""
+    mock_create.return_value = SHARE_RESULT
+    response = handler(_event(authorized_event, VALID_BODY), mock_context)
+    assert response['statusCode'] == 200
+    mock_upsert.assert_not_called()
+
+
+@patch('lambdas.shares_create.handler.upsert_track_rating')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_with_valid_rating_writes_both_rows(
+    mock_create, mock_upsert, mock_context, authorized_event
+):
+    """Share with rating=4 writes the share row and then calls upsert_track_rating."""
+    mock_create.return_value = SHARE_RESULT
+    body = {**VALID_BODY, "rating": 4}
+    response = handler(_event(authorized_event, body), mock_context)
+    assert response['statusCode'] == 200
+    mock_upsert.assert_called_once()
+    call_kwargs = mock_upsert.call_args.kwargs
+    assert call_kwargs['rating'] == 4
+    assert call_kwargs['track_id'] == VALID_BODY['trackId']
+
+
+@patch('lambdas.shares_create.handler.upsert_track_rating')
+@patch('lambdas.shares_create.handler.create_share')
+def test_shares_create_with_out_of_range_rating_ignores_rating(
+    mock_create, mock_upsert, mock_context, authorized_event
+):
+    """Share with rating=99 writes share only; upsert is not called (silently ignored)."""
+    mock_create.return_value = SHARE_RESULT
+    body = {**VALID_BODY, "rating": 99}
+    response = handler(_event(authorized_event, body), mock_context)
+    assert response['statusCode'] == 200
+    mock_upsert.assert_not_called()


### PR DESCRIPTION
## Summary
- `lambdas/shares_create/handler.py`: accept optional `rating: int` body field. After writing the share row, calls `upsert_track_rating` when value is 1-5. Values outside that range are silently ignored. Rating write is best-effort — failures log WARN but do not fail the share request.
- Three new tests in `tests/test_shares_create.py`: no-rating path unchanged, valid rating writes both rows, out-of-range rating writes share only.

## Test plan
- [x] `pytest tests/test_shares_create.py` — 16/16 pass