### PR TITLE
fix: release radar resilience — token rotation + atomic playlist update

### DIFF
--- a/lambdas/common/aiohttp_helper.py
+++ b/lambdas/common/aiohttp_helper.py
@@ -253,6 +253,74 @@ async def delete_json(
         )
 
 
+async def put_json(
+    session: aiohttp.ClientSession,
+    url: str,
+    headers: dict = None,
+    json: dict = None,
+    retry_count: int = 0
+) -> dict:
+    """
+    PUT JSON to URL with rate limit handling.
+    """
+    try:
+        rate_event = _get_rate_limit_event()
+        await rate_event.wait()
+
+        async with session.put(url, headers=headers, json=json) as resp:
+            if resp.status == 429:
+                retry_after = int(resp.headers.get('Retry-After', 1))
+                log.warning(f"Rate limited on PUT {url}. Waiting {retry_after}s...")
+
+                rate_event.clear()
+                await asyncio.sleep(retry_after + 1)
+                rate_event.set()
+
+                if retry_count < MAX_RETRIES:
+                    return await put_json(session, url, headers, json, retry_count + 1)
+
+                raise SpotifyAPIError(
+                    message=f"Rate limit exceeded after {MAX_RETRIES} retries",
+                    endpoint=url
+                )
+
+            if resp.status == 401:
+                raise SpotifyAPIError(
+                    message="Unauthorized - token may have expired",
+                    endpoint=url
+                )
+
+            if resp.status not in (200, 201):
+                text = await resp.text()
+                raise SpotifyAPIError(
+                    message=f"API error {resp.status}: {text}",
+                    endpoint=url
+                )
+
+            return await resp.json()
+
+    except aiohttp.ClientError as err:
+        log.error(f"AIOHTTP client error on PUT: {err}")
+
+        if retry_count < MAX_RETRIES:
+            wait_time = (2 ** retry_count) + 1
+            await asyncio.sleep(wait_time)
+            return await put_json(session, url, headers, json, retry_count + 1)
+
+        raise SpotifyAPIError(
+            message=f"PUT failed after {MAX_RETRIES} retries: {err}",
+            endpoint=url
+        )
+    except SpotifyAPIError:
+        raise
+    except Exception as err:
+        log.error(f"Unexpected error in put_json: {err}")
+        raise SpotifyAPIError(
+            message=str(err),
+            endpoint=url
+        )
+
+
 async def put_data(
     session: aiohttp.ClientSession,
     url: str,

--- a/lambdas/common/playlist.py
+++ b/lambdas/common/playlist.py
@@ -2,7 +2,7 @@ import requests
 import aiohttp
 import asyncio
 from lambdas.common.logger import get_logger
-from lambdas.common.aiohttp_helper import fetch_json, post_json, delete_json, put_data
+from lambdas.common.aiohttp_helper import fetch_json, post_json, delete_json, put_data, put_json
 
 log = get_logger(__file__)
 
@@ -74,12 +74,11 @@ class Playlist:
             raise Exception(f"Update Playlist: {err}") from err
         
     async def aiohttp_update_playlist(self, uri_list: list):
+        """Replace all tracks atomically via PUT (first 100) + POST (remainder)."""
         try:
             log.info(f"Updating playlist (aiohttp): {self.name} with {len(uri_list)} tracks")
             self.uri_list = uri_list
-            await self.aiohttp_delete_playlist_songs()
-            await asyncio.sleep(1)
-            await self.aiohttp_add_playlist_songs()
+            await self.aiohttp_replace_playlist_songs()
             log.info(f"Playlist '{self.name}' Updated!")
         except Exception as err:
             log.error(f"AIOHTTP Update Playlist: {err}")
@@ -169,6 +168,35 @@ class Playlist:
         except Exception as err:
             log.error(f"AIOHTTP Add Playlist Songs: {err}")
             raise Exception (f"AIOHTTP Add Playlist Songs: {err}") from err
+
+    # ------------------------
+    # Replace Playlist Songs (atomic PUT + POST)
+    # ------------------------
+    async def aiohttp_replace_playlist_songs(self):
+        """PUT first 100 URIs (replaces all tracks), then POST remaining batches."""
+        try:
+            if not self.uri_list or len(self.uri_list) == 0:
+                log.info("No tracks to add. Clearing playlist.")
+                url = f"{self.BASE_URL}/playlists/{self.id}/tracks"
+                await put_json(self.aiohttp_session, url, headers=self.headers, json={"uris": []})
+                return
+
+            batch_size = 100
+            url = f"{self.BASE_URL}/playlists/{self.id}/tracks"
+
+            first_batch = self.uri_list[:batch_size]
+            await put_json(self.aiohttp_session, url, headers=self.headers, json={"uris": first_batch})
+            log.debug(f"AIOHTTP Replaced with {len(first_batch)} tracks (PUT)")
+
+            for i in range(batch_size, len(self.uri_list), batch_size):
+                batch_uris = self.uri_list[i:i + batch_size]
+                await post_json(self.aiohttp_session, url, headers=self.headers, json={"uris": batch_uris})
+                log.debug(f"AIOHTTP Added {len(batch_uris)} tracks (POST batch)")
+
+            log.info(f"AIOHTTP All {len(self.uri_list)} tracks replaced successfully.")
+        except Exception as err:
+            log.error(f"AIOHTTP Replace Playlist Songs: {err}")
+            raise Exception(f"AIOHTTP Replace Playlist Songs: {err}") from err
 
     # ------------------------
     # Add Playlist Image

--- a/lambdas/common/spotify.py
+++ b/lambdas/common/spotify.py
@@ -181,7 +181,11 @@ class Spotify:
             raise Exception(f"Get Spotify Access Token: {err}") from err
         
     async def aiohttp_get_access_token(self) -> str:
-        """Get access token using refresh token (async)."""
+        """Get access token using refresh token (async).
+
+        Persists a rotated refresh_token back to DynamoDB when Spotify
+        returns one — prevents token-revocation drift.
+        """
         try:
             log.info("Getting spotify access token (aiohttp)...")
             url = "https://accounts.spotify.com/api/token"
@@ -199,12 +203,30 @@ class Spotify:
                 if response.status != 200:
                     raise Exception(f"Error refreshing token: {response_data}")
 
+                new_refresh = response_data.get('refresh_token')
+                if new_refresh and new_refresh != self.refresh_token:
+                    log.info("Spotify rotated refresh token — persisting new token")
+                    self.refresh_token = new_refresh
+                    self._persist_rotated_refresh_token(new_refresh)
+
                 log.info("Successfully retrieved spotify access token!")
                 return response_data['access_token']
-                
+
         except Exception as err:
             log.error(f"AIOHTTP Get Spotify Access Token: {err}")
             raise Exception(f"AIOHTTP Get Spotify Access Token: {err}") from err
+
+    def _persist_rotated_refresh_token(self, new_token: str):
+        """Save a rotated refresh token back to the users table."""
+        try:
+            from lambdas.common.dynamo_helpers import update_table_item_field
+            from lambdas.common.constants import USERS_TABLE_NAME
+            update_table_item_field(
+                USERS_TABLE_NAME, 'email', self.email,
+                'refreshToken', new_token
+            )
+        except Exception as err:
+            log.warning(f"Failed to persist rotated refresh token: {err}")
         
     async def get_top_tracks(self):
         """Fetch top tracks for all time ranges (sync version)."""

--- a/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
+++ b/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
@@ -136,25 +136,21 @@ async def process_user(
 
         # Fetch releases for this specific week
         log.info(f"[{email}] Fetching releases for {week_key}...")
-        releases = await fetch_releases_for_week(
+        releases, skipped_count = await fetch_releases_for_week(
             spotify,
             artist_ids,
             start_date,
             end_date
         )
-        log.info(f"[{email}] Found {len(releases)} releases")
+        log.info(f"[{email}] Found {len(releases)} releases ({skipped_count} artists failed)")
 
         # Get track URIs for playlist
         track_uris = []
         for release in releases:
             uri = release.get('uri')
             if uri:
-                # If it's an album, we need to get its tracks
-                if 'album' in uri:
-                    album_tracks = await get_album_track_uris(spotify, uri)
-                    track_uris.extend(album_tracks)
-                else:
-                    track_uris.append(uri)
+                album_tracks = await get_album_track_uris(spotify, uri)
+                track_uris.extend(album_tracks)
 
         # Remove duplicates
         track_uris = list(set(track_uris))
@@ -174,8 +170,19 @@ async def process_user(
                 update_user_table_release_radar_id(user, playlist_id)
                 log.info(f"[{email}] Created playlist: {playlist_id}")
             else:
-                log.info(f"[{email}] Updating playlist: {playlist_id}")
-                await spotify.release_radar_playlist.aiohttp_update_playlist(track_uris)
+                try:
+                    log.info(f"[{email}] Updating playlist: {playlist_id}")
+                    await spotify.release_radar_playlist.aiohttp_update_playlist(track_uris)
+                except Exception as update_err:
+                    log.warning(f"[{email}] Playlist update failed ({update_err}), recreating...")
+                    spotify.release_radar_playlist.set_id(None)
+                    await spotify.release_radar_playlist.aiohttp_build_playlist(
+                        track_uris,
+                        BLACK_LOGO_BASE_64
+                    )
+                    playlist_id = spotify.release_radar_playlist.id
+                    update_user_table_release_radar_id(user, playlist_id)
+                    log.info(f"[{email}] Recreated playlist: {playlist_id}")
         else:
             log.info(f"[{email}] No tracks to add to playlist")
 
@@ -210,7 +217,7 @@ async def fetch_releases_for_week(
     artist_ids: list,
     start_date: datetime,
     end_date: datetime
-) -> list:
+) -> tuple[list, int]:
     """
     Fetch all releases from followed artists within the week.
 
@@ -226,24 +233,27 @@ async def fetch_releases_for_week(
         end_date: Friday end of week (23:59:59)
 
     Returns:
-        List of normalized release objects, sorted by releaseDate descending
+        Tuple of (releases list sorted by releaseDate desc, skipped_artists count)
+
+    Raises:
+        ReleaseRadarError: If majority of artist fetches fail (systematic issue)
     """
     releases = []
     seen_ids = set()
     skipped_artists = 0
+    last_error = None
 
     # Semaphore limits concurrent requests within a batch
     semaphore = asyncio.Semaphore(8)
 
     async def fetch_artist(artist_id: str) -> list:
         """Fetch releases for a single artist (one combined API call)."""
-        nonlocal skipped_artists
+        nonlocal skipped_artists, last_error
         async with semaphore:
             try:
-                # Combined include_groups in one call (#123 optimization)
                 url = (
                     f"https://api.spotify.com/v1/artists/{artist_id}/albums"
-                    f"?include_groups=album,single,appears_on&limit=20"
+                    f"?include_groups=album,single,appears_on&limit=50"
                 )
 
                 data = await fetch_json(
@@ -285,6 +295,7 @@ async def fetch_releases_for_week(
 
             except Exception as err:
                 skipped_artists += 1
+                last_error = err
                 log.warning(f"Failed to fetch releases for artist {artist_id}: {err}")
                 return []
 
@@ -308,13 +319,19 @@ async def fetch_releases_for_week(
             await asyncio.sleep(0.3)
 
     # Log summary
-    checked = total
-    log.info(f"Checked {checked} artists, skipped {skipped_artists} due to errors")
+    log.info(f"Checked {total} artists, skipped {skipped_artists} due to errors")
+
+    # If majority of artists failed, something is systematically wrong
+    if total > 0 and skipped_artists > total * 0.5:
+        raise ReleaseRadarError(
+            message=f"{skipped_artists}/{total} artist fetches failed. Last error: {last_error}",
+            function="fetch_releases_for_week"
+        )
 
     # Sort by release date (newest first)
     releases.sort(key=lambda x: x.get('releaseDate', ''), reverse=True)
 
-    return releases
+    return releases, skipped_artists
 
 
 def is_in_week(release_date_str: str, start_date: datetime, end_date: datetime) -> bool:


### PR DESCRIPTION
## Summary
- **Root cause**: Refresh token revoked → cron fails silently every week, playlist never updates
- Persist rotated refresh tokens from Spotify token response (prevents future token drift)
- Replace DELETE+POST playlist update with atomic PUT (no more empty playlists on partial failure)
- Recreate playlist automatically if existing one is inaccessible (deleted, 404, etc.)
- Surface errors when >50% of artist API calls fail instead of silently returning 0 releases
- Bump artist album limit 20→50

## Test plan
- [ ] Re-auth via Spotify OAuth to get fresh refresh token
- [ ] Trigger release radar cron manually or wait for Saturday
- [ ] Verify playlist updates with new tracks
- [ ] Confirm wrapped cron unaffected (uses same token path, benefits from rotation fix)