### PR TITLE
fix: ratings save and read (KeyError on /ratings/track + silent rerate skip)

### DIFF
--- a/lambdas/common/track_ratings_dynamo.py
+++ b/lambdas/common/track_ratings_dynamo.py
@@ -72,12 +72,12 @@ def get_single_track_rating_for_user(email: str, track_id: str):
             }
         )
 
-        items = response["Items"]
-        if len(items) < 0:
-            log.warning(f"No rating found for email {email} and track id {track_id}")
+        item = response.get("Item")
+        if not item:
+            log.info(f"No rating found for email {email} and track id {track_id}")
             return {}
-        
-        return items[0]
+
+        return item
 
     except Exception as err:
         log.error(f"Get Single Track Rating for User failed: {err}")
@@ -142,19 +142,10 @@ def upsert_track_rating(
             },
             UpdateExpression=update_expression,
             ExpressionAttributeValues=expression_values,
-            ConditionExpression=(
-                "attribute_not_exists(rating) OR rating <> :rating"
-            ),
             ReturnValues="ALL_NEW",
         )
 
         return response["Attributes"]
-
-    except table.meta.client.exceptions.ConditionalCheckFailedException:
-        log.info(
-            f"Rating unchanged for email {email} and trackId {track_id}; skipping update"
-        )
-        return {}
 
     except Exception as err:
         log.error(f"Upsert Track Rating failed: {err}")

--- a/lambdas/ratings_publish/handler.py
+++ b/lambdas/ratings_publish/handler.py
@@ -29,7 +29,7 @@ def handler(event, context):
     artist_name = body.get('artistName')
     album_art = body.get('albumArt')
     album_name = body.get('album_name', None)
-    rating_context = body.get('contetxt', None)
+    rating_context = body.get('context', None)
 
     log.info(f"Creating/Updating Single Track Rating for user {email} and track id {track_id} with rating {rating}")
     rating = upsert_track_rating(email, track_id, rating, track_name, artist_name, album_art, album_name, rating_context)

--- a/tests/test_track_ratings_dynamo.py
+++ b/tests/test_track_ratings_dynamo.py
@@ -1,0 +1,94 @@
+"""
+Regression tests for track_ratings_dynamo helpers.
+
+Bugs caught here:
+  1. `get_single_track_rating_for_user` previously read `response["Items"]`
+     from `get_item` (which returns a singular `Item` key, or no key on miss).
+     That raised KeyError on every call -> /ratings/track 500'd, the iOS
+     detail page rendered "no rating" after a successful save, and ratings
+     looked like they didn't persist.
+  2. `upsert_track_rating` previously had a ConditionExpression that returned
+     {} when re-rating the same value. Callers depending on the response
+     payload (e.g. a freshly persisted row to echo back) saw an empty dict.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch, MagicMock
+
+from lambdas.common.track_ratings_dynamo import (
+    get_single_track_rating_for_user,
+    upsert_track_rating,
+)
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_get_single_track_rating_returns_item_when_present(mock_ddb):
+    table = MagicMock()
+    table.get_item.return_value = {
+        "Item": {
+            "email": "a@b.com",
+            "trackId": "t1",
+            "rating": Decimal("4.5"),
+        }
+    }
+    mock_ddb.Table.return_value = table
+
+    result = get_single_track_rating_for_user("a@b.com", "t1")
+
+    assert result["trackId"] == "t1"
+    assert result["rating"] == Decimal("4.5")
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_get_single_track_rating_returns_empty_dict_on_miss(mock_ddb):
+    """get_item returns {} (no 'Item' key) when the row doesn't exist."""
+    table = MagicMock()
+    table.get_item.return_value = {}
+    mock_ddb.Table.return_value = table
+
+    result = get_single_track_rating_for_user("a@b.com", "missing")
+
+    assert result == {}
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_upsert_track_rating_returns_persisted_row(mock_ddb):
+    """First write returns the persisted row from ALL_NEW."""
+    table = MagicMock()
+    table.update_item.return_value = {
+        "Attributes": {
+            "email": "a@b.com",
+            "trackId": "t1",
+            "rating": Decimal("4.0"),
+        }
+    }
+    mock_ddb.Table.return_value = table
+
+    result = upsert_track_rating(
+        "a@b.com", "t1", 4.0, "Song", "Artist", "art.jpg"
+    )
+
+    assert result["rating"] == Decimal("4.0")
+    kwargs = table.update_item.call_args.kwargs
+    # Critical: no ConditionExpression -- writing the same value twice
+    # must still return the canonical row to the caller.
+    assert "ConditionExpression" not in kwargs
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_upsert_track_rating_re_rate_same_value_still_returns_row(mock_ddb):
+    """Re-rating the same value must not return {}; UI relies on the row."""
+    persisted = {
+        "email": "a@b.com",
+        "trackId": "t1",
+        "rating": Decimal("4.0"),
+    }
+    table = MagicMock()
+    table.update_item.return_value = {"Attributes": persisted}
+    mock_ddb.Table.return_value = table
+
+    result = upsert_track_rating(
+        "a@b.com", "t1", 4.0, "Song", "Artist", "art.jpg"
+    )
+
+    assert result == persisted


### PR DESCRIPTION
## Summary
- Fix \`get_single_track_rating_for_user\` reading \`response[\"Items\"]\` on a \`get_item\` call. \`get_item\` returns \`Item\` (singular). KeyError on every call → \`/ratings/track\` 500'd → iOS detail page rendered \"no rating\" after a successful save → user reported \"ratings not saving anywhere.\"
- Remove the ConditionExpression on \`upsert_track_rating\`. Re-rating the same value was returning \`{}\` and making the canonical row invisible to the caller. Writes are idempotent; just always write + return ALL_NEW.
- Fix \`ratings_publish/handler.py\` typo \`'contetxt'\` → \`'context'\` (rating context never persisted from the iOS publish path).

## Test plan
- [x] \`pytest tests/test_track_ratings_dynamo.py\` — 4 new helper tests pass
- [x] Existing rating + share-create tests still green (31/31)
- [ ] After deploy: rate a track on iOS feed → reopen detail page → rating shows
- [ ] After deploy: rate same value twice on web feed → no errors, /ratings page shows it