### PR TITLE
Fix enrollment double-flag clobber (partial update)

### DIFF
--- a/lambdas/common/dynamo_helpers.py
+++ b/lambdas/common/dynamo_helpers.py
@@ -275,20 +275,34 @@ def update_user_table_refresh_token(email: str, user_id: str, display_name: str,
         )
 
 
-def update_user_table_enrollments(email: str, wrapped_enrolled: bool, release_radar_enrolled: bool) -> dict:
+def update_user_table_enrollments(
+    email: str,
+    wrapped_enrolled: bool | None = None,
+    release_radar_enrolled: bool | None = None,
+) -> dict:
     """
     Update user enrollment status.
+
+    Partial update: a ``None`` argument means "leave this flag exactly as it
+    is in the stored row." Only the flags explicitly provided are written, so
+    toggling one enrollment can never clobber its sibling (the double-flag
+    clobber bug).
     """
     try:
         user = get_item_by_key(USERS_TABLE_NAME, 'email', email)
-        
-        user['activeWrapped'] = wrapped_enrolled
-        user['activeReleaseRadar'] = release_radar_enrolled
+
+        if wrapped_enrolled is not None:
+            user['activeWrapped'] = wrapped_enrolled
+        if release_radar_enrolled is not None:
+            user['activeReleaseRadar'] = release_radar_enrolled
         user['updatedAt'] = _get_timestamp()
-        
+
         update_table_item(USERS_TABLE_NAME, user)
-        log.info(f"Updated enrollments for {email}: wrapped={wrapped_enrolled}, radar={release_radar_enrolled}")
-        
+        log.info(
+            f"Updated enrollments for {email}: "
+            f"wrapped={user.get('activeWrapped')}, radar={user.get('activeReleaseRadar')}"
+        )
+
         return user
         
     except Exception as err:

--- a/lambdas/user_update/handler.py
+++ b/lambdas/user_update/handler.py
@@ -77,8 +77,12 @@ def handler(event, context):
         log.info(f"Updated refresh token for {caller_email}")
 
     elif has_enrollment_fields:
-        wrapped = body.get('wrappedEnrolled', False)
-        radar = body.get('releaseRadarEnrolled', False)
+        # Partial update: only forward the flags actually present in the body.
+        # An absent flag is passed as None so the helper leaves the stored
+        # value untouched. Previously both flags defaulted to False, so a
+        # single-flag toggle silently clobbered its sibling enrollment.
+        wrapped = body.get('wrappedEnrolled')
+        radar = body.get('releaseRadarEnrolled')
 
         response = update_user_table_enrollments(
             caller_email,

--- a/tests/test_user_update.py
+++ b/tests/test_user_update.py
@@ -118,6 +118,50 @@ def test_user_update_enrollments_via_context(
     mock_update_enrollments.assert_called_once_with('test@example.com', True, False)
 
 
+@patch('lambdas.user_update.handler.update_user_table_enrollments')
+def test_user_update_enrollment_wrapped_only_leaves_radar_untouched(
+    mock_update_enrollments, mock_context, authorized_event,
+):
+    """
+    Partial update: a body carrying ONLY wrappedEnrolled must forward
+    releaseRadarEnrolled as None so the helper leaves the sibling flag
+    alone. Regression guard for the double-flag clobber (a Wrapped toggle
+    silently un-enrolling Release Radar).
+    """
+    mock_update_enrollments.return_value = {'email': 'test@example.com'}
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({"wrappedEnrolled": True}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_update_enrollments.assert_called_once_with('test@example.com', True, None)
+
+
+@patch('lambdas.user_update.handler.update_user_table_enrollments')
+def test_user_update_enrollment_radar_only_leaves_wrapped_untouched(
+    mock_update_enrollments, mock_context, authorized_event,
+):
+    """Partial update: a body carrying ONLY releaseRadarEnrolled must
+    forward wrappedEnrolled as None (sibling untouched)."""
+    mock_update_enrollments.return_value = {'email': 'test@example.com'}
+    event = authorized_event(
+        email="test@example.com",
+        httpMethod="POST",
+        path="/user/user-table",
+        body=json.dumps({"releaseRadarEnrolled": False}),
+    )
+
+    response = handler(event, mock_context)
+
+    assert response['statusCode'] == 200
+    mock_update_enrollments.assert_called_once_with('test@example.com', None, False)
+
+
 @patch('lambdas.user_update.handler.update_user_table_refresh_token')
 def test_user_update_invalid_request_returns_400(
     mock_update_token, mock_context, authorized_event,

--- a/tests/test_user_update_enrollments_dynamo.py
+++ b/tests/test_user_update_enrollments_dynamo.py
@@ -1,0 +1,73 @@
+"""
+Tests for ``update_user_table_enrollments`` partial-update semantics.
+
+The double-flag clobber bug: toggling one enrollment (Wrapped) used to
+overwrite the sibling flag (Release Radar) because the helper always wrote
+BOTH ``activeWrapped`` and ``activeReleaseRadar`` from whatever the caller
+passed. A ``None`` argument now means "leave this flag exactly as it is in
+the stored row" so a single-flag update can never clobber its sibling.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from lambdas.common import dynamo_helpers
+
+
+@patch("lambdas.common.dynamo_helpers.update_table_item")
+@patch("lambdas.common.dynamo_helpers.get_item_by_key")
+def test_wrapped_only_update_preserves_release_radar(mock_get, mock_put):
+    """Passing release_radar_enrolled=None keeps the stored radar flag."""
+    mock_get.return_value = {
+        "email": "u@example.com",
+        "activeWrapped": False,
+        "activeReleaseRadar": True,
+    }
+
+    result = dynamo_helpers.update_user_table_enrollments(
+        "u@example.com", wrapped_enrolled=True, release_radar_enrolled=None
+    )
+
+    assert result["activeWrapped"] is True
+    # Sibling flag untouched — the clobber regression guard.
+    assert result["activeReleaseRadar"] is True
+    written = mock_put.call_args.args[1]
+    assert written["activeWrapped"] is True
+    assert written["activeReleaseRadar"] is True
+
+
+@patch("lambdas.common.dynamo_helpers.update_table_item")
+@patch("lambdas.common.dynamo_helpers.get_item_by_key")
+def test_radar_only_update_preserves_wrapped(mock_get, mock_put):
+    """Passing wrapped_enrolled=None keeps the stored wrapped flag."""
+    mock_get.return_value = {
+        "email": "u@example.com",
+        "activeWrapped": True,
+        "activeReleaseRadar": False,
+    }
+
+    result = dynamo_helpers.update_user_table_enrollments(
+        "u@example.com", wrapped_enrolled=None, release_radar_enrolled=True
+    )
+
+    assert result["activeReleaseRadar"] is True
+    assert result["activeWrapped"] is True
+
+
+@patch("lambdas.common.dynamo_helpers.update_table_item")
+@patch("lambdas.common.dynamo_helpers.get_item_by_key")
+def test_both_flags_update_when_provided(mock_get, mock_put):
+    """Both flags still update together when both are provided (unchanged)."""
+    mock_get.return_value = {
+        "email": "u@example.com",
+        "activeWrapped": True,
+        "activeReleaseRadar": True,
+    }
+
+    result = dynamo_helpers.update_user_table_enrollments(
+        "u@example.com", wrapped_enrolled=False, release_radar_enrolled=False
+    )
+
+    assert result["activeWrapped"] is False
+    assert result["activeReleaseRadar"] is False


### PR DESCRIPTION
## Problem

The enrollment update path (`POST /user/update`) always wrote **both**
`activeWrapped` and `activeReleaseRadar` from whatever the caller passed,
defaulting any absent flag to `False`. So a single-flag toggle sent from the
Wrapped or Release-Radar page silently overwrote its **sibling** enrollment
(the double-flag clobber bug — audit finding #5).

## Fix

- `lambdas/user_update/handler.py`: forward absent enrollment flags as `None`
  instead of defaulting to `False`.
- `lambdas/common/dynamo_helpers.py`: `update_user_table_enrollments` now treats
  `None` as "leave this flag exactly as stored", writing only the flags actually
  provided. A partial (single-flag) update can no longer clobber its sibling.

Existing callers that send both flags are unaffected.

## Tests (RED-before-GREEN)

- `tests/test_user_update.py`: partial wrapped-only → `(email, True, None)`;
  partial radar-only → `(email, None, False)`.
- `tests/test_user_update_enrollments_dynamo.py` (new): sibling flag preserved
  when one arg is `None`, both-flags path still updates together.
- Full suite: **495 passed**.

Pairs with the frontend PR (targeted single-flag update calls + `ensureLoaded`
fix + opt-in UX redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)