### PR TITLE
fix: shares cursor uses KeyConditionExpression (fixes empty group feed beyond first page)

### DIFF
--- a/lambdas/common/shares_dynamo.py
+++ b/lambdas/common/shares_dynamo.py
@@ -180,19 +180,20 @@ def list_shares_for_user(
     try:
         table = dynamodb.Table(SHARES_TABLE_NAME)
 
+        key_condition = Key("email").eq(email)
+        if before:
+            # `before` is a cursor on createdAt — return rows strictly older.
+            # We can't use ExclusiveStartKey here because we don't have the
+            # base table's PK (shareId) for the cursor row; DynamoDB rejects
+            # GSI pagination keys missing the base PK with ValidationException.
+            key_condition = key_condition & Key("createdAt").lt(before)
+
         query_kwargs: dict[str, Any] = {
             "IndexName": SHARES_EMAIL_INDEX,
-            "KeyConditionExpression": Key("email").eq(email),
+            "KeyConditionExpression": key_condition,
             "ScanIndexForward": False,
             "Limit": limit,
         }
-
-        if before:
-            # ExclusiveStartKey needs all GSI + base-table keys
-            query_kwargs["ExclusiveStartKey"] = {
-                "email": email,
-                "createdAt": before,
-            }
 
         response = table.query(**query_kwargs)
         items = response.get("Items", [])

--- a/tests/test_shares_dynamo_cursor.py
+++ b/tests/test_shares_dynamo_cursor.py
@@ -1,0 +1,51 @@
+"""
+Regression test for `list_shares_for_user` cursor handling.
+
+Bug: previously the function set `ExclusiveStartKey={email, createdAt}` when a
+`before` cursor was supplied. That key shape is invalid for a GSI query
+(missing the base table's PK `shareId`) and DynamoDB returned a
+ValidationException, which got swallowed upstream and surfaced as an empty
+feed page on iteration 2+ of the group-feed pagination loop.
+
+Fix: express the cursor as `KeyConditionExpression` -> `Key("createdAt").lt(before)`
+so the query is valid without needing a real LastEvaluatedKey.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from lambdas.common.shares_dynamo import list_shares_for_user
+
+
+@patch('lambdas.common.shares_dynamo.dynamodb')
+def test_list_shares_for_user_no_cursor_uses_simple_keycond(mock_ddb):
+    table = MagicMock()
+    table.query.return_value = {"Items": [], "LastEvaluatedKey": None}
+    mock_ddb.Table.return_value = table
+
+    list_shares_for_user("a@b.com", limit=25)
+
+    kwargs = table.query.call_args.kwargs
+    assert "ExclusiveStartKey" not in kwargs
+    # KeyConditionExpression is a boto3.dynamodb.conditions.Equals when no cursor
+    assert "KeyConditionExpression" in kwargs
+
+
+@patch('lambdas.common.shares_dynamo.dynamodb')
+def test_list_shares_for_user_with_before_uses_keycond_not_startkey(mock_ddb):
+    table = MagicMock()
+    table.query.return_value = {"Items": [], "LastEvaluatedKey": None}
+    mock_ddb.Table.return_value = table
+
+    list_shares_for_user(
+        "a@b.com",
+        limit=25,
+        before="2026-04-28T12:00:00+00:00",
+    )
+
+    kwargs = table.query.call_args.kwargs
+    # Critical: never pass ExclusiveStartKey when we don't have the base PK.
+    assert "ExclusiveStartKey" not in kwargs, (
+        "ExclusiveStartKey with only GSI keys is invalid for a GSI query — "
+        "use KeyConditionExpression to express the cursor instead."
+    )
+    assert "KeyConditionExpression" in kwargs


### PR DESCRIPTION
## Summary
- Replace invalid `ExclusiveStartKey={email, createdAt}` GSI cursor with `Key('createdAt').lt(before)` on the `KeyConditionExpression`.
- DynamoDB rejects ExclusiveStartKey on a GSI query when the base table's PK (`shareId`) is missing — the ValidationException was being swallowed by `_fetch` in `query_feed_for_emails`, surfacing as silently-empty pages on iteration 2+ of the group-feed pagination loop.
- This is the residual cause of "BBnJ group feed not loading all posts" after PR #176.

## Test plan
- [x] `pytest tests/test_shares_dynamo_cursor.py` — 2 new regression tests pass
- [x] Full suite still green (11 passed locally)
- [ ] After deploy: load BBnJ group feed on web with >25 historical shares and confirm pagination retrieves the older items