### PR TITLE
chore: bump GitHub Actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -38,7 +38,7 @@ jobs:
       has_lambda_changes: ${{ steps.changes.outputs.has_lambda_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -120,10 +120,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -150,10 +150,10 @@ jobs:
       layer_arn: ${{ steps.deploy-layer.outputs.layer_arn }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -216,10 +216,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/update-all-layers.yml
+++ b/.github/workflows/update-all-layers.yml
@@ -43,7 +43,7 @@ jobs:
       all_lambdas: ${{ steps.list-lambdas.outputs.all_lambdas }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: List all lambda folders
         id: list-lambdas


### PR DESCRIPTION
## Summary

Bumps pinned GitHub Actions to Node-24-compatible major versions ahead of the Node 20 deprecation deadline (~2026-06-02 per GitHub Actions runner deprecation notice).

## Version bumps applied (where present)

- `actions/checkout` → v6
- `actions/setup-python` → v6
- `actions/setup-node` → v6
- `hashicorp/setup-terraform` → v4
- `aws-actions/configure-aws-credentials` → v6
- `actions/cache` → v5
- `actions/upload-artifact` → v7
- `actions/download-artifact` → v6

## Test plan

- CI passes on this PR
- No Node 20 deprecation annotation in the workflow run