### PR TITLE
Add admin-only Spotify impersonation-token endpoint

### DIFF
--- a/lambdas/admin_impersonation_token/handler.py
+++ b/lambdas/admin_impersonation_token/handler.py
@@ -1,0 +1,108 @@
+"""
+GET /admin/impersonation-token?email= - Mint a fresh Spotify access token for
+any user (admin only).
+
+Unlike `/admin/view-as` (a read-only projection of the target's own
+email-keyed data), this endpoint hands back a short-lived, LIVE Spotify access
+token minted from the target user's stored `refreshToken`. It lets an admin
+impersonate the target against Spotify-derived surfaces (top items,
+recently-played, now-playing, playlists, profile) exactly as that user would.
+
+Security:
+- The admin gate (`require_admin`) resolves the TRUE caller identity from the
+  authorizer context and enforces `email == ADMIN_EMAIL`. It never trusts an
+  impersonated identity, and non-admins receive HTTP 403.
+- Only the target's short-lived ACCESS token is returned. The refresh token is
+  never returned and token values are never logged (masked in structured logs).
+- The request-log hook already audits this call like any other route.
+
+Response (200):
+{
+  "accessToken": "<short-lived Spotify access token>",
+  "expiresIn": 3600
+}
+
+Errors:
+- 400 if `email` query param is missing.
+- 403 if the caller is not the configured admin.
+- 404 if the target user (or their refresh token) does not exist.
+"""
+
+from lambdas.common.admin import require_admin
+from lambdas.common.dynamo_helpers import get_user_table_data
+from lambdas.common.errors import (
+    NotFoundError,
+    ValidationError,
+    handle_errors,
+    mask_sensitive_data,
+)
+from lambdas.common.logger import get_logger
+from lambdas.common.spotify import Spotify
+from lambdas.common.utility_helpers import get_query_params, success_response
+
+log = get_logger(__file__)
+
+HANDLER = "admin_impersonation_token"
+
+# Spotify short-lived access tokens default to 3600s; used only when Spotify
+# omits `expires_in` from its refresh response.
+_DEFAULT_EXPIRES_IN = 3600
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    # Admin gate: resolves and verifies the TRUE caller (never an impersonated
+    # identity). Raises 401 if unauthenticated, 403 if not the admin.
+    admin_email = require_admin(event)
+
+    params = get_query_params(event)
+    email = params.get("email")
+    if not email:
+        raise ValidationError("email is required", handler=HANDLER, field="email")
+
+    try:
+        user = get_user_table_data(email)
+    except NotFoundError:
+        raise NotFoundError(
+            message=f"No user found for {email}",
+            handler=HANDLER,
+            resource=email,
+        )
+
+    if not user.get("refreshToken"):
+        # Target exists but never connected Spotify (or token was cleared) —
+        # nothing to impersonate.
+        raise NotFoundError(
+            message=f"No Spotify refresh token for {email}",
+            handler=HANDLER,
+            resource=email,
+        )
+
+    # Reuse the SAME client-credentials + refresh flow the crons use
+    # (Spotify.get_access_token, invoked by the sync constructor). This mints a
+    # fresh access token from the target's stored refresh token.
+    spotify = Spotify(user)
+    access_token = spotify.access_token
+    expires_in = spotify.token_expires_in or _DEFAULT_EXPIRES_IN
+
+    if not access_token:
+        # Defensive: the refresh flow raises on failure, but never hand back a
+        # null token.
+        raise NotFoundError(
+            message=f"Could not mint Spotify access token for {email}",
+            handler=HANDLER,
+            resource=email,
+        )
+
+    # Never log token values.
+    log.info(
+        "admin_impersonation_token by=%s target=%s minted=%s",
+        admin_email,
+        email,
+        mask_sensitive_data({"accessToken": access_token}),
+    )
+
+    return success_response({
+        "accessToken": access_token,
+        "expiresIn": expires_in,
+    })

--- a/lambdas/common/spotify.py
+++ b/lambdas/common/spotify.py
@@ -42,6 +42,9 @@ class Spotify:
         
         # Auth - initialized later for async
         self.access_token: str = None
+        # Seconds until the current access token expires (populated by the sync
+        # refresh path). Spotify short-lived tokens default to 3600s.
+        self.token_expires_in: int | None = None
         self.headers: dict = {}
         
         # Initialize synchronously if no aiohttp session
@@ -183,9 +186,13 @@ class Spotify:
             if response.status_code != 200:
                 raise Exception(f"Error refreshing token: {response_data}")
 
+            # Capture time-to-expiry so callers that need to surface it (e.g. the
+            # admin impersonation-token endpoint) can, without re-deriving it.
+            self.token_expires_in = response_data.get('expires_in')
+
             log.info("Successfully retrieved spotify access token!")
             return response_data['access_token']
-            
+
         except Exception as err:
             log.error(f"Get Spotify Access Token: {err}")
             raise Exception(f"Get Spotify Access Token: {err}") from err

--- a/tests/test_admin_impersonation_token.py
+++ b/tests/test_admin_impersonation_token.py
@@ -1,0 +1,127 @@
+"""
+Tests for GET /admin/impersonation-token (admin-only Spotify access-token mint).
+
+Admin email is `admin@example.com` (conftest). Non-admin uses the default
+`test@example.com` identity.
+
+The endpoint reuses `Spotify.get_access_token` (invoked by the sync
+constructor) to exchange the target user's stored refresh token for a fresh
+short-lived access token, so the tests patch the `Spotify` client the handler
+imports rather than making real HTTP calls.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+ADMIN = "admin@example.com"
+NON_ADMIN = "test@example.com"
+
+
+def _spotify_stub(access_token="fresh-access-token", expires_in=3600):
+    """Build a Spotify() replacement that mimics the sync-constructed client."""
+    def _factory(user, session=None):
+        stub = MagicMock()
+        stub.access_token = access_token
+        stub.token_expires_in = expires_in
+        return stub
+    return _factory
+
+
+@patch("lambdas.admin_impersonation_token.handler.Spotify")
+@patch("lambdas.admin_impersonation_token.handler.get_user_table_data")
+def test_impersonation_token_happy(mock_user, mock_spotify,
+                                   authorized_event, mock_context):
+    from lambdas.admin_impersonation_token.handler import handler
+
+    mock_user.return_value = {"email": "u@x.com", "userId": "sp1",
+                              "refreshToken": "target-refresh-tok"}
+    mock_spotify.side_effect = _spotify_stub("fresh-access-token", 3600)
+
+    event = authorized_event(email=ADMIN, httpMethod="GET",
+                             queryStringParameters={"email": "u@x.com"})
+    resp = handler(event, mock_context)
+
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body == {"accessToken": "fresh-access-token", "expiresIn": 3600}
+
+    # The client is built from the TARGET user's row (their refresh token).
+    built_user = mock_spotify.call_args.args[0]
+    assert built_user["refreshToken"] == "target-refresh-tok"
+    # Refresh token is never returned.
+    assert "refreshToken" not in body
+
+
+@patch("lambdas.admin_impersonation_token.handler.Spotify")
+@patch("lambdas.admin_impersonation_token.handler.get_user_table_data")
+def test_impersonation_token_defaults_expiry(mock_user, mock_spotify,
+                                             authorized_event, mock_context):
+    from lambdas.admin_impersonation_token.handler import handler
+
+    mock_user.return_value = {"email": "u@x.com", "refreshToken": "tok"}
+    # Spotify omitted expires_in -> handler falls back to 3600.
+    mock_spotify.side_effect = _spotify_stub("tok-access", None)
+
+    event = authorized_event(email=ADMIN, httpMethod="GET",
+                             queryStringParameters={"email": "u@x.com"})
+    resp = handler(event, mock_context)
+
+    assert resp["statusCode"] == 200
+    assert json.loads(resp["body"])["expiresIn"] == 3600
+
+
+def test_impersonation_token_non_admin_403(authorized_event, mock_context):
+    from lambdas.admin_impersonation_token.handler import handler
+
+    with patch("lambdas.admin_impersonation_token.handler.get_user_table_data") as mock_user, \
+         patch("lambdas.admin_impersonation_token.handler.Spotify") as mock_spotify:
+        event = authorized_event(email=NON_ADMIN, httpMethod="GET",
+                                 queryStringParameters={"email": "u@x.com"})
+        resp = handler(event, mock_context)
+
+    assert resp["statusCode"] == 403
+    # Non-admins never reach the lookup or token mint.
+    mock_user.assert_not_called()
+    mock_spotify.assert_not_called()
+
+
+def test_impersonation_token_missing_email_400(authorized_event, mock_context):
+    from lambdas.admin_impersonation_token.handler import handler
+
+    resp = handler(authorized_event(email=ADMIN, httpMethod="GET",
+                                    queryStringParameters={}), mock_context)
+    assert resp["statusCode"] == 400
+
+
+@patch("lambdas.admin_impersonation_token.handler.Spotify")
+@patch("lambdas.admin_impersonation_token.handler.get_user_table_data")
+def test_impersonation_token_unknown_user_404(mock_user, mock_spotify,
+                                              authorized_event, mock_context):
+    from lambdas.admin_impersonation_token.handler import handler
+    from lambdas.common.errors import NotFoundError
+
+    mock_user.side_effect = NotFoundError(message="nope", resource="u@x.com")
+
+    event = authorized_event(email=ADMIN, httpMethod="GET",
+                             queryStringParameters={"email": "u@x.com"})
+    resp = handler(event, mock_context)
+
+    assert resp["statusCode"] == 404
+    mock_spotify.assert_not_called()
+
+
+@patch("lambdas.admin_impersonation_token.handler.Spotify")
+@patch("lambdas.admin_impersonation_token.handler.get_user_table_data")
+def test_impersonation_token_no_refresh_token_404(mock_user, mock_spotify,
+                                                  authorized_event, mock_context):
+    from lambdas.admin_impersonation_token.handler import handler
+
+    # Target exists but never connected Spotify.
+    mock_user.return_value = {"email": "u@x.com", "userId": "sp1"}
+
+    event = authorized_event(email=ADMIN, httpMethod="GET",
+                             queryStringParameters={"email": "u@x.com"})
+    resp = handler(event, mock_context)
+
+    assert resp["statusCode"] == 404
+    mock_spotify.assert_not_called()


### PR DESCRIPTION
## What
Adds `GET /admin/impersonation-token?email=<target-email>` (admin-only), which mints a fresh **short-lived Spotify access token** for any user so an admin can impersonate that user's live Spotify data (top items, recently-played, now-playing, playlists, profile).

Contract:
```
GET /admin/impersonation-token?email=<target-email>
-> 200 { "accessToken": "<short-lived token>", "expiresIn": 3600 }
```

## How
- New lambda `lambdas/admin_impersonation_token/` -> deploys as function `xomify-admin-impersonation-token`.
- **Reuses the crons' refresh flow**: `Spotify.get_access_token` (invoked by the sync `Spotify(user)` constructor) — the same client-credentials + `refresh_token` grant the Wrapped / Release-Radar crons use. Added a small additive capture of `expires_in` on the sync path (`Spotify.token_expires_in`) so the endpoint can return seconds-to-expiry; no behavior change for existing callers.
- **Admin gate**: `require_admin(event)` resolves the TRUE caller from the authorizer context and enforces `email == ADMIN_EMAIL`. It never trusts an impersonated identity. Non-admin -> 403.
- Reads the target's row from `xomify-users` by email; `404` if the user or their `refreshToken` is absent.

## Security
- Returns `{accessToken, expiresIn}` only — the refresh token is never returned.
- Token values are never logged (masked via `mask_sensitive_data`; `accessToken` is in `SENSITIVE_FIELDS`).
- Admin-only and audit-logged by the existing request-log hook.

## Tests
- Happy path, default-expiry fallback, `403` non-admin, `400` missing email, `404` unknown user, `404` no refresh token.
- New tests pass; full suite: **589 passed**.

## Infra
Route + function wiring is in a companion PR on `xomify-infrastructure`. **Apply infra first**, then merge/deploy this backend PR.

Do not merge yet.