### PR TITLE
Fix flaky deploy-changed-lambdas: cap parallelism + retry with backoff

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -214,6 +214,9 @@ jobs:
       matrix:
         lambda: ${{ fromJson(needs.detect-changes.outputs.changed_lambdas) }}
       fail-fast: false
+      # Cap concurrency so we don't hammer the Lambda API (TooManyRequestsException)
+      # when many functions change at once. Tune down further if throttling persists.
+      max-parallel: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -237,31 +240,63 @@ jobs:
           # Convert underscores to hyphens for AWS function names
           FUNCTION_NAME=$(echo $FUNCTION_NAME | tr '_' '-')
 
-          echo "Deploying code for $FUNCTION_NAME"
-          aws lambda update-function-code \
-            --function-name $FUNCTION_NAME \
-            --zip-file fileb://${{ matrix.lambda }}.zip \
-            --region $AWS_REGION
+          # Retry helper: up to 5 attempts w/ exponential backoff (3s, 6s, 12s, 24s
+          # between attempts). Retries on ANY non-zero exit -- this covers both
+          # Lambda API throttling (TooManyRequestsException / transient 5xx) AND the
+          # just-created-function race (ResourceNotFoundException when this step runs
+          # right after `terraform apply` and the function isn't visible to the
+          # control plane yet). A short wait lets either condition clear on its own.
+          # Idempotent: update-function-code/-configuration are safe to call again.
+          retry_aws() {
+            local desc="$1"; shift
+            local max_attempts=5
+            local delay=3
+            local attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "❌ $desc failed after $attempt attempts"
+                return 1
+              fi
+              echo "⚠️  $desc failed (attempt $attempt/$max_attempts), retrying in ${delay}s..."
+              sleep "$delay"
+              delay=$((delay * 2))
+              attempt=$((attempt + 1))
+            done
+            echo "✅ $desc succeeded on attempt $attempt"
+          }
 
-          # Wait for function to finish updating before config change
+          echo "Deploying code for $FUNCTION_NAME"
+          retry_aws "update-function-code for $FUNCTION_NAME" \
+            aws lambda update-function-code \
+              --function-name "$FUNCTION_NAME" \
+              --zip-file "fileb://${{ matrix.lambda }}.zip" \
+              --region "$AWS_REGION"
+
+          # Wait for function to finish updating before config change. Wrapped in
+          # the same retry helper since the waiter's polling calls can also be
+          # throttled under high fan-out.
           echo "Waiting for function update to complete..."
-          aws lambda wait function-updated \
-            --function-name $FUNCTION_NAME \
-            --region $AWS_REGION
+          retry_aws "wait function-updated (post code) for $FUNCTION_NAME" \
+            aws lambda wait function-updated \
+              --function-name "$FUNCTION_NAME" \
+              --region "$AWS_REGION"
 
           # If layer was updated, also update config (only after code update completes)
           if [ "${{ needs.deploy-layer.outputs.layer_arn }}" != "" ]; then
             echo "Updating layer configuration for $FUNCTION_NAME"
-            aws lambda update-function-configuration \
-              --function-name $FUNCTION_NAME \
-              --layers ${{ needs.deploy-layer.outputs.layer_arn }} \
-              --region $AWS_REGION
+            retry_aws "update-function-configuration for $FUNCTION_NAME" \
+              aws lambda update-function-configuration \
+                --function-name "$FUNCTION_NAME" \
+                --layers "${{ needs.deploy-layer.outputs.layer_arn }}" \
+                --region "$AWS_REGION"
 
-            # Wait for config update to complete
+            # Wait for config update to complete before declaring success, so a
+            # ResourceConflictException can't leak into whatever runs next.
             echo "Waiting for configuration update to complete..."
-            aws lambda wait function-updated \
-              --function-name $FUNCTION_NAME \
-              --region $AWS_REGION
+            retry_aws "wait function-updated (post config) for $FUNCTION_NAME" \
+              aws lambda wait function-updated \
+                --function-name "$FUNCTION_NAME" \
+                --region "$AWS_REGION"
           fi
 
           echo "✅ $FUNCTION_NAME deployment complete"


### PR DESCRIPTION
## Problem
`deploy-changed-lambdas` fails on random functions each run (observed twice today):
1. **Throttling** — matrix fans out with unbounded parallelism, concurrent `update-function-code`/config calls get throttled (`TooManyRequestsException` / transient 5xx).
2. **New-function race** — this runs right after `terraform apply`; `update-function-code` can hit `ResourceNotFoundException` before a newly-created function is visible to the control plane.

Folder→function name mapping (`FUNCTION_NAME="xomify-${matrix.lambda}"` + `tr '_' '-'`) is untouched.

## Fix
- `deploy-changed-lambdas` job: added `strategy.max-parallel: 5` to bound concurrent Lambda API calls.
- Added a `retry_aws` bash helper wrapping `update-function-code`, `update-function-configuration`, and both `wait function-updated` calls: 5 attempts, exponential backoff (3s, 6s, 12s, 24s), retries on **any** non-zero exit (covers throttling and the not-yet-visible-function race — the wait gives AWS time to catch up either way). Job only fails once all attempts are exhausted.
- Kept the existing `wait function-updated` between code update and config update (was already present, just wrapped in retry now) to avoid `ResourceConflictException: update in progress`.

Retry snippet:
```bash
retry_aws() {
  local desc="$1"; shift
  local max_attempts=5
  local delay=3
  local attempt=1
  until "$@"; do
    if [ "$attempt" -ge "$max_attempts" ]; then
      echo "❌ $desc failed after $attempt attempts"
      return 1
    fi
    echo "⚠️  $desc failed (attempt $attempt/$max_attempts), retrying in ${delay}s..."
    sleep "$delay"
    delay=$((delay * 2))
    attempt=$((attempt + 1))
  done
  echo "✅ $desc succeeded on attempt $attempt"
}
```

## Out of scope (intentionally untouched)
- Packaging, function-name mapping, `deploy-layer`/`update-all-lambdas-layer` jobs, `test-lambdas` matrix.
- Action pinning (still `@v6` majors) and AWS auth (static keys, not OIDC) — left as-is to match this repo's existing house style; not changing auth mechanism as part of a reliability fix.

## Validation
Verified by reading — YAML parses (`yaml.safe_load`), logic traced manually. **Full validation requires a real deploy run** (throttling/race conditions can't be reproduced locally). Recommend watching the next `master` push or a manual `workflow_dispatch` (`deploy_mode: all`) run after merge.

Do not merge — opened for review only.