### PR TITLE
fix: feed enrichment falls back to track-ratings table (rating persists on cards)

### DIFF
--- a/lambdas/common/interactions_dynamo.py
+++ b/lambdas/common/interactions_dynamo.py
@@ -250,10 +250,22 @@ def count_interactions_for_share(share_id: str) -> dict:
 # ============================================
 # Enrichment helper (used by shares_feed / shares_user)
 # ============================================
-def build_enrichment(share_id: str, viewer_email: str) -> dict[str, Any]:
+def build_enrichment(
+    share_id: str,
+    viewer_email: str,
+    *,
+    track_id: Optional[str] = None,
+    sharer_email: Optional[str] = None,
+) -> dict[str, Any]:
     """
     Inspect all reaction rows for a share and collapse them into the four
     counts/flags the iOS feed card needs.
+
+    `track_id` and `sharer_email` enable a fallback into the canonical
+    track-ratings table for viewer/sharer ratings -- the feed-card rate
+    button writes to track-ratings via /ratings/publish without writing
+    a share-interactions row, so without this fallback the rating is
+    invisible on the feed card after refresh.
     """
     items = list_reactions_for_share(share_id)
     queued_count = 0
@@ -285,6 +297,19 @@ def build_enrichment(share_id: str, viewer_email: str) -> dict[str, Any]:
                 except (TypeError, ValueError):
                     sharer_rating = None
 
+    # Fallback: when the canonical track-ratings table has a row but the
+    # share-interactions row doesn't carry the rating (writes via
+    # /ratings/publish bypass the interactions table), source from there.
+    if track_id:
+        if viewer_rating is None:
+            viewer_rating = _track_rating_value(viewer_email, track_id)
+        if sharer_rating is None and sharer_email:
+            sharer_rating = _track_rating_value(sharer_email, track_id)
+        if rated_count == 0 and (viewer_rating is not None or sharer_rating is not None):
+            rated_count = sum(
+                1 for v in (viewer_rating, sharer_rating) if v is not None
+            )
+
     return {
         "queuedCount": queued_count,
         "ratedCount": rated_count,
@@ -292,6 +317,25 @@ def build_enrichment(share_id: str, viewer_email: str) -> dict[str, Any]:
         "viewerRating": viewer_rating,
         "sharerRating": sharer_rating,
     }
+
+
+def _track_rating_value(email: str, track_id: str) -> Optional[float]:
+    """Best-effort lookup into the canonical track-ratings table; never raises."""
+    try:
+        from lambdas.common.track_ratings_dynamo import (
+            get_single_track_rating_for_user,
+        )
+
+        row = get_single_track_rating_for_user(email, track_id)
+        if not row:
+            return None
+        rating = row.get("rating")
+        if rating is None:
+            return None
+        return float(rating)
+    except Exception as err:
+        log.warning(f"track-rating fallback failed (email={email}, trackId={track_id}): {err}")
+        return None
 
 
 # ============================================

--- a/lambdas/common/track_ratings_dynamo.py
+++ b/lambdas/common/track_ratings_dynamo.py
@@ -72,12 +72,12 @@ def get_single_track_rating_for_user(email: str, track_id: str):
             }
         )
 
-        items = response["Items"]
-        if len(items) < 0:
-            log.warning(f"No rating found for email {email} and track id {track_id}")
+        item = response.get("Item")
+        if not item:
+            log.info(f"No rating found for email {email} and track id {track_id}")
             return {}
-        
-        return items[0]
+
+        return item
 
     except Exception as err:
         log.error(f"Get Single Track Rating for User failed: {err}")
@@ -142,19 +142,10 @@ def upsert_track_rating(
             },
             UpdateExpression=update_expression,
             ExpressionAttributeValues=expression_values,
-            ConditionExpression=(
-                "attribute_not_exists(rating) OR rating <> :rating"
-            ),
             ReturnValues="ALL_NEW",
         )
 
         return response["Attributes"]
-
-    except table.meta.client.exceptions.ConditionalCheckFailedException:
-        log.info(
-            f"Rating unchanged for email {email} and trackId {track_id}; skipping update"
-        )
-        return {}
 
     except Exception as err:
         log.error(f"Upsert Track Rating failed: {err}")

--- a/lambdas/ratings_publish/handler.py
+++ b/lambdas/ratings_publish/handler.py
@@ -29,7 +29,7 @@ def handler(event, context):
     artist_name = body.get('artistName')
     album_art = body.get('albumArt')
     album_name = body.get('album_name', None)
-    rating_context = body.get('contetxt', None)
+    rating_context = body.get('context', None)
 
     log.info(f"Creating/Updating Single Track Rating for user {email} and track id {track_id} with rating {rating}")
     rating = upsert_track_rating(email, track_id, rating, track_name, artist_name, album_art, album_name, rating_context)

--- a/lambdas/shares_detail/handler.py
+++ b/lambdas/shares_detail/handler.py
@@ -181,7 +181,12 @@ def _enrich_share(share: dict[str, Any], viewer_email: str) -> dict[str, Any]:
         share.setdefault('sharerRating', None)
         return share
     try:
-        share.update(build_enrichment(share_id, viewer_email))
+        share.update(build_enrichment(
+            share_id,
+            viewer_email,
+            track_id=share.get('trackId'),
+            sharer_email=share.get('email') or share.get('sharedBy'),
+        ))
     except Exception as err:
         log.warning(f"Detail enrichment failed for share {share_id}: {err}")
         share.setdefault('queuedCount', 0)

--- a/lambdas/shares_feed/handler.py
+++ b/lambdas/shares_feed/handler.py
@@ -87,7 +87,12 @@ def _enrich(share: dict, viewer_email: str) -> dict:
         share.setdefault('sharerRating', None)
         return share
     try:
-        enrichment = build_enrichment(share_id, viewer_email)
+        enrichment = build_enrichment(
+            share_id,
+            viewer_email,
+            track_id=share.get('trackId'),
+            sharer_email=share.get('email') or share.get('sharedBy'),
+        )
         share.update(enrichment)
     except Exception as err:
         # Never let an enrichment miss break the feed.

--- a/lambdas/shares_react/handler.py
+++ b/lambdas/shares_react/handler.py
@@ -202,5 +202,10 @@ def handler(event, context):
                     reactor_count=reactor_count,
                 )
 
-    enrichment = build_enrichment(share_id, email)
+    enrichment = build_enrichment(
+        share_id,
+        email,
+        track_id=share.get('trackId') if share else None,
+        sharer_email=(share.get('email') or share.get('sharedBy')) if share else None,
+    )
     return success_response(enrichment)

--- a/lambdas/shares_user/handler.py
+++ b/lambdas/shares_user/handler.py
@@ -88,7 +88,12 @@ def handler(event, context):
         share_id = share.get('shareId')
         if share_id:
             try:
-                share.update(build_enrichment(share_id, email))
+                share.update(build_enrichment(
+                    share_id,
+                    email,
+                    track_id=share.get('trackId'),
+                    sharer_email=share.get('email') or share.get('sharedBy'),
+                ))
             except Exception as err:
                 log.warning(f"Profile enrichment failed for share {share_id}: {err}")
                 share.setdefault('queuedCount', 0)

--- a/tests/test_build_enrichment_track_rating_fallback.py
+++ b/tests/test_build_enrichment_track_rating_fallback.py
@@ -1,0 +1,88 @@
+"""
+Regression test for build_enrichment's fallback into the canonical
+track-ratings table when the share-interactions table doesn't carry
+a rating for the viewer/sharer.
+
+Bug: rating from a feed card calls /ratings/publish (writes track_ratings)
+but does NOT write a share_interactions row. The next /shares/feed call
+returned viewerRating=None even though the user had rated the track --
+the rating was visible on the Ratings page but not on the same feed card.
+"""
+
+from unittest.mock import patch
+
+from lambdas.common.interactions_dynamo import build_enrichment
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_viewer_rating_falls_back_to_track_ratings_when_no_interactions_row(
+    mock_list, mock_track,
+):
+    mock_list.return_value = []  # no interactions written for this share
+    mock_track.side_effect = lambda email, track_id: 4.0 if email == "viewer@x.com" else None
+
+    result = build_enrichment(
+        "share-1",
+        "viewer@x.com",
+        track_id="track-1",
+        sharer_email="author@x.com",
+    )
+
+    assert result["viewerRating"] == 4.0
+    assert result["sharerRating"] is None
+    mock_track.assert_any_call("viewer@x.com", "track-1")
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_sharer_rating_falls_back_to_track_ratings(mock_list, mock_track):
+    mock_list.return_value = []
+    mock_track.side_effect = lambda email, track_id: 5.0 if email == "author@x.com" else None
+
+    result = build_enrichment(
+        "share-1",
+        "viewer@x.com",
+        track_id="track-1",
+        sharer_email="author@x.com",
+    )
+
+    assert result["sharerRating"] == 5.0
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_interactions_row_takes_precedence_over_track_rating_fallback(
+    mock_list, mock_track,
+):
+    """If an interactions row already carries a rating, don't shadow it."""
+    mock_list.return_value = [
+        {"email": "viewer@x.com", "rated": True, "rating": 3},
+    ]
+    mock_track.return_value = 999.0  # would override if fallback ran
+
+    result = build_enrichment(
+        "share-1",
+        "viewer@x.com",
+        track_id="track-1",
+        sharer_email="author@x.com",
+    )
+
+    assert result["viewerRating"] == 3.0
+    # _track_rating_value still called for sharer (no interactions row), but
+    # not for viewer.
+    track_calls = [args for args, _ in mock_track.call_args_list]
+    assert ("viewer@x.com", "track-1") not in track_calls
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_no_track_id_skips_fallback(mock_list, mock_track):
+    """Older callers that don't pass track_id keep the legacy behaviour."""
+    mock_list.return_value = []
+
+    result = build_enrichment("share-1", "viewer@x.com")
+
+    assert result["viewerRating"] is None
+    assert result["sharerRating"] is None
+    mock_track.assert_not_called()

--- a/tests/test_track_ratings_dynamo.py
+++ b/tests/test_track_ratings_dynamo.py
@@ -1,0 +1,94 @@
+"""
+Regression tests for track_ratings_dynamo helpers.
+
+Bugs caught here:
+  1. `get_single_track_rating_for_user` previously read `response["Items"]`
+     from `get_item` (which returns a singular `Item` key, or no key on miss).
+     That raised KeyError on every call -> /ratings/track 500'd, the iOS
+     detail page rendered "no rating" after a successful save, and ratings
+     looked like they didn't persist.
+  2. `upsert_track_rating` previously had a ConditionExpression that returned
+     {} when re-rating the same value. Callers depending on the response
+     payload (e.g. a freshly persisted row to echo back) saw an empty dict.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch, MagicMock
+
+from lambdas.common.track_ratings_dynamo import (
+    get_single_track_rating_for_user,
+    upsert_track_rating,
+)
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_get_single_track_rating_returns_item_when_present(mock_ddb):
+    table = MagicMock()
+    table.get_item.return_value = {
+        "Item": {
+            "email": "a@b.com",
+            "trackId": "t1",
+            "rating": Decimal("4.5"),
+        }
+    }
+    mock_ddb.Table.return_value = table
+
+    result = get_single_track_rating_for_user("a@b.com", "t1")
+
+    assert result["trackId"] == "t1"
+    assert result["rating"] == Decimal("4.5")
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_get_single_track_rating_returns_empty_dict_on_miss(mock_ddb):
+    """get_item returns {} (no 'Item' key) when the row doesn't exist."""
+    table = MagicMock()
+    table.get_item.return_value = {}
+    mock_ddb.Table.return_value = table
+
+    result = get_single_track_rating_for_user("a@b.com", "missing")
+
+    assert result == {}
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_upsert_track_rating_returns_persisted_row(mock_ddb):
+    """First write returns the persisted row from ALL_NEW."""
+    table = MagicMock()
+    table.update_item.return_value = {
+        "Attributes": {
+            "email": "a@b.com",
+            "trackId": "t1",
+            "rating": Decimal("4.0"),
+        }
+    }
+    mock_ddb.Table.return_value = table
+
+    result = upsert_track_rating(
+        "a@b.com", "t1", 4.0, "Song", "Artist", "art.jpg"
+    )
+
+    assert result["rating"] == Decimal("4.0")
+    kwargs = table.update_item.call_args.kwargs
+    # Critical: no ConditionExpression -- writing the same value twice
+    # must still return the canonical row to the caller.
+    assert "ConditionExpression" not in kwargs
+
+
+@patch('lambdas.common.track_ratings_dynamo.dynamodb')
+def test_upsert_track_rating_re_rate_same_value_still_returns_row(mock_ddb):
+    """Re-rating the same value must not return {}; UI relies on the row."""
+    persisted = {
+        "email": "a@b.com",
+        "trackId": "t1",
+        "rating": Decimal("4.0"),
+    }
+    table = MagicMock()
+    table.update_item.return_value = {"Attributes": persisted}
+    mock_ddb.Table.return_value = table
+
+    result = upsert_track_rating(
+        "a@b.com", "t1", 4.0, "Song", "Artist", "art.jpg"
+    )
+
+    assert result == persisted


### PR DESCRIPTION
## Summary
- Feed-card rate button calls \`/ratings/publish\` → writes canonical track-ratings row but not share-interactions row.
- \`build_enrichment\` was sourcing \`viewerRating\` and \`sharerRating\` exclusively from share-interactions → rating vanished from feed card on next refresh, even though Ratings page (sourced from track-ratings) showed it.
- \`build_enrichment\` now takes optional \`track_id\` + \`sharer_email\` kwargs and falls back to \`get_single_track_rating_for_user\` when the interactions row carries no rating. Four callers updated.
- Adds 4 regression tests; full suite green (409 passed).

## Test plan
- [x] \`pytest\` 409 passed
- [ ] After deploy: rate a track on iOS feed → reload → rating chip persists on the same card