### PR TITLE
fix: critical bugs - event loop, auth bypass, rate-on-share, album name, group image

### DIFF
--- a/.claude/prompts/ci-triage.md
+++ b/.claude/prompts/ci-triage.md
@@ -1,0 +1,53 @@
+You are a triage bot. Keep it light — a developer will do deep analysis later via /work-issue.
+
+Read the project's CLAUDE.md to find the `## Project Config` block. Use it for:
+- `base_branch` — which branch to create feature branches from
+- `pm_tool` — whether to create a Notion task
+- Notion field IDs (datasource, project, goal, pillar, assignee) — for task creation
+
+DO NOT:
+- Write or modify any source code
+- Create pull requests or commit code
+- Do deep codebase analysis (no reading file contents, no line numbers)
+- Read source files — just use Glob to confirm files exist
+
+DO:
+1. Read the issue — understand what's being reported (bug, feature, question)
+2. Read CLAUDE.md to get Project Config values
+3. Use Glob to find the likely files involved (just paths, don't read them)
+4. Classify: bug, enhancement, or documentation
+5. Estimate scope: small (1-2 files), medium (3-5 files), large (5+ files)
+6. Add labels using: gh issue edit <number> --add-label <label>
+   - Type: bug, enhancement, or documentation
+   - Priority: P1-critical, P2-high, P3-medium, or P4-low
+7. Create a branch off {base_branch} from Project Config:
+   - Format: {type}/{issue#}-{short-desc}
+   - Types: feature, fix, chore, docs, refactor
+   - Commands: git fetch origin {base_branch} && git checkout -b {branch} origin/{base_branch} && git push origin {branch}
+8. If Notion MCP tools are available AND pm_tool is "notion", create a task:
+   - Use mcp__notion__API-post-page with parent database from Project Config
+   - Set properties from Project Config: Name, Status, Priority, Assignee, Project, Goal, Pillar
+   - Content: brief summary + file list
+   - If permission error, skip and note N/A
+
+Your output is posted as a GitHub issue comment. Use emojis and clean formatting:
+
+### Triage: [issue title]
+
+| | |
+|---|---|
+| **Type** | bug / enhancement / docs |
+| **Priority** | P1-P4 |
+| **Scope** | small / medium / large |
+| **Branch** | `{type}/{issue#}-{short-desc}` |
+| **PM Task** | [task link] or N/A |
+
+**Summary:** [1-2 sentences — what the issue is, not how to fix it]
+
+**Files likely involved:**
+- `path/to/file`
+
+**Recommended approach:** `/fix` / `/plan` / `/brainstorm` — [one line why]
+
+---
+*Auto-triaged. Run `/work-issue {number}` to start.*

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -1,0 +1,119 @@
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  id-token: write
+
+jobs:
+  triage:
+    if: |
+      (github.event_name == 'issues') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # CONFIGURE: set to your base branch (main or develop)
+          ref: master
+          fetch-depth: 0
+
+      - name: Install Claude Code and Notion MCP
+        run: |
+          npm install -g @anthropic-ai/claude-code@latest
+          npm install -g @notionhq/notion-mcp-server
+
+      - name: Set up Notion MCP config
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "NOTION_TOKEN not set, skipping MCP config"
+            exit 0
+          fi
+          cat > /tmp/mcp-config.json << 'MCPEOF'
+          {
+            "mcpServers": {
+              "notion": {
+                "command": "notion-mcp-server",
+                "env": {
+                  "NOTION_TOKEN": "PLACEHOLDER"
+                }
+              }
+            }
+          }
+          MCPEOF
+          sed -i "s|PLACEHOLDER|${NOTION_TOKEN}|g" /tmp/mcp-config.json
+
+      - name: Acknowledge trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content=eyes
+          else
+            gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/reactions -f content=eyes
+          fi
+
+      - name: Get issue info
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUMBER=${{ github.event.issue.number }}
+          TITLE=$(gh issue view $NUMBER --json title -q .title)
+          BODY=$(gh issue view $NUMBER --json body -q .body)
+          echo "number=$NUMBER" >> $GITHUB_OUTPUT
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          echo "$BODY" > /tmp/issue-body.txt
+
+      - name: Run Claude triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.DEV_ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: |
+          ISSUE_BODY=$(cat /tmp/issue-body.txt)
+          SYSTEM_PROMPT=$(cat .claude/prompts/ci-triage.md)
+
+          # Build MCP flag if config exists
+          MCP_FLAG=""
+          if [ -f /tmp/mcp-config.json ]; then
+            MCP_FLAG="--mcp-config /tmp/mcp-config.json"
+          fi
+
+          # Write the user prompt to a file (avoids ENAMETOOLONG)
+          cat > /tmp/triage-prompt.txt << PROMPTEOF
+          Triage issue #${{ steps.issue.outputs.number }}: ${{ steps.issue.outputs.title }}
+
+          Issue body:
+          $ISSUE_BODY
+
+          Repository is checked out at $(pwd). Analyze the codebase, then:
+          1. Analyze and produce your triage report
+          2. Add labels with: gh issue edit ${{ steps.issue.outputs.number }} --add-label <label>
+          3. Create a branch off the base branch (read from Project Config in CLAUDE.md)
+          4. Create a PM task if Notion MCP is available (read IDs from Project Config in CLAUDE.md)
+          PROMPTEOF
+
+          claude -p "$(cat /tmp/triage-prompt.txt)" \
+            --print \
+            --model claude-sonnet-4-6 \
+            --system-prompt "$SYSTEM_PROMPT" \
+            --max-turns 15 \
+            --allowedTools "Read,Glob,Grep,Bash(git fetch:*),Bash(git checkout:*),Bash(git push:*),Bash(git branch:*),Bash(gh issue edit:*),Bash(gh label create:*),mcp__notion__API-post-page,mcp__notion__API-post-search,mcp__notion__API-retrieve-a-database,mcp__notion__API-query-data-source,mcp__notion__API-retrieve-a-page,mcp__notion__API-patch-page" \
+            $MCP_FLAG > /tmp/triage-output.md
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ steps.issue.outputs.number }} --body-file /tmp/triage-output.md

--- a/docs/features/auth-fallback-removal/PLAN.md
+++ b/docs/features/auth-fallback-removal/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1l
+repo: xomify-backend
+---
+
+# auth-fallback-removal
+
+> **Status: Stub.** This is a placeholder. Run `/plan auth-fallback-removal` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Single backend PR. Two cleanups:
+1. Delete the query-param/body fallback in `get_caller_email` / `get_caller_user_id`. Helper now hard-fails 401 if context is missing.
+2. Delete the **legacy static-token shim** in the authorizer (0b). Authorizer now requires `email` + `userId` claims; tokens without them deny.
+- Delete the WARN logs around fallback. Delete the INFO log for `legacy_token=true`.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(1j) AND (1k) deployed AND fallback rate < 1% for 7 consecutive days (Q5)
+
+## Exit criteria
+A request with the legacy static token returns 401. A request with a per-user JWT but no context (impossible barring misconfig) returns 401. Production traffic unaffected.
+
+## Notes
+- HARD HUMAN GATE: 7-day burn-in with < 1% fallback rate before this can ship.
+- Open action item from epic: product comms plan (in-app banner? release notes? force-update?) for users on stale builds before (1l) cuts them off.
+- Risk: "Fallback rate never drops below threshold (stale installs)" — (1l) intentionally locks them out.

--- a/docs/features/auth-identity-and-live-top-items/FRIEND_PROFILE_DIAGNOSTICS.md
+++ b/docs/features/auth-identity-and-live-top-items/FRIEND_PROFILE_DIAGNOSTICS.md
@@ -1,0 +1,207 @@
+# Friend Profile + Music Match + Recent Activity — 2026-04-27
+
+Diagnostic report for six related web/iOS issues on the friend-profile flow.
+No fixes applied; this is a hand-off doc for specialist agents.
+
+Repo paths used throughout:
+- Web:     `/Users/dom/Code/xomify-frontend`
+- iOS:     `/Users/dom/Code/xomify-ios`
+- Backend: `/Users/dom/Code/xomify-backend`
+
+---
+
+## Issue 1: Friend likes don't load
+
+**Files:**
+- `/Users/dom/Code/xomify-frontend/src/app/pages/friend-profile/friend-profile.component.ts:346-348` — `goToLikes()` navigates to `/likes/<friendEmail>`.
+- `/Users/dom/Code/xomify-frontend/src/app/pages/friend-profile/friend-profile.component.html:82-90` — Likes chip is the entry point and **only renders if `profile.likesCount != null`**.
+- `/Users/dom/Code/xomify-frontend/src/app/pages/likes/likes.component.ts` — works correctly; routes through `/likes/:email`, hits `LikesService.getLikesByUser` for non-self path.
+- `/Users/dom/Code/xomify-backend/lambdas/friends_profile/handler.py:112-122` — likesCount is **only added to payload** when the lookup succeeds AND (`is_self` OR `likes_public == True`).
+- `/Users/dom/Code/xomify-backend/lambdas/likes_by_user/handler.py:108-130` — also enforces `likes_public` for non-self callers (returns 403).
+
+**Root cause:** The Likes chip is conditionally rendered on `*ngIf="profile.likesCount != null"`. The backend `friends_profile` handler **omits** `likesCount` from the response whenever the friend has `likes_public=false`. So if the friend has hidden their likes (the default for many users post-migration), the chip disappears entirely — there is no fallback UI, no "private" state, no greyed chip. From the user's POV, "Likes does nothing."
+
+Two sub-cases the user is conflating:
+1. **Friend has `likes_public=false`**: chip is hidden by `*ngIf`. No way to navigate. Even if you craft `/likes/<friendEmail>` by hand, `likes_by_user` returns 403, and `likes.component.ts:163-167` flips `isPrivate = true` (the page DOES render a private-state, but the user never gets there).
+2. **Friend has `likes_public=true` but the lookup returned a stale cached `friends_profile` response from before they enabled it**: `friends.service.ts:282-298` caches `getFriendProfile` for 10 minutes (`PROFILE_CACHE_TTL`). So the chip can lag behind the truth.
+
+Note: there's no third case — when `likes_public=true` and the chip renders, navigation works; the likes page handles loading and the response.
+
+**Suggested fix:**
+- **Web (preferred):** Always render the Likes chip when the user is a friend. If `profile.likesCount == null`, render a chip labeled "Private" or with a lock glyph and disable the click. Mirrors iOS `ProfileHeaderView.swift:132-142` which also auto-hides — this is consistent across platforms but the user wants more explicit signaling on web.
+- **Alternative backend:** Have `friends_profile` always include `likesPublic: bool` in the payload (not just `likesCount`). Web could then render `Private` vs the count without changing chip-presence logic. Cleaner contract.
+- **Cache invalidation:** When a user toggles `likes_public` (from `my-profile`), broadcast an event so other clients' cached `friends_profile` entries get evicted on next visit. Lower priority — only matters for users who toggle frequently.
+
+---
+
+## Issue 2: Friend playlists don't load
+
+**Files:**
+- `/Users/dom/Code/xomify-frontend/src/app/pages/friend-profile/friend-profile.component.html:550-592` — Playlists tab template.
+- `/Users/dom/Code/xomify-frontend/src/app/pages/friend-profile/friend-profile.component.ts:128-189` (`loadFriendStats`) and `:263-266` (`getPlaylists`).
+- `/Users/dom/Code/xomify-backend/lambdas/common/friends_profile_helper.py:41-100` (`get_user_public_playlists`).
+- `/Users/dom/Code/xomify-frontend/src/app/services/user.service.ts:187-194` (`getUserPublicPlaylists` → Spotify direct).
+- iOS reference: `/Users/dom/Code/xomify-ios/Xomify-iOS/ViewModels/UserProfileViewModel.swift:146-171` (`parsePreloadedPlaylists`).
+
+**Root cause:** Field-shape mismatch. The backend returns playlists in a **slim shape** (`get_user_public_playlists` line 84-92):
+
+```
+{ id, name, description, imageUrl, trackCount, uri, externalUrl }
+```
+
+The web template at `friend-profile.component.html:561` reads `playlist.images?.[0]?.url` and at line 568 reads `playlist.tracks?.total` — both **Spotify-API shapes**. The slim payload has `imageUrl` (string) and `trackCount` (int). Result: every playlist card renders with a broken/placeholder image and "0 tracks", regardless of how many backend rows came back. To the user, the tab "doesn't load".
+
+Secondary mess: `loadFriendStats` (lines 145-167) re-fetches playlists from Spotify directly via `getUserPublicPlaylists(userId, 50)` — this returns Spotify-shaped objects (`images[0].url`, `tracks.total`) that DO match the template. Then lines 163-166 do:
+
+```ts
+if ((!this.profile.playlists || this.profile.playlists.length === 0) && data.playlists?.items) {
+  this.profile.playlists = data.playlists.items;
+}
+```
+
+So the Spotify-shaped fetch is only used as a fallback when the backend returned **nothing**. As long as the backend returns ANY playlists (slim shape), the fallback never runs and the user sees broken cards.
+
+iOS handles this correctly: `parsePreloadedPlaylists` explicitly maps the slim payload into `SpotifyPlaylist` (lines 152-169 of `UserProfileViewModel.swift`).
+
+**Suggested fix:**
+- Update `getPlaylists()` (or the template) to read the slim shape: use `playlist.imageUrl || playlist.images?.[0]?.url` and `playlist.trackCount ?? playlist.tracks?.total`. This handles both shapes in case there's any drift.
+- OR: Add a normalization step in `friends.service.ts:getFriendProfile` that converts slim → Spotify-ish before the component sees it. Cleaner long-term — single source of truth for shape.
+- **Stop the redundant Spotify fetch** at line 147. The backend already returns the public playlists; calling Spotify again is wasteful and only exists to work around the shape bug.
+
+---
+
+## Issue 3: Friends-of-friends missing
+
+**Status:** Backend issue Xomware/xomify-backend#173 is **OPEN** as of 2026-04-27. Confirmed via `gh issue view 173`.
+
+**Files:**
+- `/Users/dom/Code/xomify-frontend/src/app/pages/friend-profile/friend-profile.component.ts:151` — `this.friendsService.getFriendsList(this.friendEmail)` — passing friend's email.
+- `/Users/dom/Code/xomify-frontend/src/app/services/friends.service.ts:188-217` — `getFriendsList`. Per the comments at lines 184-187, the `email` argument is now ONLY used as a cache-partition key; it is **not forwarded to the backend**. The backend reads caller from JWT context.
+- `/Users/dom/Code/xomify-backend/lambdas/friends_profile/handler.py:98-122` — payload does **not** include `friendsCount`.
+- iOS reference: `/Users/dom/Code/xomify-ios/Xomify-iOS/Models/SocialModels.swift:604` declares `let friendsCount: Int?` on `FriendProfile`. iOS reads it at `UserProfileViewModel.swift:256` (`friendCount = profile.friendsCount`).
+
+**Root cause:** Two related bugs, both flowing from issue #173 not being shipped yet.
+
+1. **Web shows `friendsCount` of the caller, not the friend.** `friend-profile.component.ts:151` calls `getFriendsList(this.friendEmail)`. Since the email arg is no longer forwarded (Track 1a migration), the backend returns the **caller's** friends list. Then line 171 sets `this.friendsCount = data.friendsList.acceptedCount` — the caller's count, displayed under the friend's name. Silently wrong.
+
+2. **iOS shows nil/0** for the same reason — `friendsCount` is never present in the `friends_profile` payload, so `profile.friendsCount` is always nil, so the iOS header chip shows 0.
+
+The proposed fix in #173 (option 2) is to extend `friends_profile` to include `friendsCount: int`. Once shipped:
+- iOS picks it up automatically (already wired).
+- Web needs to switch from the broken `getFriendsList(friendEmail)` call to reading `profile.friendsCount` directly — and **delete** the misleading service call (lines 150-151, 169-172 in `friend-profile.component.ts`).
+
+**Suggested fix:**
+- Block on backend #173. Either author the fix yourself or hand it off.
+- After backend ships: web change is small — read `profile.friendsCount` from the profile payload, drop the `getFriendsList` call from `loadFriendStats`. ~10 LOC. Follow-up: also wire up the friends-of-friends LIST view if you want it to be navigable (currently the count is display-only). That requires the new `GET /friends/list?friendEmail=` endpoint variant (option 1 from #173) — a bigger change. Recommend punting on the list view for v1; just show the accurate count.
+
+---
+
+## Issue 4: Music match always 0
+
+**Files:**
+- `/Users/dom/Code/xomify-frontend/src/app/pages/friend-profile/friend-profile.component.ts:531-633` (`calculateCompatibility`).
+- `/Users/dom/Code/xomify-frontend/src/app/services/artist.service.ts:14-71` (cache fields default to `[]`, no auto-population).
+- `/Users/dom/Code/xomify-frontend/src/app/services/song.service.ts:119-132` (same — empty caches).
+- `/Users/dom/Code/xomify-frontend/src/app/pages/my-profile/my-profile.component.ts:326-358` (`loadTickerData` reads `topItemsService.getTopItems()` but **never writes** to song/artist caches).
+
+**Root cause:** Viewer-side inputs are always empty. The compatibility calc reads:
+
+```ts
+const myArtistsShort = this.artistService.getShortTermTopArtists() || [];
+const myArtistsMedium = this.artistService.getMedTermTopArtists() || [];
+const myArtistsLong = this.artistService.getLongTermTopArtists() || [];
+const mySongsShort = this.songService.getShortTermTopTracks() || [];
+const mySongsMedium = this.songService.getMediumTermTopTracks() || [];
+const mySongsLong = this.songService.getLongTermTopTracks() || [];
+```
+
+I grepped for the writers:
+- `setShortTermTopArtists`/`setMedTermTopArtists`/`setLongTermTopArtists` are called from exactly **two** places: `pages/news/news.component.ts:51` and `pages/top-genres/top-genres.component.ts:78-80`.
+- `setShortTermTopTracks`/`setMediumTermTopTracks`/`setLongTermTopTracks` are **never called anywhere** (zero hits). The song-cache writers are dead code.
+
+So unless the user has previously visited `/news` or `/top-genres` in the same session before opening a friend profile, every "my" array is `[]`. Then:
+
+```
+myArtistIds = ∅, mySongIds = ∅, myGenres = ∅
+sharedArtists = friendArtists.filter(a => ∅.has(a.id)) = []
+sharedSongs   = []
+sharedGenres  = []
+```
+
+All three `*Points` calculations multiply by 0 and saturate, so `compatibilityScore = 0`. Algorithm itself (lines 612-630) is fine; inputs are wrong.
+
+The friend's data IS available correctly — it's loaded from `profile.topSongs`/`topArtists`/`topGenres` which the backend populates from `friends_profile_helper.get_user_top_items`. So the bug is one-sided.
+
+**Suggested fix:**
+- Have `calculateCompatibility` (or a precursor) call `topItemsService.getTopItems()` directly to fetch the **viewer's** top items, then operate on that response. This is the same source `my-profile`'s ticker uses — server-cached per UTC day, so it's cheap. Don't try to repair the dead ArtistService/SongService caches; they're not the right abstraction here.
+- Move the `compatibilityCalculated = false` reset to AFTER the new fetch resolves, so the loading UI is honest.
+- Consider extracting compatibility into a service (`MusicMatchService` per the user's hypothesis) so the same logic can power the Friends list (mutual-affinity sort) and any future widgets.
+- **iOS:** No equivalent exists. New feature. Wait until web logic is solid, then port. Backend can stay the same (top-items is already a shared lambda).
+
+---
+
+## Issue 5: iOS profile parity gaps (web vs iOS)
+
+**iOS sections** (read from `/Users/dom/Code/xomify-ios/Xomify-iOS/Views/ProfileView.swift` + `ViewModels/UserProfileViewModel.swift:98-103`):
+- Header: avatar, displayName, email, **stats row** (Friends, Ratings, Posts, Likes — Likes auto-hides when nil).
+- Action button: "Edit Profile" (self) / "Message" (other, disabled).
+- **Tabs (self):** Posts (Shares), Ratings, Taste, Playlists, Recent.
+- **Tabs (other):** Posts, Ratings, Taste, Playlists. (Recent is self-only because Spotify recently-played is JWT-scoped.)
+
+**Web sections** (read from `/Users/dom/Code/xomify-frontend/src/app/pages/my-profile/my-profile.component.html`):
+- Header: avatar, displayName, email, **stats row** (Followers, Following, Friends, Playlists, Likes).
+- "Open Spotify Profile" link.
+- **Tabs:** Overview, Settings.
+- Overview content: "Your Listening" cards (top-songs/top-artists/top-genres deep links), "Features" cards (Wrapped, Release Radar enrollment), "Account Details" panel.
+- Settings content: Account info (read-only), Notifications CTA, Privacy toggle (likes_public), Logout.
+- **Profile ticker** at the bottom (rotating short-term top songs/artists/genres).
+
+**Gaps (iOS has, web doesn't):**
+
+| iOS Section          | Status on web |
+|----------------------|---------------|
+| **Posts/Shares tab** | Missing as a profile tab. Shares feed exists elsewhere (`share-feed.service.ts`) but is not surfaced on the profile page. |
+| **Ratings tab**      | Missing as a profile tab. `/ratings` page exists (top-level route) but is not embedded in profile. |
+| **Recent tab** (last 25 played) | Missing entirely on web profile. No equivalent component or service surfacing recently-played tracks. |
+| **Taste tab** (auto-rotating top-3 per term) | Web has the bottom ticker which is similar but inferior — only short_term, no per-term browsing, no "See all" CTA. |
+| **Posts/Ratings/Likes counts in header stats row** | Web header shows Followers/Following/Friends/Playlists/Likes. iOS shows Friends/Ratings/Posts/Likes. Web is missing Posts and Ratings counts. |
+| **Profile-tab navigation pattern** | iOS uses tabs to keep everything on one screen. Web uses a card-grid that punts everything to separate routes. Different UX philosophy. |
+
+**Web has (iOS doesn't):**
+- Followers/Following counts in header (Spotify-direct).
+- Wrapped + Release Radar enrollment cards.
+- Account info panel (country, product, userId).
+- Privacy toggle (`likes_public`) — iOS has this in Settings, not profile.
+- Bottom rotating ticker.
+- Compatibility/Music Match (only on **friend** profile — see Issue 4).
+
+**Suggested order to ship** (smallest blast radius first):
+1. **Add Recent tab** — single Spotify call (`/me/player/recently-played`), self-only. Reuse styling from existing track lists (e.g. likes page row component). Lowest risk; immediate value. Mirror iOS `ProfileRecentTab.swift` 1:1.
+2. **Add Ratings count to header**. Reuse `RatingsService.getAllRatings`. One number, drop into stats row. Tap-through can stay broken (already routes to `/ratings`).
+3. **Add Posts/Shares count to header.** Reuse `share-feed.service.ts`. Same pattern.
+4. **Add Taste tab** (auto-rotating). Replaces the bottom ticker (delete it). Bigger refactor — touches the page layout. Worth doing for parity but should land in its own PR.
+5. **Add Shares + Ratings tabs as top-level profile tabs.** This is the biggest UX shift on web — moves from card-grid → tab-grid. Recommend doing this LAST, after the smaller pieces, because it's a re-architecture of the page. May want a brainstorm session first to align the layout with iOS without breaking web's existing affordances (Wrapped/Release Radar cards still need a home).
+
+---
+
+## Issue 6: Following 'Recent Activity' tab
+
+**Files:**
+- `/Users/dom/Code/xomify-frontend/src/app/pages/following/following.component.ts:25` — `viewMode: 'artists' | 'activity'`.
+- `/Users/dom/Code/xomify-frontend/src/app/pages/following/following.component.html:198-201` — wires `<app-activity-timeline>` inside the activity view.
+- `/Users/dom/Code/xomify-frontend/src/app/components/activity-timeline/activity-timeline.component.{ts,html}` — fully implemented; declared in `shared.module.ts:9` and imported into discovery.module.
+- `/Users/dom/Code/xomify-frontend/src/app/services/liked-artists-activity.service.ts:81-150` — `loadActivityTimeline()` exists and works. Iterates ALL followed artists, fetches recent releases per artist via `getArtistRecentReleases`, builds a reverse-chronological timeline.
+
+**Today:** the tab is **wired and functional** in the codebase — it is NOT inert. When you click "Recent Activity," it mounts `<app-activity-timeline>`, which on `ngOnInit` calls `loadActivityTimeline()`. Why the user perceives it as doing nothing:
+
+1. **First load is extremely slow.** The service fans out one Spotify `getArtistRecentReleases(artistId, 10)` call per followed artist (line 100-110). For users following 50+ artists, that's 50+ HTTPS calls in parallel before anything renders. The component has `loading = true` for the entire duration with no progressive UI. Looks frozen.
+2. **No followed artists → empty timeline.** If the user follows 0 artists, the service returns `{ activities: [], stats: emptyStats }` (lines 117-122). The `activity-timeline.component.html` renders the header + filter bar + an empty list — no overt "you're not following anyone" empty state at the same level.
+3. **Cache hides errors.** `getCache()` (line 83) returns cached results without re-fetching, so if the first load partially failed, the user sees stale or empty results until the cache expires.
+4. **Duplicates `/release-radar` content.** The page exists already at `/release-radar` and is more polished (per `app-routing.module.ts:55`). The activity tab on `/following` is functionally a worse, slower copy.
+
+**Options:**
+- **Keep & wire:** Add progressive rendering (show artists as they resolve), surface a real loading message ("Checking 47 artists for new releases…"), add a clear empty state for the no-followed-artists case. ~half-day of work. Result: still slower and uglier than `/release-radar`.
+- **Repurpose:** Replace with a friend-recent-likes timeline (e.g. "what your friends liked this week"). Different data source, more social. Reuses the timeline UI shell. Bigger product decision.
+- **Remove:** Delete the activity view-mode, drop `setViewMode`, drop `viewMode === 'activity'` block, drop the `<app-activity-timeline>` reference. The timeline component itself can stay (it's unused but harmless) or be deleted along with the unused `LikedArtistsActivityService`. Lowest effort. Best UX: users still have `/release-radar` for the same need.
+
+**Recommendation:** **Remove.** The tab is a redundant slower copy of `/release-radar`, the user perceives it as broken, and there is no unique value over the dedicated page. Add a subtle "See new releases" link from the Following page header that routes to `/release-radar` to preserve the discovery affordance. If you later want a social-flavored activity timeline, file it as its own feature so it gets a proper design.

--- a/docs/features/auth-identity-and-live-top-items/PLAN.md
+++ b/docs/features/auth-identity-and-live-top-items/PLAN.md
@@ -1,0 +1,594 @@
+# Plan: Auth Identity Hardening + Live `/user/top-items` (Epic)
+
+**Status**: Ready
+**Created**: 2026-04-26
+**Last updated**: 2026-04-26 (revised — Revision 2: infra + module scope added; flipped to Ready)
+**Owner**: Dominick
+**Type**: Epic (orchestrate into sub-feature stubs next)
+**Affected repos**:
+- `/Users/dom/Code/xomify-backend` (Python lambdas)
+- `/Users/dom/Code/xomify-frontend` (Angular)
+- `/Users/dom/Code/xomify-ios` (Swift/SwiftUI)
+- `/Users/dom/Code/xomify-infrastructure` (Terraform — API Gateway, lambdas, DDB, IAM, ACM, custom domain)
+- `api-gateway-service` (external Terraform module at `git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.2.0`, **NOT cloned locally** — user owns)
+
+---
+
+## Plan Revision Log
+
+### 2026-04-26 — Revision 2: infra + shared-module scope added
+
+**Why**: Revision 1 scoped the epic to 3 application repos and treated infrastructure as a single action item ("confirm where API GW routes are configured"). Investigation of `/Users/dom/Code/xomify-infrastructure/terraform/` showed that's a meaningful undercount:
+
+- `xomify-infrastructure` (Terraform) owns the API Gateway, every lambda resource, every DDB table, IAM, the custom domain, and ACM. Every backend lambda in this epic needs a corresponding TF resource. The Track 2 cache table is provisioned here. Routes for `/auth/login` and `/user/top-items` are defined here. The authorizer redeploy happens here.
+- The API Gateway itself is built from a **shared external Terraform module** (`api-gateway-service`, pinned at `v2.2.0`). Inside the module (verified at `/Users/dom/Code/xomify-infrastructure/terraform/.terraform/modules/api/endpoints.tf:28`), `var.authorization` is applied uniformly to every endpoint — there is **no per-endpoint override**. The `/auth/login` route MUST be public, so the module needs a per-endpoint `authorization` override added in a new release.
+
+**Decision**: User chose the **module-bump path** (cleanest end state, useful for any future public route — health checks, webhooks, OAuth callbacks). The alternative (defining `/auth/login` outside the module directly in `xomify-infrastructure`) was rejected as a workaround.
+
+**What was kept**: All goals, non-goals, the architecture diagrams, the cache TTL decision, the rollout/rollback structure, the test strategy, the migration burn-in criteria, and Revision 1's Track 0 introduction.
+
+**What changed**:
+- Affected-repos count: 3 → 5.
+- Q6 answered (was action item) — module-bump path chosen.
+- 4 new sub-features added: (0-pre), (0a-infra), (0b-infra), (2a-infra).
+- 3 existing sub-features rescoped: (0a), (0b), (2a) now scoped to backend code only; their infra work moves to the new `-infra` siblings.
+- Sub-feature total: 17 → **20**.
+- Sequencing diagram updated for the new prerequisite chain.
+- Risks table gains a "module bump regression" row.
+- Rollout step 1 rewritten; rollback note added for (0-pre).
+- Action items reorganized — Revision 1 items resolved, new items added for module release process and authorizer deploy mechanism.
+- Skills section gains `infra-specialist` agent.
+
+### 2026-04-26 — Revision 1: added Track 0 (per-user JWT issuance)
+
+**Why**: The original plan assumed each user already authenticates with their own JWT and that the authorizer simply needed to start surfacing claims into context. Investigation showed this is false:
+
+- iOS reads a single `XOMIFY_API_TOKEN` from `secrets.xcconfig` (`Config.swift:23`, `AuthService.swift:55`) — same token baked into every install.
+- Web reads `environment.apiAuthToken` from the Angular environment file — same token in every browser.
+- The authorizer (`lambdas/authorizer/handler.py:42`) verifies the JWT signature but never reads the payload. There is no per-user identity in the token at all.
+
+So the email-as-query-param pattern that Track 1 was going to retire isn't laziness — it's the only way the backend currently knows who is calling. Removing it without first issuing per-user JWTs would lock everyone out.
+
+**Decision**: User chose option A from a 3-way fork — build the per-user auth foundation first (Track 0), then migrate handlers to read identity from context (Track 1, unchanged in spirit), then ship the new endpoint (Track 2, unchanged in design).
+
+**What was kept from the original plan**:
+- All goals, non-goals, the Track 2 endpoint design, the cache TTL decision, the rollout/rollback structure, the risk table, the test strategy, and the sub-feature template.
+
+**What changed**:
+- Added Track 0 (per-user JWT issuance) as a hard prerequisite for Track 1.
+- Track 1 sub-features now read identity from a `requestContext.authorizer` populated by real per-user JWTs (not the static shared token).
+- Track 1 cleanup sub-feature (`auth-fallback-removal`) now also removes the **legacy static-token shim** in the authorizer, not just the query-param fallback in handlers.
+- Added (2b) Music Taste page wire-up on web in addition to (2c) iOS — user confirmed both pages exist.
+- Added six new open questions (TTL, secret rotation, web token storage, iOS keychain group, migration success criterion, public-route exemption).
+
+---
+
+## Problem
+
+Three coupled problems, fixed together because each unlocks the next.
+
+### 0. No per-user identity exists today (Track 0 — NEW)
+A single static JWT is shared across every install of every client. The authorizer accepts any valid signature and discards the payload. There is no way for the backend to know which user is calling without trusting a request-supplied `email`.
+
+### 1. Security gap (Track 1)
+Because of #0, every authorized lambda accepts the caller's `email` (and sometimes `userId`) as a query-string or body field. Any holder of the static token can read or mutate any user's data by guessing an email address. Affects all 49 authorized handlers.
+
+### 2. Stale "current" top items on iOS (Track 2)
+The iOS "Top 25 — Last 4 Weeks (Current)" page reads from `GET /wrapped/all`, which only returns frozen monthly snapshots written by `cron_wrapped` on the 1st of each month. The Angular Music Taste page has the same problem. There is no live "today" endpoint — the only live `/me/top/*` path lives inside `lambdas/common/friends_profile_helper.py:get_user_top_items()` and is reachable only via the friends-profile route.
+
+We need a live `GET /user/top-items` endpoint. Adding it on top of the current authorizer would mean shipping a brand-new endpoint that takes caller-email as a query param — institutionalizing the security gap. So Track 0 + Track 1 land first.
+
+---
+
+## Goals
+
+- Each user authenticates with their own JWT, minted from their Spotify identity, on every authorized request.
+- Caller identity is sourced from the JWT, not the request, on every authorized route.
+- Target identity (looking up someone else's data, e.g. `friendEmail`) remains explicit in the request.
+- iOS "Last 4 Weeks (Current)" page and Angular Music Taste page show top items at most ~24h stale, with one Spotify hit per user per day.
+- Zero downtime during migration; no in-flight callers (legacy static-token clients, friends/profile, wrapped/all) break mid-rollout.
+- Test suite migrates with the code — fixtures stub `requestContext.authorizer` once, in `conftest.py`.
+
+## Non-Goals
+
+- Re-architecting auth (still custom HS256 JWT; no Cognito/Auth0).
+- Per-route RBAC or scopes.
+- Caching anything beyond `/user/top-items`.
+- Changing `/wrapped/*` semantics — Wrapped page stays on monthly snapshots.
+- Backfilling historical top-items into the cache table.
+- A separate `/auth/refresh` endpoint — re-mint by calling `/auth/login` again with a fresh Spotify access token (see Q1).
+
+---
+
+## Architecture
+
+### Auth flow — before
+```
+iOS/Web --HTTPS w/ Bearer XOMIFY_API_TOKEN--> API GW --token--> Authorizer
+                                                                   |
+                                            Allow / Deny only — payload discarded
+                                                                   v
+                                                                Handler
+                                                                   |
+                                                  caller email = ?queryString.email
+                                                  target email = ?queryString.friendEmail
+```
+
+### Auth flow — after Track 0 + Track 1
+```
+[once per session]
+iOS/Web --POST /auth/login { spotifyAccessToken }--> auth_login lambda
+                                                          |
+                                              Spotify /me --> { email, id }
+                                                          |
+                                              mint HS256 JWT { email, userId, iat, exp }
+                                                          |
+                                                          v
+                                              { data: { token, expiresAt } }
+
+[every authorized request]
+iOS/Web --HTTPS w/ Bearer <per-user JWT>--> API GW --token--> Authorizer
+                                                                   |
+                                            Allow + context: { email, userId }
+                                                                   v
+                                                                Handler
+                                                                   |
+                                  caller email = event.requestContext.authorizer.email   (TRUSTED)
+                                  target email = ?queryString.friendEmail                (UNCHANGED)
+```
+
+### Request flow — `GET /user/top-items` (Track 2)
+```
+iOS/Web --GET /user/top-items--> API GW --> Authorizer (Allow + ctx)
+                                                  |
+                                                  v
+                                    user_top_items handler
+                                                  |
+                           caller_email = ctx.email
+                                                  |
+                           cached = top_items_cache.get_cached(caller_email)
+                                                  |
+                              hit? --> return success_response(cached)
+                                                  |
+                              miss --v
+                           user = get_user_table_data(caller_email)
+                           top  = await Spotify.get_top_items_for_api()  # 6 calls
+                           top_items_cache.set_cached(caller_email, top)
+                           return success_response({ ...top, meta: { failed_ranges: [...] } })
+```
+
+---
+
+## Open Question Decisions
+
+### Q1. JWT TTL — **Recommend: 7 days**
+
+Reasoning:
+- Spotify refresh tokens are long-lived and we already persist them. The client always has a path to a fresh Spotify access token, so re-minting a Xomify JWT is one extra round-trip on cold launch — no separate `/auth/refresh` endpoint needed.
+- 7 days balances re-mint frequency (rare) against blast radius if a JWT is leaked (one week max). A leaked Spotify access token is a much bigger problem; the Xomify JWT only authorizes Xomify routes.
+- iOS/web 401-retry interceptor handles the boundary transparently: any 401 triggers Spotify-token refresh -> `/auth/login` -> retry once.
+- Keeps the auth surface small: no refresh-token table, no rotation.
+
+Tradeoff: a stolen JWT is valid for up to 7 days. Mitigated by HTTPS-only transport, keychain/sessionStorage at rest, and the fact that the JWT only confers Xomify access (not Spotify).
+
+### Q2. JWT secret rotation strategy — **Recommend: dual-secret support via `kid` claim, but defer implementation**
+
+Reasoning:
+- Today the secret is in SSM (`API_SECRET_KEY`). A rotation invalidates every in-flight JWT and forces every user through `/auth/login` again — disruptive but not catastrophic (clients have the Spotify refresh token, can re-mint).
+- A proper `kid` (key id) claim + dual-secret authorizer (try current, fall back to previous) would make rotation seamless. But it adds complexity that is not needed for v1.
+- **For this epic**: ship with single-secret. Document the rotation behavior (forces re-login) in the auth_login sub-feature. File a follow-up issue for `kid`-based dual-secret if rotation cadence becomes painful.
+
+### Q3. Web token storage — **Recommend: `sessionStorage`**
+
+Tradeoffs:
+- `localStorage`: persists across tabs/sessions; XSS-vulnerable.
+- `sessionStorage`: cleared on tab close; XSS-vulnerable but smaller window; user re-logs each session.
+- `httpOnly cookie`: not XSS-readable; requires backend CORS work + `SameSite` config + cookie-based auth in API Gateway authorizer (today it's header-based). Significant infra change.
+- **Pick `sessionStorage`** for v1: better security than `localStorage` without infra rework. Re-login on tab close is acceptable for a hobby app.
+- Document the cookie option as a future improvement if user-experience complaints arise.
+
+### Q4. iOS keychain access group — **Recommend: same group as Spotify refresh token**
+
+Reasoning:
+- Both are identity material for the same user, same app target. No reason to split.
+- Keeps `AuthService.swift` storage logic single-pathed.
+- If/when a share extension or widget needs the JWT, the existing keychain group is already configured.
+
+Confirm at execution: read `AuthService.swift` keychain wrapper to verify the access group constant, then reuse it for the new JWT key.
+
+### Q5. Migration monitoring — success criterion for shipping (1l) cleanup
+
+**Recommend: < 1% of authorized requests using fallback for 7 consecutive days**, measured per-handler in CloudWatch via the WARN log emitted by the helper.
+
+- 7 days covers weekly-active users who only open the app on weekends.
+- 1% (not 0%) accounts for users on stale app versions who refuse to update. Cleanup PR (1l) intentionally locks them out — they must update.
+- Helper logs include user-agent so we can break down fallback usage by client (web vs iOS-version).
+
+### Q6. Public route exemption for `/auth/login` — **Recommend: bump `api-gateway-service` to v2.3.0 with per-endpoint `authorization` override**
+
+Investigation of `/Users/dom/Code/xomify-infrastructure/terraform/` revealed:
+- API Gateway is built from a shared external Terraform module: `git::github.com/domgiordano/api-gateway-service.git@v2.2.0`.
+- Inside the module (`endpoints.tf:28`), `var.authorization` is set uniformly across every endpoint. There is NO per-endpoint override today.
+- Three options were considered:
+  - (a) Bump module to v2.3.0 with per-endpoint override.
+  - (b) Define `/auth/login` outside the module directly in `xomify-infrastructure/terraform/api_gateway.tf`.
+  - (c) Two-API approach (overkill).
+- **Decision: (a) bump the module.** Cleanest end state. Reusable for any future public route (health checks, webhooks, OAuth callbacks). User owns the module.
+
+Module change spec:
+- Each entry in the `services.<service>.endpoints[]` list gains an optional `authorization` field that overrides `var.authorization` for that endpoint. Defaults to `var.authorization` if unset.
+- Backwards-compatible: existing callers that don't set the field get current behavior.
+- Tag as v2.3.0. Bump the ref in `xomify-infrastructure/terraform/api_gateway.tf:91`.
+
+### Q7. Cache TTL boundary for `/user/top-items` — **Unchanged from original plan: midnight UTC**
+
+(Carried forward verbatim from the original revision.)
+- Spotify's `/me/top/*` is computed on a rolling daily window. Aligning our cache to UTC midnight makes support trivial: _"top items refresh once per UTC day on first request"_.
+- DDB native TTL has up to 48h eviction lag, so we **gate on `cachedAt` in the handler** (`if cachedAt.date() < today_utc.date(): treat as miss`). TTL attribute = `next_midnight_utc + 7 days`, purely a janitor for inactive users.
+
+### Q8. What lives in authorizer context — **Unchanged: `email` AND `userId`**
+
+(Carried forward.) Now satisfied unambiguously by Track 0 — `auth_login` mints both claims, so they will always be present for non-legacy callers. The dual-mode authorizer (legacy static token allowed but no context, new per-user JWT allowed with context) handles the migration window.
+
+---
+
+## Sub-Feature Breakdown
+
+Each sub-feature is independently shippable and gets its own `PLAN.md` stub via `/orchestrate`. Listed in dependency order.
+
+### Track 0 — Per-user JWT foundation
+
+#### (0-pre) `module-per-endpoint-auth-override`
+**Scope**:
+- Extend the `api-gateway-service` Terraform module so each entry in `services.<service>.endpoints[]` can opt out of (or override) the shared authorizer via an optional `authorization` field. Default behavior (when unset): use `var.authorization`, which preserves today's API.
+- Backwards-compatible. Existing callers see no change.
+- Tag and publish as **v2.3.0**.
+- Add a module-level test (or example) that confirms a NONE-auth endpoint and a CUSTOM-auth endpoint coexist in the same API GW deploy.
+**Repos**: `api-gateway-service` (external; user owns; not cloned locally — clone first at execution)
+**Deps**: none. Track 0 prerequisite — ships before everything else.
+**Exit**: v2.3.0 tagged. Test confirms mixed-auth endpoints in a single deploy. Bumping `xomify-infrastructure` to v2.3.0 with no per-endpoint overrides set produces a no-op `terraform plan`.
+
+#### (0a-infra) `auth-login-route-and-lambda-resources`
+**Scope**:
+- Bump module ref to `v2.3.0` in `xomify-infrastructure/terraform/api_gateway.tf:91`.
+- Add `auth_login` lambda Terraform resource (mirror existing patterns in `lambdas_user.tf`).
+- Add `/auth/login` to the appropriate `services` block with `authorization = "NONE"`.
+- Add IAM policy for the lambda to read the SSM secret (`API_SECRET_KEY`).
+- Update `cloudwatch.tf` for the new lambda log group.
+**Repos**: `xomify-infrastructure`
+**Deps**: (0-pre) — needs v2.3.0 published.
+**Exit**: `terraform plan` shows the new lambda + public route. `terraform apply` succeeds. `curl -X POST /auth/login` reaches the lambda (returns 200 once the (0a) backend code is also deployed; until then, deploys an empty/stub lambda artifact or 5xx is acceptable as long as the route is wired).
+
+#### (0a) `auth-login-endpoint`
+**Scope** (lambda code only — infra moved to (0a-infra)):
+- New `lambdas/auth_login/handler.py`. Public route `POST /auth/login` (route provisioned in (0a-infra)).
+- Body validated: `{ spotifyAccessToken: string }`.
+- Calls Spotify `/me`, extracts `email` + `id` (Spotify user id).
+- Mints HS256 JWT using existing `API_SECRET_KEY`. Claims: `{ email, userId, iat, exp }`. TTL: 7 days (Q1).
+- Response: `{ data: { token, expiresAt }, error: null, meta: {} }` per backend response standard.
+- Tests: happy path (mock Spotify `/me`), invalid Spotify token (401 from upstream), expired Spotify token (401 from upstream), malformed request body (400).
+- `DEPLOYMENT_GUIDE.md` updated.
+**Repos**: backend
+**Deps**: (0a-infra)
+**Exit**: `curl -X POST /auth/login -d '{"spotifyAccessToken":"<valid>"}'` returns a JWT. Token decodes to expected claims. Invalid Spotify token returns structured 401.
+
+#### (0b) `authorizer-extract-claims`
+**Scope** (lambda code only):
+- Modify `lambdas/authorizer/handler.py:42`.
+- Decode JWT (already done). If payload contains both `email` and `userId`: include them in policy `context`.
+- If payload is missing those claims (legacy static token): allow the request, but emit nothing into context. Log INFO with `legacy_token=true` for monitoring.
+- This **dual-mode** behavior is what lets old clients keep working through the migration.
+- Tests: per-user JWT path (context populated), legacy static-token path (allow, no context), invalid signature (deny).
+**Repos**: backend
+**Deps**: (0a) deployed (so we can mint test JWTs against the real authorizer)
+**Exit**: Backend code merged. Note: until (0b-infra) ships, the new artifact may not be live in AWS yet.
+
+#### (0b-infra) `authorizer-redeploy-with-claims`
+**Scope**:
+- Ensure the authorizer lambda's deploy artifact in AWS reflects the new dual-mode behavior from (0b).
+- Verify whether `terraform/lambda_authorizer.tf` needs a `source_code_hash` bump or whether the deploy is artifact-driven via CI in `xomify-backend` (if CI pushes the zip, this sub-feature may be a no-op Terraform PR + a manual workflow trigger).
+- Confirm via CloudWatch that the live authorizer is on the new version.
+**Repos**: `xomify-infrastructure` (and possibly the backend deploy workflow)
+**Deps**: (0b) backend code merged.
+**Exit**: CloudWatch shows authorizer log version reflecting the new code. A request bearing a per-user JWT lands at a stub handler with `requestContext.authorizer = { email, userId }`. A request with the legacy static token still passes through with no context.
+
+#### (0c) `caller-identity-helper`
+**Scope**:
+- Add `get_caller_email(event)` and `get_caller_user_id(event)` to `lambdas/common/utility_helpers.py`.
+- Resolution order:
+  1. `event.requestContext.authorizer.email` (trusted) — log DEBUG `auth_path=context`.
+  2. Fallback: `event.queryStringParameters.email` or body `email` — log WARN `auth_path=fallback user_agent=<ua>` (Q5).
+  3. Neither present: raise structured 401.
+- Update `tests/conftest.py`: new `authorized_event` fixture that injects `requestContext.authorizer = { email, userId }`. Old `api_gateway_event` fixture stays for legacy paths during migration.
+- Helper-level unit tests cover all three resolution branches.
+**Repos**: backend
+**Deps**: (0b-infra) deployed (otherwise context is always empty, fallback always fires, monitoring is meaningless)
+**Exit**: Helper imported and exercised in a unit test. Production deploy is a no-op until handlers start using it in Track 1.
+
+#### (0d) `ios-per-user-jwt`
+**Scope**:
+- After Spotify OAuth completes (existing `AuthService.saveRefreshTokenToXomify` flow at line 247), call `POST /auth/login` with the Spotify access token.
+- Store returned Xomify JWT in keychain, same access group as the Spotify refresh token (Q4).
+- Replace every `XOMIFY_API_TOKEN` reference (`AuthService.swift:265`, `NetworkService.swift:202`, and any others — execution agent must `grep -r "XOMIFY_API_TOKEN" /Users/dom/Code/xomify-ios/`) with the keychain-stored JWT.
+- `secrets.xcconfig` entry can stay readable but must not be sent on requests post-migration. Document in commit.
+- Add 401-retry interceptor in `NetworkService`: on any 401, refresh Spotify access token (existing logic) -> call `/auth/login` -> retry the original request once. Only one retry to prevent loops.
+**Repos**: ios
+**Deps**: (0a) deployed
+**Exit**: Fresh install completes Spotify OAuth, calls `/auth/login`, stores JWT, makes an authorized request that succeeds with the per-user JWT (verify in CloudWatch — authorizer logs `legacy_token=false`).
+
+#### (0e) `web-per-user-jwt`
+**Scope**:
+- After Spotify OAuth completes, call `POST /auth/login` with the Spotify access token.
+- Store JWT in `sessionStorage` (Q3) under a single key, e.g. `xomify_jwt`.
+- Replace every `environment.apiAuthToken` reference. Known services using it (verify count at execution): `user.service`, `ratings.service`, `invites.service`, `share-feed.service`, `groups.service`, `friends.service`, `notifications.service`, `wrapped.service`, `release-radar.service`. Likely also `shares.service`. Centralize via an `HttpInterceptor` that reads from `sessionStorage` and attaches `Authorization: Bearer <jwt>`.
+- 401-retry interceptor: on any 401, refresh Spotify access token -> call `/auth/login` -> retry original request once.
+- `environment.apiAuthToken` field can stay in the file but is no longer read.
+**Repos**: frontend
+**Deps**: (0a) deployed
+**Exit**: Fresh login flow stores a JWT in `sessionStorage`. Network tab shows `Authorization: Bearer <per-user JWT>` on every API call. Authorizer logs `legacy_token=false` for these requests.
+
+---
+
+### Track 1 — Caller identity migration (handlers + clients drop fallback)
+
+#### (1a) `backend-handler-migration-friends` (7 handlers)
+#### (1b) `backend-handler-migration-groups` (13)
+#### (1c) `backend-handler-migration-shares` (11)
+#### (1d) `backend-handler-migration-invites` (4)
+#### (1e) `backend-handler-migration-ratings` (4)
+#### (1f) `backend-handler-migration-notifications` (2)
+#### (1g) `backend-handler-migration-release-radar` (2)
+#### (1h) `backend-handler-migration-wrapped` (4) — read-only, low risk
+#### (1i) `backend-handler-migration-user` (3) — `user_data`, `user_all`, `user_update` (trickiest mix of caller + target)
+
+**Scope (each batch, identical pattern)**:
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+**Repos**: backend
+**Deps**: (0c)
+**Exit (per batch)**: All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+#### (1j) `frontend-drop-caller-email`
+**Scope**: Sweep Angular services. Remove caller `email` query params and body fields. Keep target emails (`friendEmail`, etc.).
+**Repos**: frontend
+**Deps**: ALL of (1a)–(1i) deployed AND (0e) deployed (web is now sending per-user JWTs; backend now reads from context)
+**Exit**: Web app round-trips every authenticated request without a caller `email`. Backend fallback WARN count for web user-agents trends to zero in CloudWatch.
+
+#### (1k) `ios-drop-caller-email`
+**Scope**: Sweep iOS networking layer. Remove caller `email` from request construction. Keep target emails.
+**Repos**: ios
+**Deps**: ALL of (1a)–(1i) deployed AND (0d) deployed
+**Exit**: Latest TestFlight build round-trips without caller email. Backend fallback WARN count for iOS user-agent trends to zero.
+
+#### (1l) `auth-fallback-removal`
+**Scope**: Single backend PR. Two cleanups:
+1. Delete the query-param/body fallback in `get_caller_email` / `get_caller_user_id`. Helper now hard-fails 401 if context is missing.
+2. Delete the **legacy static-token shim** in the authorizer (0b). Authorizer now requires `email` + `userId` claims; tokens without them deny.
+- Delete the WARN logs around fallback. Delete the INFO log for `legacy_token=true`.
+**Repos**: backend
+**Deps**: (1j) AND (1k) deployed AND fallback rate < 1% for 7 consecutive days (Q5)
+**Exit**: A request with the legacy static token returns 401. A request with a per-user JWT but no context (impossible barring misconfig) returns 401. Production traffic unaffected.
+
+---
+
+### Track 2 — Live `/user/top-items` endpoint
+
+#### (2a-infra) `top-items-cache-table-and-route`
+**Scope**:
+- In `xomify-infrastructure/terraform/dynamodb.tf` add the `TOP_ITEMS_CACHE` table — PK `email`, native TTL on `ttl` attr.
+- In `xomify-infrastructure/terraform/lambdas_user.tf` add the `user_top_items` lambda resource.
+- Add `/user/top-items` to the `user` service endpoints block with `authorization = "CUSTOM"` (default — explicit for clarity).
+- Wire env var `TOP_ITEMS_CACHE_TABLE_NAME` into the lambda.
+- IAM policy grants `GetItem` + `PutItem` on the new table.
+- Update `cloudwatch.tf` for the new lambda log group.
+**Repos**: `xomify-infrastructure`
+**Deps**: (0-pre) — module ref bump (already shipped via (0a-infra), no re-bump needed); (2a) backend code merged.
+**Exit**: `terraform apply` creates the table and route. `curl GET /user/top-items` with a valid per-user JWT returns 200.
+
+#### (2a) `user-top-items-endpoint`
+**Scope** (backend lambda code + tests only — infra moved to (2a-infra)):
+- `lambdas/common/top_items_cache.py`: `get_cached(email) -> dict | None`, `set_cached(email, top_items) -> None`. `get_cached` returns None if `cachedAt.date() < today_utc.date()` (Q7).
+- `lambdas/user_top_items/handler.py`: reads caller email from context (via 0c), cache-then-fetch. Per-range partial failure handled — `meta.failed_ranges` is a list of strings.
+- `DEPLOYMENT_GUIDE.md` updated.
+- GitHub Actions deploy matrix updated.
+- Tests: `tests/test_user_top_items.py` covering cache hit, cache miss, partial Spotify failure (one range raises), TTL boundary (cachedAt yesterday-UTC = miss; cachedAt today-UTC = hit), 401 on missing context.
+**Repos**: backend
+**Deps**: (0c). Does NOT depend on (1*) work.
+**Exit**: Lambda code merged; cache helper unit-tested. End-to-end exit (route live, table populated) gated on (2a-infra) apply.
+
+#### (2b) `music-taste-page-wire-up` (web)
+**Scope**:
+- Verify path: execution agent runs `ls /Users/dom/Code/xomify-frontend/src/app/pages/` to locate the Music Taste page (likely `music-taste/` or similar).
+- Add `getUserTopItems()` to `UserService` (or a new `TopItemsService` if it warrants its own file).
+- Wire the Music Taste page to call this method instead of whatever it currently uses (snapshot or none).
+- Loading + error states handled per existing service patterns.
+**Repos**: frontend
+**Deps**: (2a-infra) AND (0e)
+**Exit**: Music Taste page shows top items refreshed within the last UTC day.
+
+#### (2c) `ios-current-page-wire-up`
+**Scope**:
+- Point "Top 25 — Last 4 Weeks (Current)" page at `GET /user/top-items` instead of `GET /wrapped/all`.
+- Wrapped page (the historical snapshot view) stays on `/wrapped/all`.
+**Repos**: ios
+**Deps**: (2a-infra) AND (0d)
+**Exit**: iOS "Last 4 Weeks (Current)" page shows top items refreshed within the last UTC day. Wrapped page unchanged.
+
+(Decision: 2b and 2c are kept as separate sub-features. They're independent code-wise, in different repos, and gated by different upstream Track 0 sub-features.)
+
+---
+
+## Sub-Feature Counts
+
+- **Track 0**: 1 module sub (0-pre) + 2 infra subs (0a-infra, 0b-infra) + 5 backend/client subs (0a, 0b, 0c, 0d, 0e) = **8**
+- **Track 1**: 12 (unchanged — 1a–1l)
+- **Track 2**: 1 infra sub (2a-infra) + 3 backend/client subs (2a, 2b, 2c) = **4**
+- **Total**: **20**
+
+## Hard Sequencing Edges
+
+```
+(0-pre) module-per-endpoint-auth-override   [api-gateway-service v2.3.0 published]
+   |
+   +---> (0a-infra) auth-login-route-and-lambda-resources   [bumps module ref; provisions lambda + public route]
+   |        |
+   |        v
+   |     (0a) auth-login-endpoint   [lambda code]
+   |        |
+   |        v
+   |     (0b) authorizer-extract-claims   [lambda code, dual-mode]
+   |        |
+   |        v
+   |     (0b-infra) authorizer-redeploy-with-claims   [ship the new authorizer artifact]
+   |        |
+   |        v
+   |     (0c) caller-identity-helper
+   |        |
+   |        +---> (0d) ios-per-user-jwt          (parallel with 0e)
+   |        +---> (0e) web-per-user-jwt          (parallel with 0d)
+   |        |
+   |        +---> (1a)..(1i) backend handler batches  (parallel with each other; parallel with 0d/0e)
+   |        |        |
+   |        |        +---> (1j) frontend-drop-caller-email   (needs ALL 1a-1i AND 0e)
+   |        |        +---> (1k) ios-drop-caller-email        (needs ALL 1a-1i AND 0d)
+   |        |                |
+   |        |                +---> (1l) auth-fallback-removal   (needs 1j AND 1k AND 7-day burn-in)
+   |        |
+   |        +---> (2a) user-top-items-endpoint   [lambda code, parallel with all of Track 1]
+   |                  |
+   |                  v
+   |               (2a-infra) top-items-cache-table-and-route   [DDB + route + lambda resource]
+   |                  |
+   |                  +---> (2b) music-taste-page-wire-up   (also needs 0e)
+   |                  +---> (2c) ios-current-page-wire-up   (also needs 0d)
+   |
+   +---> (2a-infra) also depends on (0-pre) for the module ref  [same one-time bump; no re-publish needed]
+```
+
+Note: (0-pre) is a **one-time** module publish. Once shipped, all downstream `-infra` sub-features simply consume the published v2.3.0 — they don't re-publish anything.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Module bump (0-pre) breaks existing API GW deploys | Changes are backwards-compatible (per-endpoint `authorization` field is optional, defaults to `var.authorization`). Test by applying v2.3.0 module ref to `xomify-infrastructure` with NO per-endpoint overrides set; deploy must be a no-op. |
+| `/auth/login` lambda exposed publicly invites abuse | Rate-limit at API Gateway. Lambda only mints if Spotify `/me` returns 200, so attacker needs a valid Spotify token first. Log every mint with email + IP for audit. |
+| Authorizer dual-mode (0b) accidentally accepts unsigned tokens | Signature verification stays mandatory. Dual-mode only bifurcates on whether claims are present, not on whether the signature is valid. Test covers both branches. |
+| Old clients break before they update to per-user JWTs | (0b) keeps legacy token allowed; (1*) handlers keep query-param fallback; (1l) doesn't ship until fallback rate < 1% for 7d (Q5). |
+| Fallback rate never drops below threshold (stale installs) | (1l) intentionally locks them out — that's the point. Communicate via in-app banner + force-update prompt before shipping (1l). Track this as an action item for product comms. |
+| JWT secret rotation invalidates all in-flight tokens | Documented in Q2. Single-secret v1 forces re-login on rotation; clients re-mint via Spotify refresh token automatically. |
+| iOS keychain group misconfigured -> JWT not retrievable across app launches | Confirmed at (0d) execution by reading existing keychain wrapper. Add a launch-time read test in `AuthService` that logs if retrieval fails. |
+| Web `sessionStorage` cleared on tab close annoys users | Documented tradeoff (Q3). Re-login is one Spotify-token round-trip, transparent to user (no new OAuth window). |
+| Two clients call `/auth/login` simultaneously and store different tokens | Either token is valid for 7 days. No race condition; backend doesn't track sessions. |
+| Handler migration breaks in-flight callers | Query-param fallback in (1a)–(1i) keeps everything working. WARN logs make migration progress visible. |
+| Tests not migrated alongside handlers | Each handler PR in (1*) MUST include its test update. CI gate. |
+| Spotify rate limits during cache stampede on first launch | Cache writes per-user; miss rate decays quickly. Per-user lock skipped for v1; revisit if pathological. |
+| DDB TTL eviction lag (up to 48h) leaves stale rows readable | Handler-side gate on `cachedAt.date() < today_utc.date()`. TTL is a janitor. |
+| Music Taste page (web) doesn't exist where assumed | (2b) execution starts with a `ls` to confirm. If layout differs, plan adjusts in the sub-feature stub, not here. |
+| Partial-failure response shape confuses iOS deserializer | Document `meta.failed_ranges` in API contract. iOS treats `null` ranges as "show prior data / show empty state". |
+| Someone runs `/execute` on (0c) before (0b-infra) is in prod | Plan status gate + sub-feature `Deps:` field. Orchestrator must check upstream `Status: Done` before queuing. |
+
+---
+
+## Test Strategy
+
+**Backend**:
+- New `tests/test_auth_login.py`: happy path (Spotify `/me` mocked), invalid Spotify token, malformed body. Decodes returned JWT and asserts claims.
+- New `tests/test_authorizer_dual_mode.py`: per-user JWT (context populated), legacy static-token (allow, no context), invalid signature (deny).
+- Update `tests/conftest.py`: new `authorized_event(email='test@example.com', user_id='spotify123')` fixture.
+- Each handler test in (1a)–(1i) migrates from `email` in `queryStringParameters` to `authorized_event`.
+- New `tests/test_user_top_items.py`: cache hit, cache miss, partial Spotify failure, TTL boundary (freeze time), 401 on missing context.
+- `pytest` runs locally and in CI before each batch deploys.
+
+**Frontend (Angular)**:
+- New unit test for the `HttpInterceptor` from (0e): attaches Bearer header from `sessionStorage`; on 401, calls `/auth/login` and retries.
+- (1j) is a deletion sweep — no new tests; run existing `ng test`.
+- Manual smoke: log in, hit each major page (friends, groups, shares, ratings, profile, music taste), confirm 200s in network tab and `Authorization: Bearer <jwt>` on every call.
+
+**iOS**:
+- New unit test (if test target exists) for `NetworkService` 401-retry path.
+- Manual TestFlight smoke for (0d), (1k), (2c): every screen that hits the API. Verify keychain persistence across app kill/relaunch.
+
+**Cross-cutting**:
+- After each (1*) batch deploys, check CloudWatch fallback WARN counts per domain. Non-zero expected pre-(1j)/(1k); trends to zero after.
+- Before (1l) ships: 7-day CloudWatch query showing < 1% fallback rate across all 49 handlers (Q5).
+
+---
+
+## Rollout / Rollback
+
+**Rollout**:
+1. **Track 0 prerequisite**: ship (0-pre) first — release `api-gateway-service` v2.3.0. Then ship (0a-infra) to bump the module ref in `xomify-infrastructure` and provision the `auth_login` lambda + public route. Then ship (0a) backend code which fills in the lambda body.
+2. Ship (0b) backend code, then (0b-infra) to push the new authorizer artifact. Verify both code paths in CloudWatch (per-user JWT requests have context; legacy still passes).
+3. Ship (0c). No-op in prod.
+4. Ship (0d) and (0e) in either order. Watch authorizer logs flip from `legacy_token=true` to `legacy_token=false` as users update.
+5. **Track 1 batches.** Ship (1a)–(1i) one per day, lowest-traffic-domain-first (release_radar, notifications, invites) to highest (friends, groups, shares). Each batch: PR -> CI green -> deploy -> 1h soak -> next.
+6. Once (1a)–(1i) all in prod AND (0d)/(0e) shipped: ship (1j) and (1k) in either order.
+7. Monitor fallback rate daily. After 7 days at < 1%: ship (1l).
+8. **Track 2 in parallel** with Track 1 batches (both depend only on (0c)). Ship (2a) backend code any time after (0c). Ship (2a-infra) to provision the table + route. Ship (2b)/(2c) once (2a-infra) is live and the relevant client (0d/0e) has shipped.
+
+**Rollback** (per stage):
+- (0-pre): pin `xomify-infrastructure` back to v2.2.0 of the module — only relevant if v2.3.0 has a regression discovered post-publish. The module sub-feature itself is in a separate repo, so no in-place rollback is needed beyond the consumer's ref bump.
+- (0a-infra): `terraform apply` with the route block removed (and module ref reverted if needed). Lambda resource removed. Clients fall back to the static token path (still alive until (1l)).
+- (0a): delete API GW route + lambda. Clients can't mint; they fall back to the static token in `secrets.xcconfig` / `environment.apiAuthToken` (which still works because (0b)/(1l) haven't shipped). Zero impact.
+- (0b): revert authorizer to prior version. Handlers don't yet read context — no impact.
+- (0b-infra): re-deploy prior authorizer artifact. Handlers continue working since they don't yet read context.
+- (0c): revert helper. No callers yet — no impact.
+- (0d) / (0e): revert client deploy. Backend still accepts both token types via dual-mode authorizer.
+- (1a)–(1i) per batch: revert that batch's handlers. Other batches unaffected. Query-param fallback keeps reverted handlers working.
+- (1j) / (1k): revert client deploy. Backend fallback handles old client.
+- (1l): revert. Helper goes back to fallback mode; authorizer goes back to dual-mode. Fallback warns reappear; harmless.
+- (2a-infra): `terraform destroy` on the new table + route + lambda resource. No data loss (cache is regenerable).
+- (2a): revert lambda code. Route still exists but returns errors until reverted handler ships or route is destroyed via (2a-infra) rollback.
+- (2b) / (2c): revert client deploy. Pages go back to prior data source.
+
+**Migration window invariant**: from the moment (0a) ships until (1l) ships, BOTH the legacy static `XOMIFY_API_TOKEN` and per-user JWTs must be accepted. (1l) is the cutover.
+
+---
+
+## Out of Scope
+
+- Migrating from custom HS256 JWT to a managed identity provider (Cognito, Auth0).
+- Per-route RBAC, scopes, or audit logging beyond the (0a) mint log.
+- Refresh-token rotation changes.
+- A separate `/auth/refresh` endpoint (Q1: re-mint via `/auth/login`).
+- `kid`-claim dual-secret rotation support (Q2: deferred).
+- Caching anything other than `/user/top-items`.
+- Backfilling cache for inactive users.
+- Replacing query-string `friendEmail` / `targetEmail` / `ownerEmail` with anything else — these are legitimate target identifiers and stay.
+- Touching `cron_wrapped` or any cron lambda — they are not behind the authorizer.
+- httpOnly-cookie auth on web (Q3: deferred).
+- In-app banners or force-update prompts (handled by product comms before (1l)).
+
+---
+
+## Skills / Agents to Use
+
+- **`/orchestrate`** (next step): turn each sub-feature (0-pre), (0a-infra), (0a)–(0e), (0b-infra), (1a)–(1l), (2a-infra), (2a)–(2c) into its own `docs/features/<slug>/PLAN.md` stub. Pass this epic doc as context.
+- **`infra-specialist` agent**: invoke for (0-pre), (0a-infra), (0b-infra), (2a-infra). All Terraform/AWS work routes through this agent per project conventions.
+- **`backend-standards` skill**: invoke during (0a), (0b), (0c), (1*), (2a) handler/test work to confirm response shape, type hints, and error handling conventions.
+- **`/plan` per sub-feature**: each stub gets fleshed out with concrete file lists and step-by-step before its `/execute`.
+- **`/fix`**: NOT to be used here. Every sub-feature is large enough to warrant a real plan.
+
+---
+
+## Action Items Before `/orchestrate`
+
+These are quick reads the orchestrator (or the user) should do before stub creation; they are not blockers for this epic doc.
+
+Resolved in Revision 2:
+- [x] API Gateway route configuration location confirmed (Terraform in `xomify-infrastructure` via shared module). Q6 answered.
+- [x] iOS networking layer call sites confirmed at `Xomify-iOS/Services/NetworkService.swift` and `AuthService.swift`. (Sub-feature 0d execution will still `grep -r` for any stragglers.)
+- [x] Angular service file list partially confirmed (~10 services use `environment.apiAuthToken`); execution agent will sweep the full list at (0e).
+
+Still open:
+- [ ] iOS keychain access group constant — read at (0d) execution to confirm reuse of the Spotify refresh-token group (Q4).
+- [ ] Path to Angular Music Taste page — `ls /Users/dom/Code/xomify-frontend/src/app/pages/` at (2b) execution.
+- [ ] Path to iOS "Top 25 — Last 4 Weeks (Current)" view — grep at (2c) execution.
+- [ ] Product comms plan (in-app banner? release notes? force-update?) for users on stale builds before (1l) cuts them off (Q5 risk).
+- [ ] Confirm the module-bump release process for `api-gateway-service` — tagging convention, who can publish (user owns; presumably just `git tag v2.3.0 && git push --tags`, but verify).
+- [ ] Confirm authorizer deploy mechanism — does `terraform apply` push the lambda zip, or is that a separate GH Actions workflow in `xomify-backend`? Determines whether (0b-infra) is real Terraform work or a workflow trigger + verification step.

--- a/docs/features/auth-identity-and-live-top-items/POST_LAUNCH_DIAGNOSTICS.md
+++ b/docs/features/auth-identity-and-live-top-items/POST_LAUNCH_DIAGNOSTICS.md
@@ -1,0 +1,97 @@
+# Post-Launch Diagnostics — 2026-04-27
+
+## Issue 1: Profile UI regressions
+
+### 1a. No profile/avatar icon in top-right corner
+
+**Root cause:** The (1j) top-nav cleanup (commit `07d20b2`, PR #250 "feat(ui): group top-nav into dropdowns, move settings into profile tab") collapsed the flat 15-link nav into 4 leaf links + 3 grouped dropdowns and **removed the explicit `'/my-profile', label: 'My Profile'` entry** from `navLinks`. The fallback was supposed to be the logo (`<a routerLink="/my-profile" class="app-title">…banner-logo-x-rework.png…</a>`), but no avatar/profile-picture chip was ever added to the top-right corner. The current toolbar has only: logo (left), nav links/dropdowns (center), Logout button (far right desktop) / hamburger (mobile). There is no surface that uses the user's `profilePicture` from `UserService.getProfilePic()`.
+
+**Affected files:**
+- `/Users/dom/Code/xomify-frontend/src/app/components/toolbar/toolbar.component.html` (no avatar element)
+- `/Users/dom/Code/xomify-frontend/src/app/components/toolbar/toolbar.component.ts` (no `profilePicture` binding; doesn't inject anything that exposes the avatar URL into the template)
+
+**Suggested fix:** Add a right-aligned anchor to `/my-profile` that renders `<img [src]="profilePicture || 'assets/img/default-avatar.png'">` as a circular chip. Pull `profilePicture` from the existing injected `UserService` (`this.userService.getProfilePic()` — already used everywhere). Place between the nav `tabs` div and the desktop Logout button so it appears far-right on desktop and replaces/precedes the hamburger on mobile. ~10 lines of HTML + a `profilePicture` getter on the component.
+
+---
+
+### 1b. Profile page over-fetches Spotify `/me/top/tracks` on every visit
+
+**Root cause:** The (2b) wire-up (commit `0b15a0b`, PR #257 "Wire Music Taste page to /user/top-items") migrated `top-songs`, `top-artists`, and `top-genres` to the new `TopItemsService.getTopItems()` (which hits `/user/top-items` and is backend-cached per UTC day). **The migration deliberately did NOT touch `my-profile.component.ts`.** That page's `loadTickerData()` (lines 276–309) still calls `songService.getTopTracks('short_term')` directly against Spotify's `https://api.spotify.com/v1/me/top/tracks?limit=50&time_range=short_term`, then writes back via `setTopTracks(items, [], [])`.
+
+Two compounding problems:
+1. **In-memory cache is the only gate.** The check at line 280 (`cachedSongs.length > 0 && cachedArtists.length > 0`) is a singleton in-memory cache — survives Angular navigation but evaporates on hard reload. Since the user reports "every render," they're likely doing tab/page reloads or the cache is being clobbered.
+2. **Cache poisoning.** Line 300 writes `setTopTracks(data.songs.items, [], [])` — overwriting medium/long with empty arrays. After visiting `/my-profile` first, the next visit to `/top-songs` sees `cachedMedium.length === 0` → cache miss → fires `/user/top-items`. Asymmetric caching = double fetches across the two pages. (User likely also sees this as "tracks call every time" depending on which Network tab line they were watching.)
+3. **`loadAdditionalData()` always re-fires** Spotify `/me/playlists?limit=1` and `/me/following?type=artist&limit=1` on every `ngOnInit()` (no cache check at all, lines 230–252). These run before `loadTickerData()` and may also be what the user is seeing in the Network tab.
+
+**Affected files:**
+- `/Users/dom/Code/xomify-frontend/src/app/pages/my-profile/my-profile.component.ts` (lines 230–252 `loadAdditionalData`, 276–309 `loadTickerData`, 300 cache poisoning)
+- `/Users/dom/Code/xomify-frontend/src/app/services/song.service.ts` (line 70 `getTopTracks` direct Spotify call)
+- `/Users/dom/Code/xomify-frontend/src/app/services/top-items.service.ts` (the service that *should* be used)
+
+**Suggested fix:** Migrate `my-profile.component.ts:loadTickerData()` to use `TopItemsService.getTopItems()` — same pattern as `top-songs.component.ts:115`. Pull `tracks.short_term`, `artists.short_term`, derive genres via `extractTopGenres`. Fix line 300 by writing `setTopTracks(short, medium, long)` from the response so the cache is fully populated and the top-songs/top-artists pages can hit the cache instead of refetching. ~15 line swap. Bonus: gate `loadAdditionalData()` behind a `playlistCount > 0 && followingCount > 0` cache check so the Spotify `/me/playlists` and `/me/following` calls don't re-fire on every navigation.
+
+---
+
+## Issue 2: `/likes/push` 403 ForbiddenException
+
+**Root cause:** Most likely the **shared regional WAF ACL associated with the API Gateway stage** is blocking the request body. The route exists, the lambda exists, the deployment refreshed, and the authorizer is unrelated.
+
+Confirmed via terraform module:
+- `/Users/dom/Code/xomify-infrastructure/terraform/lambdas_likes.tf` declares `name="push"`, `path_part="push"`, `http_method="POST"` → route `/likes/push` exists.
+- `/Users/dom/Code/xomify-infrastructure/terraform/api_gateway.tf:149` registers the `likes` service with the api-gateway-service module.
+- The deployment trigger is `triggers.redeployment = sha1(jsonencode([timestamp()]))` (in `.terraform/modules/api/api_gateway.tf:42`) — `timestamp()` is evaluated every plan, so deployment **always** redeploys. Last terraform apply: `2026-04-27T01:54:25Z` (success, run 24972898237). Lambda code deployed at `2026-04-27T03:25:50Z` (success, run for PR #170).
+- Lambda permission `aws_lambda_permission.invoke` is created per-endpoint with `source_arn = "${execution_arn}/*/*"` — wildcards over methods + resources, so it allows API GW → lambda invoke for the new route.
+- Authorizer is shared with all other routes (which work). If the authorizer were the cause, **every** route would 403. Only `/likes/push` does.
+
+**Why WAF is the prime suspect:**
+- `/Users/dom/Code/xomify-infrastructure/terraform/waf.tf:15` associates a shared WAF ACL (`/xomware/shared/regional-waf-acl-arn` from SSM) with `module.api.stage_arn`. The ACL is **defined outside this repo** (in `xomware-infrastructure`) so we can't read its rules locally.
+- `/likes/push` is the only POST endpoint that ships a *large* JSON body in a single hop: `LikesService.pushUserLikes()` (`xomify-frontend/src/app/services/likes.service.ts:51-65`) batches up to **100 tracks per request**, each with `trackName`, `artistName`, `albumName`, `albumArtUrl`, `trackUri`, `trackId`, `addedAt`. Realistic payload size: ~10–15 KB. **AWS WAF Managed Rules' default body inspection limit is 8 KB for the regional API Gateway.** A `SizeRestrictions_BODY` rule (part of `AWSManagedRulesCommonRuleSet`) will return 403 with `x-amzn-errortype: ForbiddenException` for any body > 8 KB.
+- This perfectly matches the observed symptom: 403 ForbiddenException, no lambda invocation in CloudWatch.
+
+**Other possibilities (lower probability, worth ruling out):**
+- WAF rate-limit rule fired (the cold-open coordinator hits this once per 24h per session, so unlikely unless the user is testing repeatedly).
+- WAF `BadInputs` or `SQLi` rule false-positive on the JSON body (unlikely with plain track metadata).
+- The custom domain (if used) routes via CloudFront which has its own WAF — but the user's URL is the raw `wkuh988iah.execute-api...` direct stage URL, so only the regional WAF applies.
+
+**Affected files / Terraform state:**
+- `/Users/dom/Code/xomify-infrastructure/terraform/waf.tf` (the association)
+- `xomware-infrastructure` repo: `/xomware/shared/regional-waf-acl-arn` SSM parameter — the actual ACL rules live there
+- `/Users/dom/Code/xomify-frontend/src/app/services/likes.service.ts:37` (`BATCH_SIZE = 100` — easy lever)
+- `/Users/dom/Code/xomify-frontend/src/app/services/likes-push-coordinator.service.ts:65-92` (the upstream batcher)
+
+**Suggested fix:**
+1. **Verify the cause first.** Check CloudWatch for the API Gateway stage's WAF metric — if `BlockedRequests` for the request matches the timestamp, WAF is confirmed.
+2. **If WAF body-size:** Lower `BATCH_SIZE` in `likes.service.ts` from `100` to `25` (puts payload comfortably under 4 KB). One-line change. Trade-off: 4× more requests for users with > 100 likes — acceptable for a cold-open background sync.
+3. **If WAF rate-limit:** Add a per-IP exemption in the shared WAF ACL for `/likes/push`, or move the WAF associations to per-route opt-in.
+
+---
+
+## Issue 3: iOS feed cannot delete post
+
+**Root cause:** **HTTP method mismatch.** The iOS client POSTs to `/shares/delete`; the API Gateway route only accepts DELETE.
+
+Confirmed:
+- `/Users/dom/Code/xomify-ios/Xomify-iOS/Services/XomifyService.swift:181` — `try await network.xomifyPost("/shares/delete", body: [...])`.
+- `/Users/dom/Code/xomify-infrastructure/terraform/lambdas_shares.tf:22-26` — the `delete` entry has `http_method = "DELETE"`.
+- API Gateway returns `403 ForbiddenException "Missing Authentication Token"` (the standard response) when a route exists at the URL path but the requested HTTP method has no integration.
+- Cross-check: the sibling `/shares/comments-delete` route is also `DELETE` in TF, and iOS calls it correctly via `xomifyDelete("/shares/comments-delete", ...)` (`XomifyService.swift` ~line 320). So the convention in iOS is "use `xomifyDelete` for DELETE routes" — `deleteShare` just never followed it.
+
+**This bug is pre-existing — NOT caused by (1k) PR #100.** Tracing `git log -S "deleteShare" -- Xomify-iOS/Services/XomifyService.swift`, the function was originally added by commit `4e3cd20` ("refactor(ios): align Share model with deployed shares_create/shares_feed") already as `xomifyPost`. The (1k) sweep (commit `a900925`) only removed the `email` field from the body — it did not change the HTTP verb. The user attributes it to (1k) because that's when they retested feed delete; it has actually been broken since the route was first added.
+
+**Why backend (1c) shares-handler-migration is innocent:** `lambdas/shares_delete/handler.py:51-83` correctly reads `shareId` from body OR query (line 35–48 `_extract_share_id`) and `email` from authorizer context with body fallback (line 56 `get_caller_email`). The handler would happily process the iOS payload — but it's never invoked because API Gateway rejects the POST before routing.
+
+**Affected files:**
+- `/Users/dom/Code/xomify-ios/Xomify-iOS/Services/XomifyService.swift:176-186` (the `deleteShare` function — uses `xomifyPost`)
+- `/Users/dom/Code/xomify-ios/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift:445-463` (calls it; works correctly once the service is fixed)
+- `/Users/dom/Code/xomify-ios/Xomify-iOS/ViewModels/SharesByUserViewModel.swift:83-95` (also calls `xomifyService.deleteShare` — same wire fix unblocks both call sites)
+- `/Users/dom/Code/xomify-infrastructure/terraform/lambdas_shares.tf:22-26` (route definition — keep DELETE; no infra change needed)
+
+**Suggested fix:** In `XomifyService.swift:181`, change `network.xomifyPost("/shares/delete", body: [...])` to `network.xomifyDelete("/shares/delete", body: [...])`. The `xomifyDelete<T>(_ endpoint: String, body: [String: Any])` overload already exists (`NetworkService.swift:270`). One-line change. No backend or terraform change required.
+
+---
+
+## Cross-cutting observations
+
+- **(2b) wire-up was incomplete.** The PR #257 commit message says "wires the three Music Taste pages" — it did not promise to migrate `my-profile`, but the profile page's ticker is conceptually a fourth Music Taste surface and should have been included. Suggest filing a follow-up to migrate the profile ticker for consistency and to stop poisoning the songService cache.
+- **iOS HTTP-method discipline is fragile.** Three of the share routes (`delete`, `comments-delete`, `reactions-toggle`) span all three verbs (DELETE, DELETE, POST). Suggest a quick lint or compile-time check (e.g., a typed enum of route → method) so a route + method mismatch fails at build time instead of silently 403'ing in production.
+- **WAF behavior is invisible from the app repos.** The likes_push 403 is not diagnosable from xomify-backend or xomify-infrastructure alone — it needs CloudWatch + the xomware-infrastructure repo. Consider exporting the WAF ACL ID into this repo's outputs so the rule list is greppable.

--- a/docs/features/auth-identity-and-live-top-items/WEB_FEED_LIKES_PARITY_DIAGNOSTICS.md
+++ b/docs/features/auth-identity-and-live-top-items/WEB_FEED_LIKES_PARITY_DIAGNOSTICS.md
@@ -1,0 +1,156 @@
+# Web Feed/Likes Parity — 2026-04-27
+
+Diagnoses gaps between the web (Angular) and iOS (SwiftUI) feed share-cards, plus a broken `/likes` page on web. Backend endpoints are already deployed for everything iOS does, so the work is purely frontend.
+
+References:
+- Web feed page: `/Users/dom/Code/xomify-frontend/src/app/pages/feed/feed.component.{ts,html}`
+- Web share card: `/Users/dom/Code/xomify-frontend/src/app/components/share-card/share-card.component.{ts,html,scss}`
+- Web share-feed service: `/Users/dom/Code/xomify-frontend/src/app/services/share-feed.service.ts`
+- iOS feed: `/Users/dom/Code/xomify-ios/Xomify-iOS/Views/Feed/FeedView.swift`
+- iOS share card: `/Users/dom/Code/xomify-ios/Xomify-iOS/Views/Feed/ShareCardView.swift`
+- iOS share detail: `/Users/dom/Code/xomify-ios/Xomify-iOS/Views/Feed/ShareDetailView.swift`
+- iOS share-card VM: `/Users/dom/Code/xomify-ios/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift`
+- iOS share-detail VM: `/Users/dom/Code/xomify-ios/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift`
+- iOS friends-rated drilldown: `/Users/dom/Code/xomify-ios/Xomify-iOS/Views/Feed/FriendsRatedListView.swift`
+- iOS friends-queued drilldown: `/Users/dom/Code/xomify-ios/Xomify-iOS/Views/Feed/FriendsQueuedListView.swift`
+- iOS reactions bar: `/Users/dom/Code/xomify-ios/Xomify-iOS/Views/Feed/ReactionsBar.swift`
+- Backend `shares_detail`: `/Users/dom/Code/xomify-backend/lambdas/shares_detail/handler.py`
+- Backend `likes_by_user`: `/Users/dom/Code/xomify-backend/lambdas/likes_by_user/handler.py`
+
+---
+
+## Issue 1: Feed share-card UI gaps
+
+### Per-feature audit
+
+| Feature | iOS impl | Web impl | Gap | Suggested fix file |
+|---|---|---|---|---|
+| Tap card body → push detail screen | `ShareCardView.swift:116-125` (Button wraps `detailTapZone`) + `FeedView.swift:124-126,145-151` (`navigationDestination(item:)`) routes to `ShareDetailView` | None. `share-card.component.html:1-170` only exposes `openAuthor()` (avatar tap → friend profile). No share-detail navigation. No `share-detail` page or route in `pages/`. | Missing entirely. There is no web `pages/share-detail/` and no router entry for it. (`pages/share/` is a "share my top stats" screenshot composer, unrelated.) | New page `pages/share-detail/` + new method `ShareFeedService.getShareDetail(shareId, sharedBy?, sharedAt?)` calling `GET /shares/detail`. Add `(click)="openDetail()"` on the card body (header + track block + caption + tags) in `share-card.component.html`. Wire route in `app-routing.module.ts`. |
+| Comment thread (list + composer + delete) | `ShareDetailView.swift:385-514` (commentsSection / composer / row) backed by `ShareDetailViewModel.swift:154-229` calling `XomifyService.listComments / createComment / deleteComment`. Card surfaces a count via `commentButton` (`ShareCardView.swift:351-373`). | None. `share-feed.service.ts` has no comment methods. `share-card.component.html` has no comment button or count. `Share` interface (`share-feed.service.ts:23-45`) has no `commentCount`. | Missing entirely. | Add `commentCount?: number` to `Share` interface. Add comment button + count to `share-card.component.html` next to/below the kebab. Build comment list + composer inside the new `share-detail` page. New service methods on `ShareFeedService`: `listComments(shareId, limit?, before?)`, `createComment(shareId, body)`, `deleteComment(shareId, commentId)` hitting `GET/POST/DELETE /shares/comments-*`. |
+| Reaction emoji bar (toggle 6 emojis, viewer-state pills, smiley picker) | `ReactionsBar.swift` (shared between card + detail) wired through `ShareCardViewModel.toggleReaction` (`ShareCardViewModel.swift:149-187`) calling `XomifyService.toggleReaction` → `POST /shares/reactions-toggle`. | None. The "rating" thing on the card is the 1-5 star personal rating (`viewerRating`). No emoji reactions, no reactions row, no reaction summary fields. | Missing entirely. `Share` interface has no `reactionCounts` / `viewerReactions`. | Add `reactionCounts: Record<string, number>` and `viewerReactions: string[]` to `Share`. Build a `ReactionsBarComponent` (mirror of `ReactionsBar.swift` — pills for active reactions + smiley + popover picker). New service method `toggleReaction(shareId, reaction)` calling `POST /shares/reactions-toggle`. Render bar inside `share-card.component.html` and again inside the new `share-detail` page. |
+| Friends-ratings indicator + drilldown ("N friends rated, 3.8 avg") | `ShareDetailView.swift:220-235` stat tile → `FriendsRatedListView.swift` lists each friend with their stars + review. `averageFriendRating` computed in `ShareDetailViewModel.swift:104-108` from `friendRatings` returned by `/shares/detail`. Card already shows raw `ratedCount` (`Share.ratedCount`). | The card shows `ratedCount` only as `{{ ratedCount }} rated` text (`share-card.component.html:58-60`). No drilldown, no average, no list of friends. | Drilldown + average missing. The `ratedCount` integer is already on the card but unactionable. | Wire from the new `share-detail` page. `/shares/detail` already returns `friendRatings: [{email, displayName, avatar, rating, review, ratedAt}]` — render a stat tile that links to a `friends-rated` modal/sub-view. Compute `average = sum(rating) / length` client-side (same as `averageFriendRating` in `ShareDetailViewModel.swift:104-108`). |
+| Friends-listens indicator + drilldown ("N friends queued") | `ShareDetailView.swift:204-218` stat tile → `FriendsQueuedListView.swift`. Sourced from `interactions` filtered to `action == "queued"` (`ShareDetailViewModel.swift:98-100`). | Card shows raw `queuedCount` on the Queue pill (`share-card.component.html:92`). No drilldown, no friend list. | Drilldown missing. Count is on the wrong control. | Same as above — render in the new `share-detail` page. `/shares/detail` returns `interactions: [{email, displayName, avatar, action, createdAt}]`; filter where `action == "queued"`. |
+| Average-rating display | Implicit in friends-rated drilldown (`FriendsRatedListView` averageCard, lines 53-75). Not on the card itself. | Not present anywhere. | Same gap as friends-ratings drilldown. | Same fix. |
+| Queue / mark-as-listened action | iOS deliberately removed the front-of-card Queue shortcut and folded it into the `TrackActionsMenu` (the kebab). See `ShareCardView.swift:322-324` comment: *"The `Queue` shortcut moved into the Actions menu"*. The on-detail "queued count" is read-only. | The web card has BOTH a primary `queue-btn` (`share-card.component.html:65-93`) AND a duplicate "Add to Queue" item inside the kebab menu (`share-card.component.html:130-141`). Both call `toggleQueue()` (`share-card.component.ts:115-157`) which actually writes through `POST /shares/react?action=queued`. | Duplicate, prominent on the card, not gated to author/friend. | Delete the entire `<button class="queue-btn">…</button>` block (`share-card.component.html:65-93`) and the corresponding `.queue-btn` SCSS. Keep the kebab `menuQueue()` entry — but consider whether it should call `playerService` to actually add to Spotify queue (iOS path) instead of just flipping the `viewerHasQueued` flag in DynamoDB (current web behavior). |
+
+### Vertical 3-dot menu
+
+The kebab SVG in `share-card.component.html:104-114` is hand-drawn with three circles stacked **vertically**:
+
+```
+<circle cx="12" cy="5"  r="1.5" />
+<circle cx="12" cy="12" r="1.5" />
+<circle cx="12" cy="19" r="1.5" />
+```
+
+There is no CSS rotation applied (`grep -n "rotate" share-card.component.scss` → 0 hits). It just looks weird because iOS uses `Image(systemName: "ellipsis")` which is **horizontal** (`TrackActionsMenu.swift:108,117`). Two options:
+
+1. Swap the circle coordinates to horizontal: `cx="5"/"12"/"19"` and `cy="12"`. Lowest-risk.
+2. Replace with an inline SF-Symbol-equivalent SVG (three horizontal dots).
+
+Either is one-line. The user almost certainly wants horizontal to match iOS conventions.
+
+### Queue button: what it does today
+
+- **iOS**: `ShareCardViewModel.queue()` calls `SpotifyPlaybackCoordinator.queueTrack(uri:)` — actually queues on Spotify. The "queued count" surfaces only as a passive chip on the card and a stat tile on detail; there's no toggle button on the card front. The button moved into the `TrackActionsMenu` (kebab).
+- **Web**: `ShareCardComponent.toggleQueue()` (`share-card.component.ts:115-157`) calls `ShareFeedService.reactToShare(email, shareId, 'queued' | 'unqueued')`, which hits `POST /shares/react`. This only flips a `viewerHasQueued` boolean in DynamoDB — **it does not actually add the track to Spotify's queue**. So the button is misleading: it looks like "play later" but it's really "mark as interested". And it's duplicated in the kebab.
+
+**Recommendation**: drop the front-of-card Queue button entirely. Keep `Add to Queue` in the kebab and (separately, when the player parity work happens) wire it through the existing `PlayerService` to Spotify, the same way iOS does.
+
+### Suggested order to ship (web)
+
+1. **Quick win — kebab orientation**: rotate or replace the kebab SVG in `share-card.component.html:104-114`. Single-line diff.
+2. **Quick win — kill the Queue button**: delete the `<button class="queue-btn">` block + scss. Keep the kebab item.
+3. **New `share-detail` page** scaffolding:
+   - Add `getShareDetail` to `ShareFeedService` → `GET /shares/detail?shareId=&sharedBy=&sharedAt=`.
+   - Create `pages/share-detail/share-detail.component.{ts,html,scss}` mirroring `ShareDetailView.swift` (hero art, sharer block, stats row, action row).
+   - Add a route `share/:shareId` in `app-routing.module.ts`.
+   - Make the card body clickable: wrap header + track + caption + tags in a `(click)="openDetail()"`; do NOT include the action footer in that click target (mirrors `ShareCardView.swift:116-125`).
+4. **Comments**:
+   - Extend `Share` with `commentCount?: number` (already returned by backend, see `shares_detail/handler.py` and `shares_feed`).
+   - Add `commentButton` to the card with the count.
+   - Inside the share-detail page, add a `CommentThreadComponent` (composer + list + delete). New service methods: `listComments`, `createComment`, `deleteComment`.
+5. **Reactions**:
+   - Extend `Share` with `reactionCounts: Record<string, number>` and `viewerReactions: string[]`.
+   - Build a `ReactionsBarComponent` shared between the card and detail.
+   - New service method `toggleReaction(shareId, reaction)`.
+6. **Friends-rated / friends-queued drilldowns**:
+   - On the share-detail page, render two stat tiles. Each opens a dialog (or sub-view) listing `friendRatings` / `interactions[action=queued]` from the same `/shares/detail` response.
+   - Compute average client-side; mirror `averageFriendRating` in `ShareDetailViewModel.swift:104-108`.
+
+No new backend work. Every endpoint above is already in `lambdas/`.
+
+---
+
+## Issue 2: Web `/likes` performance
+
+### Data path on iOS
+
+`LikesView.swift:30-34` picks one of two sources at init:
+
+- **Self path** (`targetEmail == nil`) → `LikesSource.spotifyDirect` → `LikesViewModel.fetchSpotifyPage()` (`LikesViewModel.swift:137-161`) calls `SpotifyService.getSavedTracks(limit: 50, offset:)`. Direct Spotify API. Lazy — first page is 50 tracks; `loadMore()` triggers more when the user scrolls within 5 of the end (`LikesView.swift:106-110`).
+- **Friend path** (`targetEmail` set) → `LikesSource.backend` → `LikesViewModel.fetchBackendPage` (`LikesViewModel.swift:163-194`) calls `XomifyService.getLikesByUser(email:, targetEmail:, limit:, offset:)` → `GET /likes/by-user?email=&targetEmail=&limit=&offset=`.
+
+**Key**: self likes load fast on iOS because they go straight to Spotify in a single 50-track page. The backend is bypassed entirely.
+
+### Data path on web
+
+The web is broken in two places.
+
+**(a) Page-load query is malformed.** `LikesService.getLikesByUser` (`/Users/dom/Code/xomify-frontend/src/app/services/likes.service.ts:75-92`) sends:
+
+```
+GET /likes/by-user?email=<viewer>&limit=30&cursor=<token>&q=<search>
+```
+
+Backend `lambdas/likes_by_user/handler.py:88-89, 92-99` requires `targetEmail` and reads pagination from `offset` (integer), not `cursor`. It does not support `q`. Contract:
+
+| Param | Web sends | Backend expects |
+|---|---|---|
+| `targetEmail` | (never) | required |
+| `email` (the target) | `<viewer email>` | (used for legacy caller fallback only) |
+| `cursor` | `<string>` | (ignored; backend uses `offset` int) |
+| `limit` | `30` | OK |
+| `q` | `<string>` | (not supported — search is iOS-side only) |
+
+So:
+- The backend will treat `email` as the caller and have no `targetEmail`, then `require_fields(params, "targetEmail")` raises `ValidationError` → 400. **The very first page request fails.** That's why "it never finishes loading" — the loader stays up until the HTTP error tab, then there are no tracks to render (and `loading=false` only after the catch).
+- Even if the request succeeded, `cursor` is never read; `loadMore()` (`likes.component.ts:78-99`) reads `resp.cursor` which the backend never returns → `cursor` stays `null` → "load more" is hidden → infinite scroll feel never works.
+
+**(b) `LikesPushCoordinator` is fired on every app boot.** `app.component.ts:46` calls `this.likesPushCoordinator.runIfDue().subscribe()` unconditionally on `ngOnInit` for any logged-in user. The coordinator stores its last-pushed timestamp in `sessionStorage` (`likes-push-coordinator.service.ts:8, 44, 55`), which is **per-tab/per-session** — so it re-runs every time you open a new tab or refresh. `runIfDue` then calls `SongService.getAllUserTracks(0)` (`song.service.ts:45-68`), which:
+
+- Fetches `/me/tracks?limit=50&offset=0`,
+- Increments `offset += 300` (a bug — should be `+= 50`),
+- Recurses synchronously (`fetchTracks()` calls itself inside the `subscribe.next` callback, no break),
+- Stops only when an empty page returns.
+
+For a library of N tracks this issues `ceil(N / 300) + 1` Spotify requests, each one paginated wrong (missing 250 tracks per cycle), then immediately `pushUserLikes` chunks 25-at-a-time `POST /likes/push`. None of this blocks UI directly, but it monopolizes the Spotify rate limit and the Network tab, and the `pushUserLikes` `concatMap` keeps round-tripping for tens of seconds.
+
+While none of (b) is in the critical render path of `/likes`, it competes for HTTP connections and creates the perception that the whole page hangs.
+
+### Why slow
+
+**Primary cause: the page load request is malformed.** `getLikesByUser(email)` sends `email=<viewer>` and `cursor=<token>`. Backend rejects (missing `targetEmail`), so the first `loadPage` returns an error, `loading=false`, and the page renders empty. If the backend currently isn't 400'ing in production, it's because something is supplying a default — but the cursor is still undefined in the response and pagination stalls.
+
+**Secondary cause: `LikesPushCoordinator` runs on every new tab.** `sessionStorage` resets per session; the 24h interval check is effectively a no-op on a fresh tab. The `getAllUserTracks` paginator is also buggy (`offset += 300` with `limit=50`).
+
+iOS doesn't suffer either: self-likes go straight to Spotify in a single 50-track lazy page; there is no push-on-boot.
+
+### Suggested fix
+
+Two independent fixes, one critical and one cleanup:
+
+1. **Fix `LikesService.getLikesByUser` to match the backend contract** (`/Users/dom/Code/xomify-frontend/src/app/services/likes.service.ts:75-92`):
+   - Accept and pass `targetEmail` as the param name (rename the first arg or add a second).
+   - Replace `cursor: string` pagination with `offset: number`. Read `total` and `hasMore` from the response, derive `cursor`-equivalent locally as `items.length < total`.
+   - Drop the `q` param — it's not server-side. Filter client-side like iOS does (`LikesViewModel.filteredItems`, `LikesViewModel.swift:61-67`).
+   - Update `likes.component.ts:78-99,133-155` to use offset-based pagination.
+
+2. **Optionally add a Spotify-direct path for self-view**, mirroring iOS `LikesSource.spotifyDirect`. This makes self-likes feel as fast as iOS even when the backend cache is cold (e.g., right after a fresh OAuth). The page already has `email` and `isSelf`; branch to `SongService.getUserTracks(offset)` when `isSelf`. Re-use the existing pagination harness.
+
+3. **Fix `LikesPushCoordinator` cadence and pagination** (`/Users/dom/Code/xomify-frontend/src/app/services/likes-push-coordinator.service.ts`, `/Users/dom/Code/xomify-frontend/src/app/services/song.service.ts:45-68`):
+   - Move the "last pushed" timestamp from `sessionStorage` to `localStorage` so the 24h gate actually persists across tabs.
+   - Fix `getAllUserTracks` — `offset += 300` should be `offset += data.items.length` (or `+= 50` to match the page size).
+   - Even better: schedule `runIfDue` to fire after the first user-initiated navigation (`NavigationEnd`) instead of synchronously in `ngOnInit`, so it doesn't compete with the actual page render.
+
+Order of operations: ship #1 first (it's the cause of the visible breakage), #3 second (silently improves perceived performance), #2 last as nice-to-have parity.

--- a/docs/features/auth-login-endpoint/PLAN.md
+++ b/docs/features/auth-login-endpoint/PLAN.md
@@ -1,0 +1,38 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0a
+repo: xomify-backend
+---
+
+# auth-login-endpoint
+
+> **Status: Stub.** This is a placeholder. Run `/plan auth-login-endpoint` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- New `lambdas/auth_login/handler.py`. Public route `POST /auth/login` (route provisioned in (0a-infra)).
+- Body validated: `{ spotifyAccessToken: string }`.
+- Calls Spotify `/me`, extracts `email` + `id` (Spotify user id).
+- Mints HS256 JWT using existing `API_SECRET_KEY`. Claims: `{ email, userId, iat, exp }`. TTL: 7 days (Q1).
+- Response: `{ data: { token, expiresAt }, error: null, meta: {} }` per backend response standard.
+- Tests: happy path (mock Spotify `/me`), invalid Spotify token (401 from upstream), expired Spotify token (401 from upstream), malformed request body (400).
+- `DEPLOYMENT_GUIDE.md` updated.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0a-infra)
+
+## Exit criteria
+`curl -X POST /auth/login -d '{"spotifyAccessToken":"<valid>"}'` returns a JWT. Token decodes to expected claims. Invalid Spotify token returns structured 401.
+
+## Notes
+- Use `backend-standards` skill for response shape, type hints, and error handling conventions.
+- End-to-end exit verification depends on (0a-infra) being applied to AWS.

--- a/docs/features/auth-login-route-and-lambda-resources/PLAN.md
+++ b/docs/features/auth-login-route-and-lambda-resources/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0a-infra
+repo: xomify-infrastructure
+---
+
+# auth-login-route-and-lambda-resources
+
+> **Status: Stub.** This is a placeholder. Run `/plan auth-login-route-and-lambda-resources` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- Bump module ref to `v2.3.0` in `xomify-infrastructure/terraform/api_gateway.tf:91`.
+- Add `auth_login` lambda Terraform resource (mirror existing patterns in `lambdas_user.tf`).
+- Add `/auth/login` to the appropriate `services` block with `authorization = "NONE"`.
+- Add IAM policy for the lambda to read the SSM secret (`API_SECRET_KEY`).
+- Update `cloudwatch.tf` for the new lambda log group.
+
+## Repo
+xomify-infrastructure
+
+## Dependencies
+(0-pre) — needs v2.3.0 published.
+
+## Exit criteria
+`terraform plan` shows the new lambda + public route. `terraform apply` succeeds. `curl -X POST /auth/login` reaches the lambda (returns 200 once the (0a) backend code is also deployed; until then, deploys an empty/stub lambda artifact or 5xx is acceptable as long as the route is wired).
+
+## Notes
+- Requires Terraform apply to prod AWS — human gate.
+- Use `infra-specialist` agent per epic Skills section.

--- a/docs/features/authorizer-extract-claims/PLAN.md
+++ b/docs/features/authorizer-extract-claims/PLAN.md
@@ -1,0 +1,35 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0b
+repo: xomify-backend
+---
+
+# authorizer-extract-claims
+
+> **Status: Stub.** This is a placeholder. Run `/plan authorizer-extract-claims` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- Modify `lambdas/authorizer/handler.py:42`.
+- Decode JWT (already done). If payload contains both `email` and `userId`: include them in policy `context`.
+- If payload is missing those claims (legacy static token): allow the request, but emit nothing into context. Log INFO with `legacy_token=true` for monitoring.
+- This **dual-mode** behavior is what lets old clients keep working through the migration.
+- Tests: per-user JWT path (context populated), legacy static-token path (allow, no context), invalid signature (deny).
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0a) deployed (so we can mint test JWTs against the real authorizer)
+
+## Exit criteria
+Backend code merged. Note: until (0b-infra) ships, the new artifact may not be live in AWS yet.
+
+## Notes
+- Risk flagged in epic: "Authorizer dual-mode (0b) accidentally accepts unsigned tokens" — signature verification stays mandatory; dual-mode only bifurcates on whether claims are present.

--- a/docs/features/authorizer-redeploy-with-claims/PLAN.md
+++ b/docs/features/authorizer-redeploy-with-claims/PLAN.md
@@ -1,0 +1,35 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0b-infra
+repo: xomify-infrastructure
+---
+
+# authorizer-redeploy-with-claims
+
+> **Status: Stub.** This is a placeholder. Run `/plan authorizer-redeploy-with-claims` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- Ensure the authorizer lambda's deploy artifact in AWS reflects the new dual-mode behavior from (0b).
+- Verify whether `terraform/lambda_authorizer.tf` needs a `source_code_hash` bump or whether the deploy is artifact-driven via CI in `xomify-backend` (if CI pushes the zip, this sub-feature may be a no-op Terraform PR + a manual workflow trigger).
+- Confirm via CloudWatch that the live authorizer is on the new version.
+
+## Repo
+xomify-infrastructure (and possibly the backend deploy workflow)
+
+## Dependencies
+(0b) backend code merged.
+
+## Exit criteria
+CloudWatch shows authorizer log version reflecting the new code. A request bearing a per-user JWT lands at a stub handler with `requestContext.authorizer = { email, userId }`. A request with the legacy static token still passes through with no context.
+
+## Notes
+- Open action item from epic: confirm authorizer deploy mechanism — does `terraform apply` push the lambda zip, or is that a separate GH Actions workflow in `xomify-backend`? Determines whether this sub-feature is real Terraform work or a workflow trigger + verification step.
+- Use `infra-specialist` agent.
+- Requires AWS deploy + CloudWatch verification — human gate.

--- a/docs/features/backend-handler-migration-friends/PLAN.md
+++ b/docs/features/backend-handler-migration-friends/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1a
+repo: xomify-backend
+---
+
+# backend-handler-migration-friends
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-friends` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Friends batch (7 handlers).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Per epic rollout: one batch per day, lowest-traffic-domain-first. Friends is "highest" — ship after lower-traffic domains.

--- a/docs/features/backend-handler-migration-groups/PLAN.md
+++ b/docs/features/backend-handler-migration-groups/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1b
+repo: xomify-backend
+---
+
+# backend-handler-migration-groups
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-groups` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Groups batch (13 handlers).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Per epic rollout: one batch per day, lowest-traffic-domain-first. Groups is "highest" — ship after lower-traffic domains.

--- a/docs/features/backend-handler-migration-invites/PLAN.md
+++ b/docs/features/backend-handler-migration-invites/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1d
+repo: xomify-backend
+---
+
+# backend-handler-migration-invites
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-invites` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Invites batch (4 handlers).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Per epic rollout: one of the lowest-traffic batches — ship early.

--- a/docs/features/backend-handler-migration-notifications/PLAN.md
+++ b/docs/features/backend-handler-migration-notifications/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1f
+repo: xomify-backend
+---
+
+# backend-handler-migration-notifications
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-notifications` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Notifications batch (2 handlers).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Per epic rollout: one of the lowest-traffic batches — ship early.

--- a/docs/features/backend-handler-migration-ratings/PLAN.md
+++ b/docs/features/backend-handler-migration-ratings/PLAN.md
@@ -1,0 +1,35 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1e
+repo: xomify-backend
+---
+
+# backend-handler-migration-ratings
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-ratings` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Ratings batch (4 handlers).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.

--- a/docs/features/backend-handler-migration-release-radar/PLAN.md
+++ b/docs/features/backend-handler-migration-release-radar/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1g
+repo: xomify-backend
+---
+
+# backend-handler-migration-release-radar
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-release-radar` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Release Radar batch (2 handlers).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Per epic rollout: lowest-traffic batch — ship first.

--- a/docs/features/backend-handler-migration-shares/PLAN.md
+++ b/docs/features/backend-handler-migration-shares/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1c
+repo: xomify-backend
+---
+
+# backend-handler-migration-shares
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-shares` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Shares batch (11 handlers).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Per epic rollout: one batch per day, lowest-traffic-domain-first. Shares is "highest" — ship after lower-traffic domains.

--- a/docs/features/backend-handler-migration-user/PLAN.md
+++ b/docs/features/backend-handler-migration-user/PLAN.md
@@ -1,0 +1,37 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1i
+repo: xomify-backend
+---
+
+# backend-handler-migration-user
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-user` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+User batch (3 handlers): `user_data`, `user_all`, `user_update` (trickiest mix of caller + target).
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Flagged as "trickiest mix of caller + target" — extra audit care required.
+- Note `user_update` body `userId` (token persistence) stays in the body — it is target identity, not caller.

--- a/docs/features/backend-handler-migration-wrapped/PLAN.md
+++ b/docs/features/backend-handler-migration-wrapped/PLAN.md
@@ -1,0 +1,37 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1h
+repo: xomify-backend
+---
+
+# backend-handler-migration-wrapped
+
+> **Status: Stub.** This is a placeholder. Run `/plan backend-handler-migration-wrapped` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Wrapped batch (4 handlers) — read-only, low risk.
+- Each handler in the batch reads caller identity via `get_caller_email` / `get_caller_user_id` (from 0c).
+- Audit each request field: caller (move to ctx) vs. target (`friendEmail`, `targetEmail`, `ownerEmail`, body `userId` for token persistence — these stay).
+- Update the corresponding test file to use the `authorized_event` fixture.
+- Fallback to query-param `email` is **kept** during this phase so legacy static-token clients still function.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c)
+
+## Exit criteria
+All handlers in the batch deployed, reading from context with fallback. CloudWatch fallback WARN count > 0 expected (clients haven't migrated yet — that's what (1j)/(1k) addresses).
+
+## Notes
+- Use `backend-standards` skill.
+- Read-only, low risk — flagged in epic.
+- Note: only `/wrapped/*` HANDLERS migrate; `cron_wrapped` is not behind authorizer (out of scope).

--- a/docs/features/caller-identity-helper/PLAN.md
+++ b/docs/features/caller-identity-helper/PLAN.md
@@ -1,0 +1,37 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0c
+repo: xomify-backend
+---
+
+# caller-identity-helper
+
+> **Status: Stub.** This is a placeholder. Run `/plan caller-identity-helper` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- Add `get_caller_email(event)` and `get_caller_user_id(event)` to `lambdas/common/utility_helpers.py`.
+- Resolution order:
+  1. `event.requestContext.authorizer.email` (trusted) — log DEBUG `auth_path=context`.
+  2. Fallback: `event.queryStringParameters.email` or body `email` — log WARN `auth_path=fallback user_agent=<ua>` (Q5).
+  3. Neither present: raise structured 401.
+- Update `tests/conftest.py`: new `authorized_event` fixture that injects `requestContext.authorizer = { email, userId }`. Old `api_gateway_event` fixture stays for legacy paths during migration.
+- Helper-level unit tests cover all three resolution branches.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0b-infra) deployed (otherwise context is always empty, fallback always fires, monitoring is meaningless)
+
+## Exit criteria
+Helper imported and exercised in a unit test. Production deploy is a no-op until handlers start using it in Track 1.
+
+## Notes
+- Risk flagged: "Someone runs `/execute` on (0c) before (0b-infra) is in prod" — orchestrator must check upstream `Status: Done` before queuing.

--- a/docs/features/frontend-drop-caller-email/PLAN.md
+++ b/docs/features/frontend-drop-caller-email/PLAN.md
@@ -1,0 +1,33 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1j
+repo: xomify-frontend
+---
+
+# frontend-drop-caller-email
+
+> **Status: Stub.** This is a placeholder. Run `/plan frontend-drop-caller-email` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Sweep Angular services. Remove caller `email` query params and body fields. Keep target emails (`friendEmail`, etc.).
+
+## Repo
+xomify-frontend
+
+## Dependencies
+ALL of (1a)–(1i) deployed AND (0e) deployed (web is now sending per-user JWTs; backend now reads from context)
+
+## Exit criteria
+Web app round-trips every authenticated request without a caller `email`. Backend fallback WARN count for web user-agents trends to zero in CloudWatch.
+
+## Notes
+- Deletion sweep — no new tests; run existing `ng test`.
+- Manual smoke required: log in, hit each major page (friends, groups, shares, ratings, profile, music taste), confirm 200s in network tab.
+- Requires deploy + CloudWatch verification — human gate.

--- a/docs/features/ios-current-page-wire-up/PLAN.md
+++ b/docs/features/ios-current-page-wire-up/PLAN.md
@@ -1,0 +1,33 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 2c
+repo: xomify-ios
+---
+
+# ios-current-page-wire-up
+
+> **Status: Stub.** This is a placeholder. Run `/plan ios-current-page-wire-up` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- Point "Top 25 — Last 4 Weeks (Current)" page at `GET /user/top-items` instead of `GET /wrapped/all`.
+- Wrapped page (the historical snapshot view) stays on `/wrapped/all`.
+
+## Repo
+xomify-ios
+
+## Dependencies
+(2a-infra) AND (0d)
+
+## Exit criteria
+iOS "Last 4 Weeks (Current)" page shows top items refreshed within the last UTC day. Wrapped page unchanged.
+
+## Notes
+- Open action item from epic: path to iOS "Top 25 — Last 4 Weeks (Current)" view — grep at execution.
+- Requires TestFlight build + manual smoke — human gate.

--- a/docs/features/ios-drop-caller-email/PLAN.md
+++ b/docs/features/ios-drop-caller-email/PLAN.md
@@ -1,0 +1,31 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 1k
+repo: xomify-ios
+---
+
+# ios-drop-caller-email
+
+> **Status: Stub.** This is a placeholder. Run `/plan ios-drop-caller-email` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Sweep iOS networking layer. Remove caller `email` from request construction. Keep target emails.
+
+## Repo
+xomify-ios
+
+## Dependencies
+ALL of (1a)–(1i) deployed AND (0d) deployed
+
+## Exit criteria
+Latest TestFlight build round-trips without caller email. Backend fallback WARN count for iOS user-agent trends to zero.
+
+## Notes
+- Requires TestFlight build + manual smoke + CloudWatch verification — human gate.

--- a/docs/features/ios-per-user-jwt/PLAN.md
+++ b/docs/features/ios-per-user-jwt/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0d
+repo: xomify-ios
+---
+
+# ios-per-user-jwt
+
+> **Status: Stub.** This is a placeholder. Run `/plan ios-per-user-jwt` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- After Spotify OAuth completes (existing `AuthService.saveRefreshTokenToXomify` flow at line 247), call `POST /auth/login` with the Spotify access token.
+- Store returned Xomify JWT in keychain, same access group as the Spotify refresh token (Q4).
+- Replace every `XOMIFY_API_TOKEN` reference (`AuthService.swift:265`, `NetworkService.swift:202`, and any others — execution agent must `grep -r "XOMIFY_API_TOKEN" /Users/dom/Code/xomify-ios/`) with the keychain-stored JWT.
+- `secrets.xcconfig` entry can stay readable but must not be sent on requests post-migration. Document in commit.
+- Add 401-retry interceptor in `NetworkService`: on any 401, refresh Spotify access token (existing logic) -> call `/auth/login` -> retry the original request once. Only one retry to prevent loops.
+
+## Repo
+xomify-ios
+
+## Dependencies
+(0a) deployed
+
+## Exit criteria
+Fresh install completes Spotify OAuth, calls `/auth/login`, stores JWT, makes an authorized request that succeeds with the per-user JWT (verify in CloudWatch — authorizer logs `legacy_token=false`).
+
+## Notes
+- Open action item from epic: iOS keychain access group constant — read at execution to confirm reuse of the Spotify refresh-token group (Q4).
+- Requires TestFlight build + manual smoke — human gate.

--- a/docs/features/module-per-endpoint-auth-override/PLAN.md
+++ b/docs/features/module-per-endpoint-auth-override/PLAN.md
@@ -1,0 +1,35 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0-pre
+repo: api-gateway-service
+---
+
+# module-per-endpoint-auth-override
+
+> **Status: Stub.** This is a placeholder. Run `/plan module-per-endpoint-auth-override` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- Extend the `api-gateway-service` Terraform module so each entry in `services.<service>.endpoints[]` can opt out of (or override) the shared authorizer via an optional `authorization` field. Default behavior (when unset): use `var.authorization`, which preserves today's API.
+- Backwards-compatible. Existing callers see no change.
+- Tag and publish as **v2.3.0**.
+- Add a module-level test (or example) that confirms a NONE-auth endpoint and a CUSTOM-auth endpoint coexist in the same API GW deploy.
+
+## Repo
+api-gateway-service (external; user owns; not cloned locally — clone first at execution)
+
+## Dependencies
+none. Track 0 prerequisite — ships before everything else.
+
+## Exit criteria
+v2.3.0 tagged. Test confirms mixed-auth endpoints in a single deploy. Bumping `xomify-infrastructure` to v2.3.0 with no per-endpoint overrides set produces a no-op `terraform plan`.
+
+## Notes
+- External repo — not present in `/Users/dom/Code/`. Execution agent must clone `git::https://github.com/domgiordano/api-gateway-service.git` first.
+- Open action item from epic: confirm tagging convention and who can publish (user owns; presumably `git tag v2.3.0 && git push --tags`).

--- a/docs/features/music-taste-page-wire-up/PLAN.md
+++ b/docs/features/music-taste-page-wire-up/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 2b
+repo: xomify-frontend
+---
+
+# music-taste-page-wire-up
+
+> **Status: Stub.** This is a placeholder. Run `/plan music-taste-page-wire-up` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- Verify path: execution agent runs `ls /Users/dom/Code/xomify-frontend/src/app/pages/` to locate the Music Taste page (likely `music-taste/` or similar).
+- Add `getUserTopItems()` to `UserService` (or a new `TopItemsService` if it warrants its own file).
+- Wire the Music Taste page to call this method instead of whatever it currently uses (snapshot or none).
+- Loading + error states handled per existing service patterns.
+
+## Repo
+xomify-frontend
+
+## Dependencies
+(2a-infra) AND (0e)
+
+## Exit criteria
+Music Taste page shows top items refreshed within the last UTC day.
+
+## Notes
+- Open action item from epic: path to Angular Music Taste page — `ls /Users/dom/Code/xomify-frontend/src/app/pages/` at execution.
+- Risk flagged: "Music Taste page (web) doesn't exist where assumed" — `ls` first; adjust the sub-feature stub if layout differs.
+- Requires deploy + manual browser verification — human gate.

--- a/docs/features/top-items-cache-table-and-route/PLAN.md
+++ b/docs/features/top-items-cache-table-and-route/PLAN.md
@@ -1,0 +1,38 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 2a-infra
+repo: xomify-infrastructure
+---
+
+# top-items-cache-table-and-route
+
+> **Status: Stub.** This is a placeholder. Run `/plan top-items-cache-table-and-route` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- In `xomify-infrastructure/terraform/dynamodb.tf` add the `TOP_ITEMS_CACHE` table — PK `email`, native TTL on `ttl` attr.
+- In `xomify-infrastructure/terraform/lambdas_user.tf` add the `user_top_items` lambda resource.
+- Add `/user/top-items` to the `user` service endpoints block with `authorization = "CUSTOM"` (default — explicit for clarity).
+- Wire env var `TOP_ITEMS_CACHE_TABLE_NAME` into the lambda.
+- IAM policy grants `GetItem` + `PutItem` on the new table.
+- Update `cloudwatch.tf` for the new lambda log group.
+
+## Repo
+xomify-infrastructure
+
+## Dependencies
+(0-pre) — module ref bump (already shipped via (0a-infra), no re-bump needed); (2a) backend code merged.
+
+## Exit criteria
+`terraform apply` creates the table and route. `curl GET /user/top-items` with a valid per-user JWT returns 200.
+
+## Notes
+- Use `infra-specialist` agent.
+- Requires Terraform apply to prod AWS — human gate.
+- Risk: "DDB TTL eviction lag (up to 48h) leaves stale rows readable" — handler-side gate on `cachedAt.date() < today_utc.date()` covers this; TTL is just a janitor.

--- a/docs/features/user-top-items-endpoint/PLAN.md
+++ b/docs/features/user-top-items-endpoint/PLAN.md
@@ -1,0 +1,37 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 2a
+repo: xomify-backend
+---
+
+# user-top-items-endpoint
+
+> **Status: Stub.** This is a placeholder. Run `/plan user-top-items-endpoint` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+Backend lambda code + tests only — infra moved to (2a-infra).
+- `lambdas/common/top_items_cache.py`: `get_cached(email) -> dict | None`, `set_cached(email, top_items) -> None`. `get_cached` returns None if `cachedAt.date() < today_utc.date()` (Q7).
+- `lambdas/user_top_items/handler.py`: reads caller email from context (via 0c), cache-then-fetch. Per-range partial failure handled — `meta.failed_ranges` is a list of strings.
+- `DEPLOYMENT_GUIDE.md` updated.
+- GitHub Actions deploy matrix updated.
+- Tests: `tests/test_user_top_items.py` covering cache hit, cache miss, partial Spotify failure (one range raises), TTL boundary (cachedAt yesterday-UTC = miss; cachedAt today-UTC = hit), 401 on missing context.
+
+## Repo
+xomify-backend
+
+## Dependencies
+(0c). Does NOT depend on (1*) work.
+
+## Exit criteria
+Lambda code merged; cache helper unit-tested. End-to-end exit (route live, table populated) gated on (2a-infra) apply.
+
+## Notes
+- Use `backend-standards` skill.
+- Risk: "Partial-failure response shape confuses iOS deserializer" — document `meta.failed_ranges` in API contract.

--- a/docs/features/web-per-user-jwt/PLAN.md
+++ b/docs/features/web-per-user-jwt/PLAN.md
@@ -1,0 +1,36 @@
+---
+status: Stub
+created: 2026-04-26
+owner: Dominick
+parent_epic: auth-identity-and-live-top-items
+parent_epic_path: ../auth-identity-and-live-top-items/PLAN.md
+sub_feature_id: 0e
+repo: xomify-frontend
+---
+
+# web-per-user-jwt
+
+> **Status: Stub.** This is a placeholder. Run `/plan web-per-user-jwt` to flesh it out before `/execute`.
+
+## Parent epic
+See [`PLAN.md`](../auth-identity-and-live-top-items/PLAN.md) for full epic context, decisions, sequencing, and risks.
+
+## Scope
+- After Spotify OAuth completes, call `POST /auth/login` with the Spotify access token.
+- Store JWT in `sessionStorage` (Q3) under a single key, e.g. `xomify_jwt`.
+- Replace every `environment.apiAuthToken` reference. Known services using it (verify count at execution): `user.service`, `ratings.service`, `invites.service`, `share-feed.service`, `groups.service`, `friends.service`, `notifications.service`, `wrapped.service`, `release-radar.service`. Likely also `shares.service`. Centralize via an `HttpInterceptor` that reads from `sessionStorage` and attaches `Authorization: Bearer <jwt>`.
+- 401-retry interceptor: on any 401, refresh Spotify access token -> call `/auth/login` -> retry original request once.
+- `environment.apiAuthToken` field can stay in the file but is no longer read.
+
+## Repo
+xomify-frontend
+
+## Dependencies
+(0a) deployed
+
+## Exit criteria
+Fresh login flow stores a JWT in `sessionStorage`. Network tab shows `Authorization: Bearer <per-user JWT>` on every API call. Authorizer logs `legacy_token=false` for these requests.
+
+## Notes
+- Tradeoff documented (Q3): `sessionStorage` cleared on tab close; re-login is one Spotify-token round-trip, transparent to user.
+- Requires deploy + manual browser verification — human gate.

--- a/lambdas/common/aiohttp_helper.py
+++ b/lambdas/common/aiohttp_helper.py
@@ -12,8 +12,12 @@ from lambdas.common.errors import SpotifyAPIError
 
 log = get_logger(__file__)
 
-# Rate limit event - initialized lazily per event loop
+# Rate limit event - initialized lazily per event loop.
+# We cache both the event and the loop it was created on so we can detect a
+# stale event bound to a closed loop (e.g. a warm Lambda invocation where
+# asyncio.run() has created a brand-new loop).
 _rate_limited: asyncio.Event = None
+_rate_limited_loop: asyncio.AbstractEventLoop = None
 
 MAX_RETRIES = 3
 
@@ -23,22 +27,20 @@ def _get_rate_limit_event() -> asyncio.Event:
     Get or create the rate limit event for the current event loop.
     This ensures the event is always bound to the correct loop.
     """
-    global _rate_limited
-    
-    try:
-        # Check if we have an event and it's bound to the current loop
-        if _rate_limited is not None:
-            # Try to access the event - will fail if wrong loop
-            loop = asyncio.get_running_loop()
-            # In Python 3.10+, events don't have _loop attribute exposed the same way
-            # So we just try to use it and recreate if it fails
-            return _rate_limited
-    except RuntimeError:
-        pass
-    
-    # Create new event for current loop
+    global _rate_limited, _rate_limited_loop
+
+    current_loop = asyncio.get_running_loop()
+
+    # Reuse the cached event only if it was created on the loop we're running
+    # on right now. Otherwise it's bound to a stale (closed) loop and would
+    # raise "got Future attached to a different loop" when awaited.
+    if _rate_limited is not None and _rate_limited_loop is current_loop:
+        return _rate_limited
+
+    # Create a new event bound to the current loop.
     _rate_limited = asyncio.Event()
     _rate_limited.set()  # Start in "open" state
+    _rate_limited_loop = current_loop
     return _rate_limited
 
 

--- a/lambdas/friends_all/handler.py
+++ b/lambdas/friends_all/handler.py
@@ -4,7 +4,7 @@ GET /friends/all - Get all friends from friendship table
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
-from lambdas.common.utility_helpers import success_response
+from lambdas.common.utility_helpers import success_response, get_caller_email
 from lambdas.common.constants import FRIENDSHIPS_TABLE_NAME
 from lambdas.common.dynamo_helpers import full_table_scan
 
@@ -15,7 +15,12 @@ HANDLER = 'friends_all'
 
 @handle_errors(HANDLER)
 def handler(event, context):
-    log.info("Getting all friends from table.")
+    # Require an authenticated caller. get_caller_email raises if the request
+    # carries no valid identity, so an unauthenticated request can never reach
+    # the full-table scan below.
+    email = get_caller_email(event)
+
+    log.info(f"Getting all friends from table for caller {email}.")
     friends = full_table_scan(FRIENDSHIPS_TABLE_NAME)
 
     return success_response({

--- a/lambdas/groups_update/handler.py
+++ b/lambdas/groups_update/handler.py
@@ -29,6 +29,7 @@ def handler(event, context):
     group_id = body.get('groupId')
     name = body.get('name')
     description = body.get('description')
+    image_url = body.get('imageUrl')
 
     # Verify user is admin
     members = list_members_of_group(group_id)
@@ -53,6 +54,11 @@ def handler(event, context):
         update_parts.append("#desc = :desc")
         attr_values[':desc'] = description
         attr_names['#desc'] = 'description'
+
+    if image_url is not None:
+        update_parts.append("#imageUrl = :imageUrl")
+        attr_values[':imageUrl'] = image_url
+        attr_names['#imageUrl'] = 'imageUrl'
 
     if not update_parts:
         raise ValidationError("No fields to update")

--- a/lambdas/ratings_publish/handler.py
+++ b/lambdas/ratings_publish/handler.py
@@ -28,7 +28,7 @@ def handler(event, context):
     track_name = body.get('trackName')
     artist_name = body.get('artistName')
     album_art = body.get('albumArt')
-    album_name = body.get('album_name', None)
+    album_name = body.get('albumName', None)
     rating_context = body.get('context', None)
 
     log.info(f"Creating/Updating Single Track Rating for user {email} and track id {track_id} with rating {rating}")

--- a/lambdas/shares_create/handler.py
+++ b/lambdas/shares_create/handler.py
@@ -219,7 +219,7 @@ def handler(event, context):
                 artist_name=artist_name,
                 album_art=album_art_url or "",
                 album_name=album_name,
-                rating_context="share",
+                context="share",
             )
             log.info(
                 f"Rate-on-share: wrote rating {raw_rating} for track {track_id} "


### PR DESCRIPTION
## Summary
- aiohttp_helper: fix event loop caching for warm Lambda starts
- friends_all: add auth check (was exposing entire table)
- shares_create: fix rating_context -> context kwarg
- ratings_publish: fix album_name -> albumName casing
- groups_update: apply imageUrl to update expression

## Test plan
- [ ] Warm Lambda invocations don't crash
- [ ] friends_all requires auth
- [ ] Rate-on-share persists rating
- [ ] Album shows in ratings
- [ ] Group image updates work

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>