### PR TITLE
now-playing: recently-played fallback

### DIFF
--- a/lambdas/common/spotify.py
+++ b/lambdas/common/spotify.py
@@ -10,6 +10,16 @@ from lambdas.common.logger import get_logger
 
 log = get_logger(__file__)
 
+
+class SpotifyInsufficientScopeError(Exception):
+    """
+    Raised when Spotify returns 403 with an insufficient-scope error.
+
+    Used by the public now-playing path to distinguish "user's token predates a
+    newly-added scope" (treat as a graceful no-data case) from a real failure.
+    """
+
+
 class Spotify:
     """
     Spotify API client for a single user.
@@ -385,6 +395,55 @@ class Spotify:
         # 200 with an empty body can occur in practice; treat as not playing.
         if not (response.content or b"").strip():
             log.info("Get Playback State: 200 with empty body (nothing playing)")
+            return None
+
+        return response.json()
+
+    def get_recently_played(self, limit: int = 1) -> dict | None:
+        """
+        Fetch the user's recently-played tracks (synchronous).
+
+        Uses `GET /me/player/recently-played?limit=<n>`, which requires the
+        `user-read-recently-played` scope. This is the fallback the public
+        now-playing path uses when nothing is actively playing.
+
+        Spotify 403 with an insufficient-scope error is raised as
+        `SpotifyInsufficientScopeError` so the caller can treat tokens that
+        predate the new scope as a graceful "no data" case rather than a hard
+        failure. A 204/empty body is surfaced as None. Any other non-200 status
+        raises so the caller can degrade.
+
+        Args:
+            limit: Number of recently-played items to request (default 1).
+
+        Returns:
+            The recently-played object (`{ "items": [...], ... }`) on 200, or
+            None on 204 / empty body.
+
+        Raises:
+            SpotifyInsufficientScopeError: On 403 insufficient scope.
+            Exception: On any other non-200/204 status.
+        """
+        url = f"{self.BASE_URL}/me/player/recently-played?limit={limit}"
+        response = requests.get(url, headers=self.headers)
+
+        if response.status_code == 403:
+            raise SpotifyInsufficientScopeError(
+                f"Get Recently Played 403 (likely insufficient scope): {response.text}"
+            )
+
+        # 204 = no recently-played history.
+        if response.status_code == 204:
+            log.info("Get Recently Played: 204 No Content (no history)")
+            return None
+
+        if response.status_code != 200:
+            raise Exception(
+                f"Get Recently Played failed ({response.status_code}): {response.text}"
+            )
+
+        if not (response.content or b"").strip():
+            log.info("Get Recently Played: 200 with empty body (no history)")
             return None
 
         return response.json()

--- a/lambdas/public_now_playing/handler.py
+++ b/lambdas/public_now_playing/handler.py
@@ -13,18 +13,26 @@ Mirrors `public_top_items` / `public_wrapped` for the gate/resolve scaffolding:
        `GET /me/player` (Get Playback State). This works with the EXISTING
        `user-read-playback-state` scope the user already granted — we do NOT
        use `/me/player/currently-playing` (needs a scope we lack).
+    5. If nothing is actively playing, fall back to the user's most
+       recently-played track via `GET /me/player/recently-played?limit=1`
+       (requires the `user-read-recently-played` scope). Tokens that predate
+       that scope return 403 insufficient-scope; we treat that specifically as
+       "no data" (source="none"), NOT an error, so the endpoint keeps working
+       for un-reauthorized users.
 
 Unlike top-items/wrapped there is NO caching here: now-playing is real-time and
 the frontend polls it. To keep the poller stable, ANY failure (token refresh,
-Spotify error/timeout, 204 no-device, non-track item) degrades to a 200 with
-`{ isPlaying: false, track: null, progressMs: null, durationMs: null }` — never
-a 5xx. Only the public-gate 404s and the missing-userId 400 are non-200.
+Spotify error/timeout, 204 no-device, non-track item, recently-played failure,
+insufficient scope) degrades to a 200 with source="none" and null fields —
+never a 5xx. Only the public-gate 404s and the missing-userId 400 are non-200.
 
 Return shape (frontend contract — pinned):
     { "isPlaying": bool,
       "track": { "name", "artist", "albumArt", "url" } | null,
       "progressMs": int | null,
-      "durationMs": int | null }
+      "durationMs": int | null,
+      "source": "playing" | "recent" | "none",
+      "playedAt": str | null }   # ISO timestamp, set only when source="recent"
 
 INFRA NOTE (handled separately in xomify-infrastructure, not here): this lambda
 folder is `public_now_playing`, so the function must be named
@@ -39,7 +47,7 @@ from lambdas.common.errors import handle_errors, NotFoundError, ValidationError
 from lambdas.common.logger import get_logger
 from lambdas.common.public_access import PUBLIC_USER_IDS as _DEFAULT_PUBLIC_USER_IDS
 from lambdas.common.public_access import is_public
-from lambdas.common.spotify import Spotify
+from lambdas.common.spotify import Spotify, SpotifyInsufficientScopeError
 from lambdas.common.top_items_transform import _flatten_track
 from lambdas.common.utility_helpers import get_query_params, success_response
 
@@ -57,49 +65,69 @@ def _is_public(user_id: str) -> bool:
     return is_public(user_id, PUBLIC_USER_IDS)
 
 
-def _not_playing() -> dict:
-    """The graceful "nothing playing" contract (used for 204, empty, errors)."""
+def _none_source() -> dict:
+    """The graceful "no data" contract (204/empty/error/insufficient scope)."""
     return {
         "isPlaying": False,
         "track": None,
         "progressMs": None,
         "durationMs": None,
+        "source": "none",
+        "playedAt": None,
     }
 
 
-def _map_playback(state: Optional[dict]) -> dict:
+def _is_actively_playing(state: Optional[dict]) -> bool:
+    """True only when there is a present, playing state carrying a track item."""
+    if not state or not state.get("is_playing"):
+        return False
+    return isinstance(state.get("item"), dict)
+
+
+def _map_playing(state: dict) -> dict:
     """
-    Map a Spotify `/me/player` playback-state object to the frontend contract.
+    Map an actively-playing `/me/player` state to the source="playing" contract.
 
-    `state` is None (204/empty) -> not playing. A present state may still carry
-    a non-track `item` (e.g. a podcast episode, `currently_playing_type !=
-    "track"`); we guard for missing `album`/`artists` via `_flatten_track`'s
-    defensive `.get()` chain and degrade to a best-effort name with null
-    albumArt rather than 500.
+    Caller guarantees `_is_actively_playing(state)` is True, so `item` is a
+    dict. `_flatten_track` is defensive about missing album/artists/external_urls
+    so a non-track item (podcast episode) degrades to {name, "", None, url}
+    instead of raising.
     """
-    if not state:
-        return _not_playing()
-
-    item = state.get("item")
-    if not isinstance(item, dict):
-        # Active device but no resolvable item (e.g. ad, or item not exposed).
-        return {
-            "isPlaying": bool(state.get("is_playing")),
-            "track": None,
-            "progressMs": state.get("progress_ms"),
-            "durationMs": None,
-        }
-
-    # `_flatten_track` is defensive about missing album/artists/external_urls,
-    # so a non-track item (podcast episode) degrades to {name, "", None, url}
-    # instead of raising.
-    track = _flatten_track(item)
-
+    item = state["item"]
     return {
-        "isPlaying": bool(state.get("is_playing")),
-        "track": track,
+        "isPlaying": True,
+        "track": _flatten_track(item),
         "progressMs": state.get("progress_ms"),
         "durationMs": item.get("duration_ms"),
+        "source": "playing",
+        "playedAt": None,
+    }
+
+
+def _map_recent(recently_played: Optional[dict]) -> dict:
+    """
+    Map a `/me/player/recently-played` payload to the source="recent" contract.
+
+    Reads `items[0]`; if its `track` is a dict we map it via `_flatten_track`
+    and stamp `playedAt` from `items[0].played_at`. Empty/missing items, or an
+    item with no resolvable track, degrade to source="none".
+    """
+    items = (recently_played or {}).get("items") or []
+    if not items:
+        return _none_source()
+
+    first = items[0] or {}
+    track = first.get("track")
+    if not isinstance(track, dict):
+        return _none_source()
+
+    return {
+        "isPlaying": False,
+        "track": _flatten_track(track),
+        "progressMs": None,
+        "durationMs": None,
+        "source": "recent",
+        "playedAt": first.get("played_at"),
     }
 
 
@@ -143,20 +171,50 @@ def handler(event: dict, context: Any) -> dict:
         )
 
     # 4. Build a sync Spotify client + fetch current playback. ANY failure
-    # (token refresh, Spotify error/timeout) degrades to not-playing 200 so the
-    # polling frontend never sees a 5xx.
+    # (token refresh, Spotify error/timeout) degrades to source="none" 200 so
+    # the polling frontend never sees a 5xx.
     try:
         spotify = Spotify(user)
         state = spotify.get_playback_state()
     except Exception as err:  # noqa: BLE001 - real-time path must never 5xx
         log.warning(
-            f"public_now_playing fetch failed userId={user_id} err={err} -> not playing 200"
+            f"public_now_playing playback fetch failed userId={user_id} err={err} "
+            f"-> source=none 200"
         )
-        return success_response(_not_playing())
+        return success_response(_none_source())
 
-    body = _map_playback(state)
+    # 4a. Actively playing a track -> source="playing".
+    if _is_actively_playing(state):
+        body = _map_playing(state)
+        log.info(
+            f"public_now_playing userId={user_id} source=playing "
+            f"hasTrack={body['track'] is not None}"
+        )
+        return success_response(body)
+
+    # 4b. Nothing actively playing -> fall back to recently-played. A 403
+    # insufficient-scope (token predates the `user-read-recently-played` scope)
+    # is treated as "no data", NOT an error, so the endpoint keeps working for
+    # users who have not re-authorized yet. Any other failure also degrades.
+    try:
+        recently_played = spotify.get_recently_played(limit=1)
+    except SpotifyInsufficientScopeError as err:
+        log.warning(
+            f"public_now_playing recently-played insufficient scope userId={user_id} "
+            f"err={err} -> source=none 200 (user likely needs to re-authorize for "
+            f"user-read-recently-played)"
+        )
+        return success_response(_none_source())
+    except Exception as err:  # noqa: BLE001 - real-time path must never 5xx
+        log.warning(
+            f"public_now_playing recently-played fetch failed userId={user_id} "
+            f"err={err} -> source=none 200"
+        )
+        return success_response(_none_source())
+
+    body = _map_recent(recently_played)
     log.info(
-        f"public_now_playing userId={user_id} isPlaying={body['isPlaying']} "
-        f"hasTrack={body['track'] is not None}"
+        f"public_now_playing userId={user_id} source={body['source']} "
+        f"hasTrack={body['track'] is not None} playedAt={body['playedAt']}"
     )
     return success_response(body)

--- a/tests/test_public_now_playing.py
+++ b/tests/test_public_now_playing.py
@@ -2,18 +2,22 @@
 Tests for the public_now_playing lambda (GET /music/public-now-playing).
 
 Public, unauthenticated endpoint serving an allowlisted user's CURRENT Spotify
-playback in the frontend now-playing contract:
+playback (with a recently-played fallback) in the frontend now-playing contract:
 
-    { isPlaying, track: {name,artist,albumArt,url}|null, progressMs, durationMs }
+    { isPlaying, track: {name,artist,albumArt,url}|null, progressMs, durationMs,
+      source: "playing"|"recent"|"none", playedAt: str|null }
 
 Covers:
-- Allowlisted user, track playing -> 200 mapped shape.
-- Spotify 204 / no playback (client returns None) -> not-playing 200.
+- Allowlisted user, track playing -> 200 source="playing".
+- Not playing + recently-played has item -> 200 source="recent" + playedAt.
+- Not playing + recently-played 403 (insufficient scope) -> 200 source="none".
+- Not playing + recently-played empty -> 200 source="none".
+- Spotify 204 / no playback then no recent -> source="none" 200.
 - Non-track item (podcast episode, no album/artists) -> graceful, no 500.
 - userId NOT on the allowlist (real user) -> 404 (no existence leak).
 - Unknown userId (resolver None) -> 404.
 - Missing userId query param -> 400.
-- Spotify error (raises) -> not-playing 200, never 5xx.
+- Spotify error (raises) -> source="none" 200, never 5xx.
 
 The users table is mocked and the Spotify client is patched — no network.
 """
@@ -23,6 +27,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from lambdas.common.spotify import SpotifyInsufficientScopeError
 from lambdas.public_now_playing import handler as np_handler
 from lambdas.public_now_playing.handler import handler
 
@@ -77,13 +82,48 @@ def _playing_state():
     }
 
 
-def _patch_spotify(return_value=None, side_effect=None):
-    """Patch the Spotify class so its instance's get_playback_state is mocked."""
+def _recently_played(played_at="2026-06-01T12:00:00.000Z"):
+    """A realistic `/me/player/recently-played?limit=1` payload."""
+    return {
+        "items": [
+            {
+                "played_at": played_at,
+                "track": {
+                    "name": "Recent Song",
+                    "duration_ms": 180000,
+                    "artists": [{"name": "Recent Artist"}],
+                    "album": {"images": [{"url": "https://art/recent.jpg"}]},
+                    "external_urls": {
+                        "spotify": "https://open.spotify.com/track/recent"
+                    },
+                },
+            }
+        ]
+    }
+
+
+def _patch_spotify(
+    playback_return=None,
+    playback_side_effect=None,
+    recent_return=None,
+    recent_side_effect=None,
+):
+    """
+    Patch the Spotify class, mocking both get_playback_state and
+    get_recently_played on the instance.
+    """
     instance = MagicMock()
-    if side_effect is not None:
-        instance.get_playback_state.side_effect = side_effect
+
+    if playback_side_effect is not None:
+        instance.get_playback_state.side_effect = playback_side_effect
     else:
-        instance.get_playback_state.return_value = return_value
+        instance.get_playback_state.return_value = playback_return
+
+    if recent_side_effect is not None:
+        instance.get_recently_played.side_effect = recent_side_effect
+    else:
+        instance.get_recently_played.return_value = recent_return
+
     return patch(
         "lambdas.public_now_playing.handler.Spotify", return_value=instance
     )
@@ -98,12 +138,14 @@ def _patch_spotify(return_value=None, side_effect=None):
 def test_playing_track_returns_mapped_shape(mock_resolve, mock_context, public_user):
     mock_resolve.return_value = public_user
 
-    with _patch_spotify(return_value=_playing_state()):
+    with _patch_spotify(playback_return=_playing_state()) as spotify_cls:
         response = handler(_event(PUBLIC_ID), mock_context)
 
     assert response["statusCode"] == 200
     body = json.loads(response["body"])
     assert body["isPlaying"] is True
+    assert body["source"] == "playing"
+    assert body["playedAt"] is None
     assert body["progressMs"] == 42000
     assert body["durationMs"] == 210000
     assert body["track"] == {
@@ -112,14 +154,47 @@ def test_playing_track_returns_mapped_shape(mock_resolve, mock_context, public_u
         "albumArt": "https://art/np.jpg",
         "url": "https://open.spotify.com/track/np",
     }
+    # Actively playing -> recently-played fallback never invoked.
+    spotify_cls.return_value.get_recently_played.assert_not_called()
 
 
 @patch("lambdas.public_now_playing.handler.get_user_by_user_id")
-def test_204_no_playback_returns_not_playing(mock_resolve, mock_context, public_user):
-    """Spotify 204 -> client returns None -> not-playing 200."""
+def test_not_playing_falls_back_to_recent(mock_resolve, mock_context, public_user):
+    """Nothing playing + recently-played has an item -> source=recent + playedAt."""
     mock_resolve.return_value = public_user
 
-    with _patch_spotify(return_value=None):
+    with _patch_spotify(
+        playback_return=None, recent_return=_recently_played()
+    ) as spotify_cls:
+        response = handler(_event(PUBLIC_ID), mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["isPlaying"] is False
+    assert body["source"] == "recent"
+    assert body["playedAt"] == "2026-06-01T12:00:00.000Z"
+    assert body["progressMs"] is None
+    assert body["durationMs"] is None
+    assert body["track"] == {
+        "name": "Recent Song",
+        "artist": "Recent Artist",
+        "albumArt": "https://art/recent.jpg",
+        "url": "https://open.spotify.com/track/recent",
+    }
+    spotify_cls.return_value.get_recently_played.assert_called_once_with(limit=1)
+
+
+@patch("lambdas.public_now_playing.handler.get_user_by_user_id")
+def test_recent_403_insufficient_scope_returns_none(
+    mock_resolve, mock_context, public_user
+):
+    """Not playing + recently-played 403 insufficient scope -> source=none, 200."""
+    mock_resolve.return_value = public_user
+
+    with _patch_spotify(
+        playback_return=None,
+        recent_side_effect=SpotifyInsufficientScopeError("403 insufficient scope"),
+    ):
         response = handler(_event(PUBLIC_ID), mock_context)
 
     assert response["statusCode"] == 200
@@ -129,6 +204,62 @@ def test_204_no_playback_returns_not_playing(mock_resolve, mock_context, public_
         "track": None,
         "progressMs": None,
         "durationMs": None,
+        "source": "none",
+        "playedAt": None,
+    }
+
+
+@patch("lambdas.public_now_playing.handler.get_user_by_user_id")
+def test_recent_empty_returns_none(mock_resolve, mock_context, public_user):
+    """Not playing + recently-played empty/no items -> source=none, 200."""
+    mock_resolve.return_value = public_user
+
+    with _patch_spotify(playback_return=None, recent_return={"items": []}):
+        response = handler(_event(PUBLIC_ID), mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["source"] == "none"
+    assert body["track"] is None
+    assert body["playedAt"] is None
+
+
+@patch("lambdas.public_now_playing.handler.get_user_by_user_id")
+def test_recent_error_returns_none(mock_resolve, mock_context, public_user):
+    """Not playing + recently-played raises a generic error -> source=none, 200."""
+    mock_resolve.return_value = public_user
+
+    with _patch_spotify(
+        playback_return=None,
+        recent_side_effect=Exception("Spotify 503 timeout"),
+    ):
+        response = handler(_event(PUBLIC_ID), mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["source"] == "none"
+    assert body["track"] is None
+
+
+@patch("lambdas.public_now_playing.handler.get_user_by_user_id")
+def test_204_no_playback_no_recent_returns_none(
+    mock_resolve, mock_context, public_user
+):
+    """Spotify 204 (None) + no recently-played -> source=none 200."""
+    mock_resolve.return_value = public_user
+
+    with _patch_spotify(playback_return=None, recent_return=None):
+        response = handler(_event(PUBLIC_ID), mock_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body == {
+        "isPlaying": False,
+        "track": None,
+        "progressMs": None,
+        "durationMs": None,
+        "source": "none",
+        "playedAt": None,
     }
 
 
@@ -148,12 +279,13 @@ def test_non_track_item_degrades_gracefully(mock_resolve, mock_context, public_u
         },
     }
 
-    with _patch_spotify(return_value=episode_state):
+    with _patch_spotify(playback_return=episode_state):
         response = handler(_event(PUBLIC_ID), mock_context)
 
     assert response["statusCode"] == 200
     body = json.loads(response["body"])
     assert body["isPlaying"] is True
+    assert body["source"] == "playing"
     assert body["progressMs"] == 5000
     assert body["durationMs"] == 3_600_000
     # Best-effort name, empty artist join, null albumArt — no crash.
@@ -164,19 +296,21 @@ def test_non_track_item_degrades_gracefully(mock_resolve, mock_context, public_u
 
 
 @patch("lambdas.public_now_playing.handler.get_user_by_user_id")
-def test_active_device_no_item_returns_not_playing_track(
-    mock_resolve, mock_context, public_user
-):
-    """Active device but item is None/missing -> isPlaying flag honored, track null."""
+def test_paused_device_falls_back_to_recent(mock_resolve, mock_context, public_user):
+    """Active device but is_playing False -> not "playing"; falls back to recent."""
     mock_resolve.return_value = public_user
 
-    with _patch_spotify(return_value={"is_playing": False, "item": None}):
+    with _patch_spotify(
+        playback_return={"is_playing": False, "item": None},
+        recent_return=_recently_played(),
+    ):
         response = handler(_event(PUBLIC_ID), mock_context)
 
     assert response["statusCode"] == 200
     body = json.loads(response["body"])
     assert body["isPlaying"] is False
-    assert body["track"] is None
+    assert body["source"] == "recent"
+    assert body["track"]["name"] == "Recent Song"
     assert body["durationMs"] is None
 
 
@@ -184,7 +318,7 @@ def test_active_device_no_item_returns_not_playing_track(
 def test_non_public_user_returns_404(mock_resolve, mock_context):
     mock_resolve.return_value = {"email": "other@example.com", "userId": "not-public"}
 
-    with _patch_spotify(return_value=_playing_state()) as spotify_cls:
+    with _patch_spotify(playback_return=_playing_state()) as spotify_cls:
         response = handler(_event("not-public"), mock_context)
 
     assert response["statusCode"] == 404
@@ -198,7 +332,7 @@ def test_non_public_user_returns_404(mock_resolve, mock_context):
 def test_unknown_user_id_returns_404(mock_resolve, mock_context):
     mock_resolve.return_value = None
 
-    with _patch_spotify(return_value=_playing_state()) as spotify_cls:
+    with _patch_spotify(playback_return=_playing_state()) as spotify_cls:
         response = handler(_event("ghost"), mock_context)
 
     assert response["statusCode"] == 404
@@ -219,11 +353,11 @@ def test_missing_user_id_param_returns_400(mock_resolve, mock_context):
 
 
 @patch("lambdas.public_now_playing.handler.get_user_by_user_id")
-def test_spotify_error_returns_not_playing_200(mock_resolve, mock_context, public_user):
-    """Any Spotify error/timeout must degrade to not-playing 200, never 5xx."""
+def test_playback_error_returns_none_200(mock_resolve, mock_context, public_user):
+    """A playback-state error/timeout must degrade to source=none 200, never 5xx."""
     mock_resolve.return_value = public_user
 
-    with _patch_spotify(side_effect=Exception("Spotify 503 timeout")):
+    with _patch_spotify(playback_side_effect=Exception("Spotify 503 timeout")):
         response = handler(_event(PUBLIC_ID), mock_context)
 
     assert response["statusCode"] == 200
@@ -233,4 +367,6 @@ def test_spotify_error_returns_not_playing_200(mock_resolve, mock_context, publi
         "track": None,
         "progressMs": None,
         "durationMs": None,
+        "source": "none",
+        "playedAt": None,
     }


### PR DESCRIPTION
When `/me/player` reports nothing active, fall back to most-recently-played (`source=recent`, `playedAt`). 403/insufficient-scope degrades to `source=none` (works before re-auth). Never 5xx. 490 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)