### PR TITLE
fix: ratedCount/queuedCount exclude viewer to match friendRatings list

### DIFF
--- a/lambdas/common/interactions_dynamo.py
+++ b/lambdas/common/interactions_dynamo.py
@@ -268,8 +268,11 @@ def build_enrichment(
     invisible on the feed card after refresh.
     """
     items = list_reactions_for_share(share_id)
-    queued_count = 0
-    rated_count = 0
+    # Counts are "people other than the viewer" — the iOS card surfaces the
+    # viewer's own state separately (myRating chip, viewerHasQueued flag), so
+    # double-counting the viewer in "X rated" / "X queued" is misleading.
+    distinct_queuers: set[str] = set()
+    distinct_raters: set[str] = set()
     viewer_has_queued = False
     viewer_rating: Optional[float] = None
     sharer_rating: Optional[float] = None
@@ -277,10 +280,10 @@ def build_enrichment(
     for item in items:
         email = item.get("email")
         shared_by = item.get("sharedBy")
-        if item.get("queued"):
-            queued_count += 1
-        if item.get("rated"):
-            rated_count += 1
+        if item.get("queued") and email and email != viewer_email:
+            distinct_queuers.add(email)
+        if item.get("rated") and email and email != viewer_email:
+            distinct_raters.add(email)
         if email == viewer_email:
             viewer_has_queued = bool(item.get("queued"))
             rating = item.get("rating")
@@ -305,14 +308,19 @@ def build_enrichment(
             viewer_rating = _track_rating_value(viewer_email, track_id)
         if sharer_rating is None and sharer_email:
             sharer_rating = _track_rating_value(sharer_email, track_id)
-        if rated_count == 0 and (viewer_rating is not None or sharer_rating is not None):
-            rated_count = sum(
-                1 for v in (viewer_rating, sharer_rating) if v is not None
-            )
+        # Sharer rated via /ratings/publish — surface them in distinct raters
+        # so the count matches what shares_detail will list (author always
+        # included, viewer always excluded).
+        if (
+            sharer_rating is not None
+            and sharer_email
+            and sharer_email != viewer_email
+        ):
+            distinct_raters.add(sharer_email)
 
     return {
-        "queuedCount": queued_count,
-        "ratedCount": rated_count,
+        "queuedCount": len(distinct_queuers),
+        "ratedCount": len(distinct_raters),
         "viewerHasQueued": viewer_has_queued,
         "viewerRating": viewer_rating,
         "sharerRating": sharer_rating,

--- a/tests/test_build_enrichment_track_rating_fallback.py
+++ b/tests/test_build_enrichment_track_rating_fallback.py
@@ -86,3 +86,82 @@ def test_no_track_id_skips_fallback(mock_list, mock_track):
     assert result["viewerRating"] is None
     assert result["sharerRating"] is None
     mock_track.assert_not_called()
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_own_post_does_not_double_count_viewer_as_sharer(mock_list, mock_track):
+    """When viewer == sharer (own post) and the rating only lives in
+    track_ratings, ratedCount must not double-count the same person."""
+    mock_list.return_value = []
+    mock_track.return_value = 4.0  # both lookups hit the same Dom rating
+
+    result = build_enrichment(
+        "share-1",
+        "dom@x.com",
+        track_id="track-1",
+        sharer_email="dom@x.com",  # own post
+    )
+
+    assert result["viewerRating"] == 4.0
+    assert result["sharerRating"] == 4.0
+    assert result["ratedCount"] == 0  # viewer excluded; sharer == viewer
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_rated_count_excludes_viewer(mock_list, mock_track):
+    """The viewer's own rating row never inflates ratedCount — the iOS
+    card surfaces myRating separately, so 'X rated' means others."""
+    mock_list.return_value = [
+        {"email": "viewer@x.com", "rated": True, "rating": 3},
+        {"email": "friend@x.com", "rated": True, "rating": 5},
+    ]
+    mock_track.return_value = None
+
+    result = build_enrichment(
+        "share-1",
+        "viewer@x.com",
+        track_id="track-1",
+        sharer_email="author@x.com",
+    )
+
+    assert result["ratedCount"] == 1  # only friend@x.com counts
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_queued_count_excludes_viewer(mock_list, mock_track):
+    """Same exclusion rule for queuedCount — viewerHasQueued is the viewer's
+    own state; the count is for everyone else."""
+    mock_list.return_value = [
+        {"email": "viewer@x.com", "queued": True},
+        {"email": "friend1@x.com", "queued": True},
+        {"email": "friend2@x.com", "queued": True},
+    ]
+    mock_track.return_value = None
+
+    result = build_enrichment("share-1", "viewer@x.com")
+
+    assert result["queuedCount"] == 2
+    assert result["viewerHasQueued"] is True
+
+
+@patch('lambdas.common.interactions_dynamo._track_rating_value')
+@patch('lambdas.common.interactions_dynamo.list_reactions_for_share')
+def test_sharer_rating_via_fallback_adds_to_rated_count(mock_list, mock_track):
+    """A sharer who rated only via /ratings/publish (no interactions row)
+    should still show up in ratedCount so the count matches what
+    shares_detail's friendRatings list will render."""
+    mock_list.return_value = []
+    mock_track.side_effect = lambda email, track_id: 5.0 if email == "author@x.com" else None
+
+    result = build_enrichment(
+        "share-1",
+        "viewer@x.com",
+        track_id="track-1",
+        sharer_email="author@x.com",
+    )
+
+    assert result["sharerRating"] == 5.0
+    assert result["ratedCount"] == 1  # author counted


### PR DESCRIPTION
## Summary
- Feed card said \"2 rated\" but tapping it surfaced 0 entries — count and list disagreed
- Root cause was layered:
  1. Track-ratings fallback double-counted when viewer == sharer (own post): same person counted twice as viewer + sharer
  2. The scan over share_interactions counted the viewer themselves, but \`_build_friend_ratings\` excludes them — so count and list could never line up
- Now \`ratedCount\` / \`queuedCount\` are distinct emails *excluding* the viewer. iOS surfaces \`viewerRating\` + \`viewerHasQueued\` separately, so \"X rated\" cleanly means \"X others rated\"

## Test plan
- [x] 4 new regression tests in \`test_build_enrichment_track_rating_fallback.py\` (own-post no double count, viewer excluded from rated/queued counts, sharer via fallback adds to count)
- [x] Full suite: 413 passing