### PR TITLE
fix: cron items-count len() on int crash

### DIFF
--- a/lambdas/cron_release_radar/handler.py
+++ b/lambdas/cron_release_radar/handler.py
@@ -24,7 +24,7 @@ def handler(event, context):
 
     def _wrapped():
         successes, failures = asyncio.run(release_radar_cron_job(event))
-        stats["items"] = len(successes) + len(failures)
+        stats["items"] = sum(v if isinstance(v, int) else len(v) for v in (successes, failures))
         return success_response({
             "successfulUsers": successes,
             "failedUsers": failures

--- a/lambdas/cron_release_radar_email/handler.py
+++ b/lambdas/cron_release_radar_email/handler.py
@@ -24,7 +24,11 @@ def handler(event, context):
 
     def _wrapped():
         successes, failures, skipped = asyncio.run(release_radar_email_cron_job(event))
-        stats["items"] = len(successes) + len(failures) + len(skipped)
+        # successes/failures/skipped may be counts (int) or collections -- handle both.
+        stats["items"] = sum(
+            v if isinstance(v, int) else len(v)
+            for v in (successes, failures, skipped)
+        )
         return success_response({
             "successfulEmails": successes,
             "failedEmails": failures,

--- a/lambdas/cron_token_keepalive/handler.py
+++ b/lambdas/cron_token_keepalive/handler.py
@@ -86,7 +86,7 @@ def handler(event, context):
 
     def _wrapped():
         successes, failures = asyncio.run(keepalive_all_tokens(event))
-        stats["items"] = len(successes) + len(failures)
+        stats["items"] = sum(v if isinstance(v, int) else len(v) for v in (successes, failures))
         return success_response({
             "refreshedUsers": successes,
             "failedUsers": failures,

--- a/lambdas/cron_wrapped/handler.py
+++ b/lambdas/cron_wrapped/handler.py
@@ -24,7 +24,7 @@ def handler(event, context):
 
     def _wrapped():
         successes, failures = asyncio.run(aiohttp_wrapped_chron_job(event))
-        stats["items"] = len(successes) + len(failures)
+        stats["items"] = sum(v if isinstance(v, int) else len(v) for v in (successes, failures))
         return success_response({
             "successfulUsers": successes,
             "failedUsers": failures

--- a/lambdas/cron_wrapped_email/handler.py
+++ b/lambdas/cron_wrapped_email/handler.py
@@ -24,7 +24,7 @@ def handler(event, context):
 
     def _wrapped():
         successes, failures = asyncio.run(wrapped_email_cron_job(event))
-        stats["items"] = len(successes) + len(failures)
+        stats["items"] = sum(v if isinstance(v, int) else len(v) for v in (successes, failures))
         return success_response({
             "successfulEmails": successes,
             "failedEmails": failures


### PR DESCRIPTION
The #194 cron-run observability wrapper computed items via len() on values that are counts (int), crashing release-radar-email (and same pattern in 4 other crons). Made it int-or-collection tolerant.