### PR TITLE
Notifications platform: kind registry, per-type prefs, inbox, producers

### DIFF
--- a/docs/features/notification-cron-producers/PLAN.md
+++ b/docs/features/notification-cron-producers/PLAN.md
@@ -3,7 +3,7 @@
 **Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
 **Sub-feature ID**: B5 (`notification-cron-producers`)
 **Track**: B — Notifications Platform
-**Status**: Draft
+**Status**: Done (broadcast fan-out still deferred)
 **Created**: 2026-08-24
 **Last updated**: 2026-08-24
 **Scope size**: TBD — run `/plan notification-cron-producers` to size
@@ -45,3 +45,55 @@ _Stub — define with `/plan notification-cron-producers`._
 
 Locked decisions live in the epic plan and must not be re-litigated here. See
 `https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.
+
+---
+
+## Outcome
+
+Suite: **14 failed / 646 passed** (baseline 14 / 600). 7 new tests.
+
+| Producer | Kind | Notes |
+|----------|------|-------|
+| `cron_wrapped` | `wrapped_drop` | sneak peek + deep link to the playlist |
+| `cron_release_radar` | `release_radar_drop` | sneak peek; **empty weeks are not notified** |
+| `cron_favorites_reminder` | `favorites_reminder` | push alongside the existing SES email |
+| `cron_rate_reminder` | `rate_reminder` | **new lambda** |
+
+### The sneak peek
+
+This is the part that was actually asked for. `notify.sneak_peek()` pulls name, artist and
+cover art off a raw Spotify track object, so a drop reads *"Starting with Midnight City —
+M83"* rather than *"Your Wrapped is ready"*. The route deep-links straight into the
+playlist. Release Radar does not need the helper — its releases are already normalised
+with `albumName` / `artistName` / `imageUrl`.
+
+`_month_label()` turns `"2026-03"` into `"March"`. A month key is a storage detail, not
+push copy.
+
+### `cron_rate_reminder`
+
+- **Window is `[24h, 48h)`.** The lower bound gives a share a day to land. The upper bound
+  is what stops a daily scan re-examining the whole table forever — without it the cost
+  grows without limit.
+- **Latch before work, not after.** `mark_rate_reminded` is a conditional write on the
+  share row, same trick as `mark_threshold_notified`. Acquiring it first means losing the
+  race costs nothing; doing the reads first and *then* discovering another run owns the
+  share wastes them.
+- **Engagement means listened OR rated.** A rating with no recorded listen is still
+  engagement, and nudging that person would be plainly wrong. Tested.
+- **Capped at 200 per run**, so a pathological day degrades into several runs rather than
+  one timeout that sends nothing.
+
+### Best-effort placement
+
+The favorites push sits **after** `send_favorites_reminder_email` and outside the
+try/except that counts a failure. The email is what "sent" means for that cron — a push
+failure must not cost someone the reminder they would otherwise have received, nor mark
+the send failed.
+
+### STILL DEFERRED: `admin_broadcasts_create`
+
+Carried over from B4 and not resolved here. Fanning out to every user needs a users-table
+scan; doing it inside the admin's request handler risks a timeout with no feedback. The
+right shape is an async invoke into a dedicated fan-out lambda, which is really its own
+small sub-feature. **It is the one notification kind in the registry with no producer.**

--- a/docs/features/notification-cron-producers/PLAN.md
+++ b/docs/features/notification-cron-producers/PLAN.md
@@ -1,0 +1,47 @@
+# Plan: notification-cron-producers
+
+**Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
+**Sub-feature ID**: B5 (`notification-cron-producers`)
+**Track**: B — Notifications Platform
+**Status**: Draft
+**Created**: 2026-08-24
+**Last updated**: 2026-08-24
+**Scope size**: TBD — run `/plan notification-cron-producers` to size
+**Repo(s) touched**: `xomify-backend`
+**Branch**: `feature/notification-cron-producers`
+**Wave**: 3
+**Depends on**: `B2`, `B3`
+
+---
+
+## Summary
+
+Push fan-out on the three existing crons, plus the new cron_rate_reminder.
+
+## Approach
+
+cron_wrapped / cron_release_radar: after generating each playlist, notify() with a SNEAK PEEK — top track name + artist + cover art in the body, deep link straight into the playlist. cron_favorites_reminder: push alongside its existing SES email. cron_rate_reminder (decision 9): scans xomify-share-interactions for shares received >=24h ago with neither queued nor rated; ONE reminder per share ever, idempotent via a REMINDED#<shareId> marker, daily schedule, no second nudge.
+
+## Affected Files / Components
+
+- `lambdas/cron_wrapped/`
+- `lambdas/cron_release_radar/`
+- `lambdas/cron_favorites_reminder/`
+- `lambdas/cron_rate_reminder/ (new)`
+
+## Implementation Steps
+
+_Stub — not yet planned. Run `/plan notification-cron-producers` to expand this into ordered, checkable steps._
+
+- [ ] TBD
+
+## Acceptance
+
+_Stub — define with `/plan notification-cron-producers`._
+
+---
+
+## Epic context
+
+Locked decisions live in the epic plan and must not be re-litigated here. See
+`https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.

--- a/docs/features/notification-inbox-api/PLAN.md
+++ b/docs/features/notification-inbox-api/PLAN.md
@@ -1,0 +1,47 @@
+# Plan: notification-inbox-api
+
+**Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
+**Sub-feature ID**: B3 (`notification-inbox-api`)
+**Track**: B — Notifications Platform
+**Status**: Draft
+**Created**: 2026-08-24
+**Last updated**: 2026-08-24
+**Scope size**: TBD — run `/plan notification-inbox-api` to size
+**Repo(s) touched**: `xomify-backend`
+**Branch**: `feature/notification-inbox-api`
+**Wave**: 2
+**Depends on**: `B1`
+
+---
+
+## Summary
+
+xomify-notifications table plus the three inbox endpoints.
+
+## Approach
+
+PK email, SK ts#<rand8>; attrs kind, title, body, route, actorEmail, actorName, imageUrl, read, createdAt, ttl (90d). GET /notifications (paginated, newest first), POST /notifications/read (one or all), GET /notifications/unread-count. Distinct from xomify-notification-log, which is PK day, scan-based, and an admin send-log rather than a per-user feed. Both tables stay.
+
+## Affected Files / Components
+
+- `lambdas/common/notifications_dynamo.py (new)`
+- `lambdas/notifications_feed/ (new)`
+- `lambdas/notifications_read/ (new)`
+- `lambdas/notifications_unread_count/ (new)`
+
+## Implementation Steps
+
+_Stub — not yet planned. Run `/plan notification-inbox-api` to expand this into ordered, checkable steps._
+
+- [ ] TBD
+
+## Acceptance
+
+_Stub — define with `/plan notification-inbox-api`._
+
+---
+
+## Epic context
+
+Locked decisions live in the epic plan and must not be re-litigated here. See
+`https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.

--- a/docs/features/notification-inbox-api/PLAN.md
+++ b/docs/features/notification-inbox-api/PLAN.md
@@ -3,7 +3,7 @@
 **Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
 **Sub-feature ID**: B3 (`notification-inbox-api`)
 **Track**: B — Notifications Platform
-**Status**: Draft
+**Status**: Done
 **Created**: 2026-08-24
 **Last updated**: 2026-08-24
 **Scope size**: TBD — run `/plan notification-inbox-api` to size
@@ -45,3 +45,47 @@ _Stub — define with `/plan notification-inbox-api`._
 
 Locked decisions live in the epic plan and must not be re-litigated here. See
 `https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.
+
+---
+
+## Outcome
+
+| File | Change |
+|------|--------|
+| `lambdas/common/notifications_dynamo.py` | new — inbox store |
+| `lambdas/notifications_feed/handler.py` | new — `GET /notifications` |
+| `lambdas/notifications_read/handler.py` | new — `POST /notifications/read` |
+| `lambdas/notifications_unread_count/handler.py` | new — `GET /notifications/unread-count` |
+| `lambdas/common/notify.py` | writes the inbox row before dispatching the push |
+| `tests/test_notifications_inbox.py` | new — 19 tests |
+
+Suite: **14 failed / 629 passed** (baseline 14 / 600 — nothing broken, +29).
+
+### Design decisions
+
+- **The SK does the sorting.** `tsId` is `"<iso8601>#<rand8>"`. ISO8601 sorts
+  chronologically and lexicographically at once, so `ScanIndexForward=False` gives
+  newest-first with no sort-key gymnastics and paging is a plain `ExclusiveStartKey`.
+  The `#<rand8>` suffix exists purely so two notifications written in the same
+  millisecond cannot collide.
+- **Inbox and push are independent.** The inbox row is written even when the kind is
+  muted, and even when the user has no device at all. Muting a push means "do not
+  interrupt me", not "hide this from my history" — and web has no APNs token whatsoever,
+  so gating the inbox on push delivery would leave every web user with a permanently
+  empty inbox.
+- **Self-notification writes nothing at all**, inbox included. You do not need a history
+  entry for your own comment.
+- **`mark_all_read` is bounded** at 300. An unbounded update loop is how a lambda finds
+  its 15-minute timeout; a user past the cap marks the rest on a second call, which is a
+  much better failure mode than a half-finished sweep reporting success.
+- **`count_unread` follows pagination.** A single query's `Count` covers only that page —
+  stopping at the first response silently undercounts the badge.
+- **Not a GSI on the send log.** `xomify-notification-log` is PK `day`, scan-read, and
+  answers "what did we send yesterday?" for the admin view. Indexing `toEmail` onto it
+  would produce a send-log with an index, not an inbox with mutable read state.
+
+### Deferred
+
+`count_unread` applies its filter after the read, so it still reads the partition. At
+90-day retention and one user's traffic that is cheap. If it stops being cheap the fix is
+a sparse GSI over unread items — noted, not built.

--- a/docs/features/notification-interaction-producers/PLAN.md
+++ b/docs/features/notification-interaction-producers/PLAN.md
@@ -3,7 +3,7 @@
 **Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
 **Sub-feature ID**: B4 (`notification-interaction-producers`)
 **Track**: B — Notifications Platform
-**Status**: Draft
+**Status**: Done (9 of 10 — broadcast deferred, see below)
 **Created**: 2026-08-24
 **Last updated**: 2026-08-24
 **Scope size**: TBD — run `/plan notification-interaction-producers` to size
@@ -51,3 +51,55 @@ _Stub — define with `/plan notification-interaction-producers`._
 
 Locked decisions live in the epic plan and must not be re-litigated here. See
 `https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.
+
+---
+
+## Outcome
+
+Suite: **14 failed / 639 passed** (baseline 14 / 600). 10 new tests.
+
+| Producer | Kind | Recipient |
+|----------|------|-----------|
+| `shares_create` | `share_received` | fan-out to the author's accepted friends |
+| `shares_comments_create` | `share_comment` | the share author |
+| `shares_reactions_toggle` | `share_reaction` | the share author, **on add only** |
+| `shares_listened` | `share_listened` | the share author (coalescing) |
+| `shares_react` (rated) | `share_rated` | the share author (coalescing) |
+| `friends_request` | `friend_request` | the target |
+| `friends_accept` | `friend_accepted` | the original requester |
+| `invites_accept` | `invite_accepted` | the inviter |
+
+### Judgement calls
+
+- **`shares_create` fans out.** A share is a friends-graph broadcast, not an addressed
+  message — there is no recipient field. `notify_friends_of` caps at 100 and filters to
+  `status == "accepted"`. That filter is load-bearing: `list_all_friends_for_user` returns
+  the whole partition, so an unfiltered fan-out would push to people who declined or
+  **blocked** you. Directly tested.
+- **Group-only shares are skipped.** `share_received` says "someone sent you a song"; a
+  group post is not that, and Groups has no client UI any more.
+- **Reactions fire on ADD only.** Pushing on both edges of a toggle is a notification
+  machine gun.
+- **Reaction slugs are mapped to glyphs.** Reactions are stored as slugs (`fire`,
+  `mind_blown`), so the push body needed `REACTION_EMOJI` — "Sam reacted fire" is not a
+  sentence. Caught by a test, not by reading.
+- **Failed writes notify nobody.** `friends_request` only notifies when
+  `send_friend_request` returned True; a failed write must not tell the target someone tried.
+- **`author_create` listens are skipped** in `shares_listened` — that source is
+  `shares_create` marking its own author as a listener. `notify()` would suppress the
+  self-case anyway, but skipping early avoids a pointless profile read.
+- **Display names never leak an address.** `display_name_for` falls back to the email's
+  local part, so a lock screen shows "dominick", not "dominick@…".
+
+### NOT wired: `invites_create`
+
+An invite is a URL/code handed to someone who is not on the platform yet. There is no
+account to notify. `invite_received` stays in the registry for a future in-app invite
+flow, but no producer can fire it today.
+
+### DEFERRED: `admin_broadcasts_create`
+
+Broadcasting to every user means scanning the users table and fanning out inside a request
+handler — a timeout waiting to happen as the user base grows, and the admin gets no
+feedback when it stalls. It belongs behind an async invoke or a cron, alongside the B5
+producers. Moved to B5.

--- a/docs/features/notification-interaction-producers/PLAN.md
+++ b/docs/features/notification-interaction-producers/PLAN.md
@@ -1,0 +1,53 @@
+# Plan: notification-interaction-producers
+
+**Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
+**Sub-feature ID**: B4 (`notification-interaction-producers`)
+**Track**: B — Notifications Platform
+**Status**: Draft
+**Created**: 2026-08-24
+**Last updated**: 2026-08-24
+**Scope size**: TBD — run `/plan notification-interaction-producers` to size
+**Repo(s) touched**: `xomify-backend`
+**Branch**: `feature/notification-interaction-producers`
+**Wave**: 3
+**Depends on**: `B2`, `B3`
+
+---
+
+## Summary
+
+Wire notify() into the ten interaction lambdas that currently notify nobody.
+
+## Approach
+
+Every call fire-and-forget — a failed notification must never fail the interaction. Self-notification suppressed. shares_react keeps its existing queue_threshold latch and gains share_rated.
+
+## Affected Files / Components
+
+- `lambdas/shares_create/`
+- `lambdas/shares_comments_create/`
+- `lambdas/shares_reactions_toggle/`
+- `lambdas/shares_listened/`
+- `lambdas/shares_react/`
+- `lambdas/friends_request/`
+- `lambdas/friends_accept/`
+- `lambdas/invites_create/`
+- `lambdas/invites_accept/`
+- `lambdas/admin_broadcasts_create/`
+
+## Implementation Steps
+
+_Stub — not yet planned. Run `/plan notification-interaction-producers` to expand this into ordered, checkable steps._
+
+- [ ] TBD
+
+## Acceptance
+
+_Stub — define with `/plan notification-interaction-producers`._
+
+---
+
+## Epic context
+
+Locked decisions live in the epic plan and must not be re-litigated here. See
+`https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.

--- a/docs/features/notification-kind-registry/PLAN.md
+++ b/docs/features/notification-kind-registry/PLAN.md
@@ -1,0 +1,91 @@
+# Plan: notification-kind-registry
+
+**Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
+**Sub-feature ID**: B1 (`notification-kind-registry`)
+**Track**: B — Notifications Platform
+**Status**: Done
+**Created**: 2026-08-24
+**Last updated**: 2026-08-24
+**Scope size**: TBD — run `/plan notification-kind-registry` to size
+**Repo(s) touched**: `xomify-backend`
+**Branch**: `feature/notification-kind-registry`
+**Wave**: 1
+**Depends on**: _nothing — can start immediately_
+
+---
+
+## Summary
+
+Kind registry, the fail-open notify() helper, and the coalescing mechanism.
+
+## Approach
+
+Registry maps kind -> default opt-in, title/body template, deep-link route, section. `notify(kind, email, **ctx)` writes the inbox row, checks per-kind opt-in, async-invokes notifications_send. Fail-open, mirroring `record_notification`. Rewrite notifications_send to validate against the registry instead of its hardcoded VALID_KINDS / OPT_IN_FLAG_BY_KIND pair. Coalescing (decision 11): kinds may declare a coalesce_key + window; share_listened and share_rated share key (actorEmail, shareId) on a 10-minute window. Needs a short-TTL pending row plus a 5-minute sweeper — NOT the daily cron_rate_reminder schedule.
+
+## Affected Files / Components
+
+- `lambdas/common/notification_kinds.py (new)`
+- `lambdas/common/notify.py (new)`
+- `lambdas/notifications_send/handler.py`
+
+## Implementation Steps
+
+_Stub — not yet planned. Run `/plan notification-kind-registry` to expand this into ordered, checkable steps._
+
+- [ ] TBD
+
+## Acceptance
+
+_Stub — define with `/plan notification-kind-registry`._
+
+---
+
+## Epic context
+
+Locked decisions live in the epic plan and must not be re-litigated here. See
+`https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.
+
+
+---
+
+## Outcome
+
+Landed on `feature/notification-kind-registry`.
+
+| File | Change |
+|------|--------|
+| `lambdas/common/notification_kinds.py` | new — 16-kind registry |
+| `lambdas/common/notify.py` | new — fail-open dispatch helper + coalescing |
+| `lambdas/common/notification_pending_dynamo.py` | new — coalescing store |
+| `lambdas/cron_notification_sweeper/handler.py` | new — 5-minute sweeper |
+| `lambdas/notifications_send/handler.py` | rewired onto the registry |
+| `tests/test_notification_kinds.py` | new — 13 tests |
+| `tests/test_notify.py` | new — 12 tests |
+| `tests/conftest.py` | 4 notification env vars added |
+
+### Decisions taken during implementation
+
+- **A pending table, not APNs `collapse_id`.** Collapse-id replaces the notification
+  already in the tray, which fixes clutter but not the buzz — the second push still
+  alerts. Coalescing only means anything if the first event is *held back*, and holding
+  it requires somewhere to hold it.
+- **Coalescing degrades to immediate send.** B1 ships before B6 provisions the table, so
+  an unset `NOTIFICATION_PENDING_TABLE_NAME` falls through to sending uncoalesced. Losing
+  coalescing is cosmetic; losing the notification is not.
+- **Conditional write to claim the coalesce slot.** Two near-simultaneous events would
+  otherwise both park and neither would ever send. Only one can create the row; the loser
+  reads it back and merges.
+- **`digest` now defaults OFF.** The old code read *every* absent flag as `True`, so a
+  device row without `digestEnabled` was receiving a weekly push nobody opted into. This
+  is the one kind where that default is actively wrong. Documented in the registry.
+- **The sweeper needs its own 5-minute schedule.** It cannot ride `cron_rate_reminder`'s
+  daily rule — a daily sweep would hold a lone "Sam listened" for up to 24 hours, which is
+  worse than never sending it. Carried into B6.
+
+### Test environment finding (pre-existing, not caused by this work)
+
+The backend suite does not run on this machine: **50 failures and 74 collection errors on
+clean `master`**, all from `X | Y` union syntax (Python 3.10+) against a local Python
+3.9.6. CI runs 3.12 (`deploy-backend.yml`). The 25 tests added here pass locally because
+they only touch modules written with `Optional[...]`, but **the rest of this track's tests
+cannot be verified locally** — they need 3.12 installed, or CI.

--- a/docs/features/notification-kind-registry/PLAN.md
+++ b/docs/features/notification-kind-registry/PLAN.md
@@ -84,8 +84,20 @@ Landed on `feature/notification-kind-registry`.
 
 ### Test environment finding (pre-existing, not caused by this work)
 
-The backend suite does not run on this machine: **50 failures and 74 collection errors on
-clean `master`**, all from `X | Y` union syntax (Python 3.10+) against a local Python
-3.9.6. CI runs 3.12 (`deploy-backend.yml`). The 25 tests added here pass locally because
-they only touch modules written with `Optional[...]`, but **the rest of this track's tests
-cannot be verified locally** — they need 3.12 installed, or CI.
+The default `python3` on this machine is 3.9.6, and the repo uses `X | Y` unions
+(3.10+) — `lambdas/common/errors.py:261` among others. Under 3.9 the suite collapses to
+50 failures and 74 collection errors on clean `master`.
+
+**It does run**, via the already-installed `uv` and Homebrew `python3.13`:
+
+```
+uv run --python 3.13 --with pytest --with boto3 --with requests \
+       --with aiohttp --with pyjwt --with cryptography python -m pytest -q
+```
+
+`--with-requirements requirements.txt` does NOT work — the pinned `cffi` fails to
+compile against Python 3.13 headers here. The explicit `--with` list above avoids it.
+
+**True baseline on 3.13: 14 failed, 600 passed.** All 14 are pre-existing favorites
+failures, unrelated to this track. Worth adding the uv invocation to the repo README so
+the next person doesn't conclude the suite is broken.

--- a/docs/features/notification-per-type-prefs/PLAN.md
+++ b/docs/features/notification-per-type-prefs/PLAN.md
@@ -3,7 +3,7 @@
 **Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
 **Sub-feature ID**: B2 (`notification-per-type-prefs`)
 **Track**: B — Notifications Platform
-**Status**: Draft
+**Status**: Done
 **Created**: 2026-08-24
 **Last updated**: 2026-08-24
 **Scope size**: TBD — run `/plan notification-per-type-prefs` to size
@@ -43,3 +43,45 @@ _Stub — define with `/plan notification-per-type-prefs`._
 
 Locked decisions live in the epic plan and must not be re-litigated here. See
 `https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.
+
+---
+
+## Outcome
+
+Landed on `feature/notification-kind-registry` (same branch as B1 — they are one
+coherent change to the device-token contract).
+
+| File | Change |
+|------|--------|
+| `lambdas/common/notification_kinds.py` | `effective_preferences()`, `sanitize_preferences()`, `VALID_FLAGS` |
+| `lambdas/common/device_tokens_dynamo.py` | `upsert_token` writes flags sparsely, per-flag |
+| `lambdas/notifications_register/handler.py` | accepts `preferences` map; returns the effective map |
+| `tests/test_notification_preferences.py` | new — 10 tests |
+| `tests/test_notifications_register.py` | 3 tests updated for the new contract |
+
+### The invariant this sub-feature exists to protect
+
+**Registration writes only the flags the client actually sent.** A blanket write of all
+sixteen booleans would stamp today's defaults onto every device row, and
+`is_opted_in`'s absent-means-default fallback — the entire no-backfill migration story —
+would be dead the moment any client registered. Two tests defend this directly:
+`test_upsert_with_no_preferences_touches_no_flags` and
+`test_register_passes_only_explicit_flags_through`.
+
+### Deliberate contract changes
+
+- **Absent is no longer coerced to `True`.** `_as_bool` now returns `None` for a missing
+  flag, so "the client did not mention this" stays distinct from "the client said yes".
+  Three existing `notifications_register` tests asserted the old coercion and were updated.
+- **The response echoes stored state, not the request.** It returns the effective map read
+  back from the row (`ReturnValues="ALL_NEW"`), so one call renders all sixteen Settings
+  toggles without the client needing to know any defaults.
+- **Unknown flags are dropped, not written.** A client typo would otherwise persist as a
+  meaningless attribute forever — the row has no schema to reject it.
+
+### Implementation note
+
+Expression placeholders are indexed (`#p0`, `:p0`, …) rather than derived from the flag
+name. Several flags share a prefix, and DynamoDB requires unique expression names per
+statement — name-derived placeholders would collide.
+Covered by `test_flag_placeholders_are_unique`.

--- a/docs/features/notification-per-type-prefs/PLAN.md
+++ b/docs/features/notification-per-type-prefs/PLAN.md
@@ -1,0 +1,45 @@
+# Plan: notification-per-type-prefs
+
+**Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
+**Sub-feature ID**: B2 (`notification-per-type-prefs`)
+**Track**: B — Notifications Platform
+**Status**: Draft
+**Created**: 2026-08-24
+**Last updated**: 2026-08-24
+**Scope size**: TBD — run `/plan notification-per-type-prefs` to size
+**Repo(s) touched**: `xomify-backend`
+**Branch**: `feature/notification-per-type-prefs`
+**Wave**: 2
+**Depends on**: `B1`
+
+---
+
+## Summary
+
+One opt-in boolean per kind on the device-token record.
+
+## Approach
+
+Absent flag reads as the registry default, so existing rows keep working with no backfill (decision 3). notifications_register accepts the full preference map. 14 kinds across three sections — see the epic plan's B2 table.
+
+## Affected Files / Components
+
+- `lambdas/common/device_tokens_dynamo.py`
+- `lambdas/notifications_register/handler.py`
+
+## Implementation Steps
+
+_Stub — not yet planned. Run `/plan notification-per-type-prefs` to expand this into ordered, checkable steps._
+
+- [ ] TBD
+
+## Acceptance
+
+_Stub — define with `/plan notification-per-type-prefs`._
+
+---
+
+## Epic context
+
+Locked decisions live in the epic plan and must not be re-litigated here. See
+`https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.

--- a/lambdas/common/device_tokens_dynamo.py
+++ b/lambdas/common/device_tokens_dynamo.py
@@ -10,8 +10,10 @@ Table Structure:
 Attributes:
 - email / deviceToken (keys)
 - platform: "ios" (only platform supported in v1)
-- digestEnabled: bool (opt-in for weekly digest pushes)
-- queueNotificationsEnabled: bool (opt-in for threshold "N friends queued" pushes)
+- <kindFlag>: bool — one opt-in per notification kind. The full set is owned by
+  lambdas/common/notification_kinds.py; `digestEnabled` and
+  `queueNotificationsEnabled` are simply the two that existed first.
+  ABSENT means "use the registry default", never False — see is_opted_in.
 - createdAt / updatedAt: ISO8601 UTC timestamps
 - ttl: int (epoch seconds — DynamoDB TTL auto-prunes dormant tokens after ~180 days)
 """
@@ -50,43 +52,74 @@ def _ttl_epoch(days: int = TOKEN_TTL_DAYS) -> int:
 def upsert_token(
     email: str,
     device_token: str,
-    digest_enabled: bool = True,
-    queue_notifications_enabled: bool = True,
+    digest_enabled: Optional[bool] = None,
+    queue_notifications_enabled: Optional[bool] = None,
     platform: str = DEFAULT_PLATFORM,
+    preferences: Optional[dict] = None,
 ) -> dict[str, Any]:
-    """Create or update a device-token row. Idempotent."""
+    """
+    Create or update a device-token row. Idempotent.
+
+    PARTIAL BY DESIGN. Only the flags actually supplied are written; anything
+    absent is left exactly as it was. That matters because a device row stores
+    only the flags it has been told about, and an absent flag is what makes
+    `notification_kinds.is_opted_in` fall back to the registry default. A
+    blanket write of all sixteen booleans would freeze today's defaults onto
+    every row and destroy that migration path forever.
+
+    `digest_enabled` / `queue_notifications_enabled` are the legacy positional
+    kwargs from the two-kind era. They still work — older clients send exactly
+    those two — and fold into `preferences`.
+    """
+    prefs: dict[str, bool] = dict(preferences or {})
+    if digest_enabled is not None:
+        prefs["digestEnabled"] = bool(digest_enabled)
+    if queue_notifications_enabled is not None:
+        prefs["queueNotificationsEnabled"] = bool(queue_notifications_enabled)
+
     try:
         table = dynamodb.Table(DEVICE_TOKENS_TABLE_NAME)
         now_iso = _iso_now()
 
+        set_parts = [
+            "#platform = :platform",
+            "#updatedAt = :now",
+            "#ttl = :ttl",
+            "#createdAt = if_not_exists(#createdAt, :now)",
+        ]
+        names = {
+            "#platform": "platform",
+            "#updatedAt": "updatedAt",
+            "#ttl": "ttl",
+            "#createdAt": "createdAt",
+        }
+        values: dict[str, Any] = {
+            ":platform": platform,
+            ":now": now_iso,
+            ":ttl": _ttl_epoch(),
+        }
+
+        # Placeholders are indexed rather than derived from the flag name —
+        # several flags share a prefix, and DynamoDB expression names have to
+        # be unique per expression.
+        for index, (flag, enabled) in enumerate(sorted(prefs.items())):
+            name_ref = f"#p{index}"
+            value_ref = f":p{index}"
+            set_parts.append(f"{name_ref} = {value_ref}")
+            names[name_ref] = flag
+            values[value_ref] = bool(enabled)
+
         response = table.update_item(
             Key={"email": email, "deviceToken": device_token},
-            UpdateExpression=(
-                "SET #platform = :platform, "
-                "#digestEnabled = :digestEnabled, "
-                "#queueNotificationsEnabled = :queueNotificationsEnabled, "
-                "#updatedAt = :now, "
-                "#ttl = :ttl, "
-                "#createdAt = if_not_exists(#createdAt, :now)"
-            ),
-            ExpressionAttributeNames={
-                "#platform": "platform",
-                "#digestEnabled": "digestEnabled",
-                "#queueNotificationsEnabled": "queueNotificationsEnabled",
-                "#updatedAt": "updatedAt",
-                "#ttl": "ttl",
-                "#createdAt": "createdAt",
-            },
-            ExpressionAttributeValues={
-                ":platform": platform,
-                ":digestEnabled": digest_enabled,
-                ":queueNotificationsEnabled": queue_notifications_enabled,
-                ":now": now_iso,
-                ":ttl": _ttl_epoch(),
-            },
+            UpdateExpression="SET " + ", ".join(set_parts),
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
             ReturnValues="ALL_NEW",
         )
-        log.info(f"Device token upserted for {email} (platform={platform})")
+        log.info(
+            f"Device token upserted for {email} "
+            f"(platform={platform}, flags={sorted(prefs)})"
+        )
         return response.get("Attributes", {})
     except Exception as err:
         log.error(f"Upsert Token failed: {err}")

--- a/lambdas/common/notification_kinds.py
+++ b/lambdas/common/notification_kinds.py
@@ -30,6 +30,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from lambdas.common.logger import get_logger
+
+log = get_logger(__file__)
+
 
 # ── Sections ────────────────────────────────────────────────────────────
 # Purely a presentation grouping for the Settings screens (iOS + web). The
@@ -291,6 +295,40 @@ def get_kind(key: str) -> Optional[NotificationKind]:
 def default_preferences() -> dict[str, bool]:
     """The preference map a brand-new device registration starts from."""
     return {k.opt_in_flag: k.default_opt_in for k in _KINDS}
+
+
+VALID_FLAGS: frozenset[str] = frozenset(k.opt_in_flag for k in _KINDS)
+
+
+def effective_preferences(token_row: dict) -> dict[str, bool]:
+    """
+    The full preference map for one device, defaults filled in.
+
+    A device row only ever stores the flags it has actually been told about.
+    This is what turns that sparse row into the complete picture a Settings
+    screen needs to render sixteen toggles.
+    """
+    return {k.opt_in_flag: is_opted_in(token_row, k) for k in _KINDS}
+
+
+def sanitize_preferences(raw: dict) -> dict[str, bool]:
+    """
+    Keep only flags this registry knows about, coerced to bool.
+
+    Unknown keys are DROPPED rather than written through. A client typo would
+    otherwise persist a junk attribute forever — the row has no schema to
+    reject it, and it would sit there looking meaningful.
+    """
+    clean: dict[str, bool] = {}
+    for key, value in (raw or {}).items():
+        if key not in VALID_FLAGS:
+            log.warning(f"ignoring unknown notification flag '{key}'")
+            continue
+        if isinstance(value, str):
+            clean[key] = value.strip().lower() in {"true", "1", "yes"}
+        else:
+            clean[key] = bool(value)
+    return clean
 
 
 def is_opted_in(token_row: dict, kind: NotificationKind) -> bool:

--- a/lambdas/common/notification_kinds.py
+++ b/lambdas/common/notification_kinds.py
@@ -1,0 +1,321 @@
+"""
+XOMIFY Notification Kind Registry
+=================================
+One place that answers, for every notification the product can send:
+
+  - what it is called on the wire (`key`)
+  - which per-device opt-in flag gates it
+  - whether it is on by default for a device that has never heard of it
+  - how its title / body / deep link are worded
+  - which Settings section it appears under
+  - whether it coalesces with a sibling kind
+
+WHY THIS EXISTS: before it, `notifications_send` carried a hardcoded
+`VALID_KINDS` set and an `OPT_IN_FLAG_BY_KIND` dict, and every producer wrote
+its own title and body inline. That was survivable at two kinds. At sixteen it
+means sixteen places to get the copy wrong and no way to answer "what can this
+app send me?" without grepping.
+
+OPT-IN DEFAULTS: an absent flag on a device-token row reads as this registry's
+`default_opt_in`. That is what lets the fourteen new kinds ship with NO
+backfill — existing rows simply inherit the defaults.
+
+The two pre-existing kinds (`queue_threshold`, `digest`) keep their exact
+wire keys and their exact flag names. Renaming either would silently opt every
+existing device out of something it had already chosen.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+# ── Sections ────────────────────────────────────────────────────────────
+# Purely a presentation grouping for the Settings screens (iOS + web). The
+# toggles are per-KIND, not per-section (see the epic plan, decision 3).
+SECTION_SHARES = "shares_social"
+SECTION_DROPS = "playlist_drops"
+SECTION_REMINDERS = "reminders_updates"
+
+SECTION_LABELS = {
+    SECTION_SHARES: "Shares & Social",
+    SECTION_DROPS: "Playlist Drops",
+    SECTION_REMINDERS: "Reminders & Updates",
+}
+
+SECTION_ORDER = [SECTION_SHARES, SECTION_DROPS, SECTION_REMINDERS]
+
+
+# ── Coalescing ──────────────────────────────────────────────────────────
+# Kinds sharing a `coalesce_group` AND the same subject collapse into one push
+# when they land inside `coalesce_window_s` of each other. Today that is
+# exactly share_listened + share_rated: one person hitting play and then
+# rating is ONE act of engagement, and buzzing the sender twice for it is how
+# you teach them to mute the app.
+COALESCE_SHARE_ENGAGE = "share_engage"
+COALESCE_WINDOW_S = 600  # 10 minutes — epic plan, decision 11
+
+
+@dataclass(frozen=True)
+class NotificationKind:
+    key: str
+    section: str
+    #: Attribute name on the xomify-device-tokens row.
+    opt_in_flag: str
+    default_opt_in: bool
+    #: `str.format(**ctx)` templates. Producers supply the context.
+    title: str
+    body: str
+    #: Deep-link route template handed to the clients as customData.route.
+    #: Client-side parsing already understands "share:<id>" and "invite:<code>".
+    route: Optional[str] = None
+    coalesce_group: Optional[str] = None
+    #: Wording used when this kind is merged with its coalesce sibling.
+    merged_title: Optional[str] = None
+    merged_body: Optional[str] = None
+    #: Human label for the Settings row.
+    label: str = ""
+    description: str = ""
+
+
+_KINDS: tuple[NotificationKind, ...] = (
+    # ── Shares & Social ─────────────────────────────────────────────────
+    NotificationKind(
+        key="share_received",
+        section=SECTION_SHARES,
+        opt_in_flag="shareReceivedEnabled",
+        default_opt_in=True,
+        title="{actor_name} sent you a song",
+        body="{track_name} — {artist_name}",
+        route="share:{share_id}",
+        label="Someone shares a song",
+        description="When a friend sends you a track.",
+    ),
+    NotificationKind(
+        key="share_comment",
+        section=SECTION_SHARES,
+        opt_in_flag="shareCommentEnabled",
+        default_opt_in=True,
+        title="{actor_name} commented",
+        body="{comment_preview}",
+        route="share:{share_id}",
+        label="Comments on your share",
+        description="When someone replies on a song you sent.",
+    ),
+    NotificationKind(
+        key="share_reaction",
+        section=SECTION_SHARES,
+        opt_in_flag="shareReactionEnabled",
+        default_opt_in=True,
+        title="{actor_name} reacted {emoji}",
+        body="on {track_name}",
+        route="share:{share_id}",
+        label="Reactions on your share",
+        description="When someone reacts to a song you sent.",
+    ),
+    NotificationKind(
+        key="share_listened",
+        section=SECTION_SHARES,
+        opt_in_flag="shareListenedEnabled",
+        default_opt_in=True,
+        title="{actor_name} listened",
+        body="to {track_name}",
+        route="share:{share_id}",
+        coalesce_group=COALESCE_SHARE_ENGAGE,
+        merged_title="{actor_name} listened and rated {stars}",
+        merged_body="{track_name} — {artist_name}",
+        label="Someone listens to your song",
+        description="When a friend plays a track you sent.",
+    ),
+    NotificationKind(
+        key="share_rated",
+        section=SECTION_SHARES,
+        opt_in_flag="shareRatedEnabled",
+        default_opt_in=True,
+        title="{actor_name} rated {stars}",
+        body="{track_name} — {artist_name}",
+        route="share:{share_id}",
+        coalesce_group=COALESCE_SHARE_ENGAGE,
+        merged_title="{actor_name} listened and rated {stars}",
+        merged_body="{track_name} — {artist_name}",
+        label="Someone rates your song",
+        description="When a friend scores a track you sent.",
+    ),
+    # PRE-EXISTING — key and flag name are load-bearing, do not rename.
+    NotificationKind(
+        key="queue_threshold",
+        section=SECTION_SHARES,
+        opt_in_flag="queueNotificationsEnabled",
+        default_opt_in=True,
+        title="Your share is heating up",
+        body="{reactor_count} friends have queued {track_name}",
+        route="share:{share_id}",
+        label="Your share takes off",
+        description="When several friends queue the same song you sent.",
+    ),
+    NotificationKind(
+        key="friend_request",
+        section=SECTION_SHARES,
+        opt_in_flag="friendRequestEnabled",
+        default_opt_in=True,
+        title="{actor_name} wants to be friends",
+        body="Tap to accept or decline.",
+        route="friends",
+        label="Friend requests",
+        description="When someone sends you a friend request.",
+    ),
+    NotificationKind(
+        key="friend_accepted",
+        section=SECTION_SHARES,
+        opt_in_flag="friendAcceptedEnabled",
+        default_opt_in=True,
+        title="{actor_name} accepted your request",
+        body="You're now friends on Xomify.",
+        route="friend:{actor_email}",
+        label="Friend requests accepted",
+        description="When someone accepts your friend request.",
+    ),
+    NotificationKind(
+        key="invite_received",
+        section=SECTION_SHARES,
+        opt_in_flag="inviteReceivedEnabled",
+        default_opt_in=True,
+        title="{actor_name} invited you",
+        body="Join them on Xomify.",
+        route="invite:{invite_code}",
+        label="Invites",
+        description="When someone invites you to Xomify.",
+    ),
+    NotificationKind(
+        key="invite_accepted",
+        section=SECTION_SHARES,
+        opt_in_flag="inviteAcceptedEnabled",
+        default_opt_in=True,
+        title="{actor_name} joined",
+        body="Your invite was accepted.",
+        route="friends",
+        label="Invites accepted",
+        description="When someone takes up your invite.",
+    ),
+    # ── Playlist Drops ──────────────────────────────────────────────────
+    # These carry the SNEAK PEEK: the body names the top track so the push is
+    # worth reading on its own, and the route opens the playlist directly.
+    NotificationKind(
+        key="wrapped_drop",
+        section=SECTION_DROPS,
+        opt_in_flag="wrappedDropEnabled",
+        default_opt_in=True,
+        title="Your {month} Wrapped is ready",
+        body="Starting with {track_name} — {artist_name}",
+        route="wrapped:{playlist_id}",
+        label="Monthly Wrapped is ready",
+        description="When your Wrapped playlist is generated.",
+    ),
+    NotificationKind(
+        key="release_radar_drop",
+        section=SECTION_DROPS,
+        opt_in_flag="releaseRadarDropEnabled",
+        default_opt_in=True,
+        title="New releases this week",
+        body="{release_count} from artists you follow, including {track_name}",
+        route="release_radar:{playlist_id}",
+        label="Release Radar is ready",
+        description="When your weekly Release Radar is generated.",
+    ),
+    # ── Reminders & Updates ─────────────────────────────────────────────
+    NotificationKind(
+        key="rate_reminder",
+        section=SECTION_REMINDERS,
+        opt_in_flag="rateReminderEnabled",
+        default_opt_in=True,
+        title="Still haven't heard {track_name}?",
+        body="{actor_name} sent it yesterday.",
+        route="share:{share_id}",
+        label="Reminders to listen & rate",
+        description="A single nudge, a day after a song lands unplayed.",
+    ),
+    NotificationKind(
+        key="favorites_reminder",
+        section=SECTION_REMINDERS,
+        opt_in_flag="favoritesReminderEnabled",
+        default_opt_in=True,
+        title="Set your {year} favorites",
+        body="Lock in your top songs, albums and artists for the year.",
+        route="favorites",
+        label="Year-end favorites",
+        description="A yearly nudge to record your favorites.",
+    ),
+    # PRE-EXISTING — key and flag name are load-bearing, do not rename.
+    #
+    # DELIBERATE BEHAVIOUR CHANGE: the old notifications_send read every absent
+    # flag as `True` (`row.get(opt_in_flag, True)`), so a device row without
+    # `digestEnabled` was silently receiving a weekly digest nobody asked for.
+    # This is the one kind where that default is wrong — it is the most
+    # annoyable notification in the set, and a weekly unsolicited push is how
+    # an app gets muted wholesale. The iOS client has always sent the flag
+    # explicitly from its Settings toggle, so rows lacking it are legacy only.
+    NotificationKind(
+        key="digest",
+        section=SECTION_REMINDERS,
+        opt_in_flag="digestEnabled",
+        default_opt_in=False,
+        title="Your weekly Xomify digest",
+        body="{summary}",
+        route="shares",
+        label="Weekly digest",
+        description="A weekly summary of shares and activity.",
+    ),
+    NotificationKind(
+        key="broadcast",
+        section=SECTION_REMINDERS,
+        opt_in_flag="broadcastEnabled",
+        default_opt_in=True,
+        title="{broadcast_title}",
+        body="{broadcast_body}",
+        route="home",
+        label="App updates",
+        description="Occasional announcements about Xomify itself.",
+    ),
+)
+
+BY_KEY: dict[str, NotificationKind] = {k.key: k for k in _KINDS}
+ALL_KINDS: tuple[NotificationKind, ...] = _KINDS
+VALID_KINDS: frozenset[str] = frozenset(BY_KEY)
+
+
+def get_kind(key: str) -> Optional[NotificationKind]:
+    return BY_KEY.get(key)
+
+
+def default_preferences() -> dict[str, bool]:
+    """The preference map a brand-new device registration starts from."""
+    return {k.opt_in_flag: k.default_opt_in for k in _KINDS}
+
+
+def is_opted_in(token_row: dict, kind: NotificationKind) -> bool:
+    """
+    Read one opt-in decision off a device-token row.
+
+    An ABSENT flag falls back to the registry default rather than to False.
+    That is the whole migration story: rows written before a kind existed keep
+    working, and nobody has to backfill fourteen booleans across every device.
+    """
+    value = token_row.get(kind.opt_in_flag)
+    if value is None:
+        return kind.default_opt_in
+    return bool(value)
+
+
+def render(template: str, ctx: dict) -> str:
+    """
+    Fill a title/body template.
+
+    Deliberately forgiving: a producer that forgets a key gets the placeholder
+    left in place rather than a KeyError that takes the whole interaction down
+    with it. Notification copy is never worth failing a write over.
+    """
+    try:
+        return template.format(**ctx)
+    except (KeyError, IndexError, ValueError):
+        return template

--- a/lambdas/common/notification_pending_dynamo.py
+++ b/lambdas/common/notification_pending_dynamo.py
@@ -1,0 +1,178 @@
+"""
+XOMIFY Pending (Coalescing) Notifications
+=========================================
+Backs the coalescing window described in the relaunch epic, decision 11.
+
+Table: xomify-notification-pending
+- PK  `coalesceKey` [S]  — "<recipient>#<group>#<subject>"
+- attrs: kind, ctx (map), recipientEmail, createdAt (ISO), expiresAt (epoch),
+         ttl (epoch, = expiresAt + slack)
+
+WHY A TABLE AND NOT APNs `collapse_id`: collapse-id replaces the notification
+already sitting in the tray, which fixes the CLUTTER but not the BUZZ — the
+second push still alerts. The whole point of coalescing here is that one act
+of engagement (play, then rate) produces one interruption. That requires
+holding the first event back, which requires somewhere to hold it.
+
+FAIL-OPEN: every function here returns a sentinel rather than raising. If this
+table is unreachable — or not yet provisioned, since B6 lands after B1 — the
+caller falls back to dispatching immediately. Losing coalescing is a cosmetic
+regression; losing the notification is not.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from lambdas.common.constants import AWS_DEFAULT_REGION
+from lambdas.common.logger import get_logger
+
+import os
+
+log = get_logger(__file__)
+
+NOTIFICATION_PENDING_TABLE_NAME = os.environ.get(
+    "NOTIFICATION_PENDING_TABLE_NAME", ""
+)
+
+#: Grace on top of the coalesce window before DynamoDB TTL reaps the row. The
+#: sweeper needs a chance to see an expired row and dispatch it; TTL deletion
+#: is only "within 48 hours" anyway, so this is belt-and-braces.
+TTL_SLACK_S = 3600
+
+_dynamodb = boto3.resource("dynamodb", region_name=AWS_DEFAULT_REGION)
+
+
+def _table():
+    if not NOTIFICATION_PENDING_TABLE_NAME:
+        return None
+    return _dynamodb.Table(NOTIFICATION_PENDING_TABLE_NAME)
+
+
+def coalesce_key(recipient_email: str, group: str, subject_id: str) -> str:
+    return f"{recipient_email}#{group}#{subject_id}"
+
+
+def claim_or_merge(
+    *,
+    key: str,
+    kind: str,
+    recipient_email: str,
+    ctx: dict[str, Any],
+    window_s: int,
+) -> Optional[dict[str, Any]]:
+    """
+    Try to park this notification for `window_s`.
+
+    Returns:
+        None                     — parked. Caller must NOT dispatch; either the
+                                   sibling event merges with it, or the sweeper
+                                   sends it once the window lapses.
+        {"merged": True, ...}    — a sibling was already parked. The row has
+                                   been deleted and the merged context returned;
+                                   caller dispatches ONE push covering both.
+        {"merged": False, ...}   — coalescing unavailable (no table, or DynamoDB
+                                   refused). Caller dispatches immediately.
+
+    The conditional write is what makes two near-simultaneous events safe: only
+    one can create the row, so the loser reads it back and merges rather than
+    both parking and neither ever sending.
+    """
+    table = _table()
+    if table is None:
+        log.warning("NOTIFICATION_PENDING_TABLE_NAME unset — coalescing disabled")
+        return {"merged": False, "ctx": ctx, "kinds": [kind]}
+
+    now = int(time.time())
+    expires_at = now + window_s
+
+    try:
+        table.put_item(
+            Item={
+                "coalesceKey": key,
+                "kind": kind,
+                "recipientEmail": recipient_email,
+                "ctx": ctx,
+                "createdAt": datetime.now(timezone.utc).isoformat(),
+                "expiresAt": expires_at,
+                "ttl": expires_at + TTL_SLACK_S,
+            },
+            ConditionExpression="attribute_not_exists(coalesceKey)",
+        )
+        return None
+    except ClientError as err:
+        if err.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
+            log.error(f"coalesce claim failed for {key}: {err} — dispatching uncoalesced")
+            return {"merged": False, "ctx": ctx, "kinds": [kind]}
+
+    # Someone got there first. Take the row and merge.
+    try:
+        existing = table.delete_item(
+            Key={"coalesceKey": key},
+            ReturnValues="ALL_OLD",
+        ).get("Attributes")
+    except ClientError as err:
+        log.error(f"coalesce merge-delete failed for {key}: {err} — dispatching uncoalesced")
+        return {"merged": False, "ctx": ctx, "kinds": [kind]}
+
+    if not existing:
+        # Raced with the sweeper, which already sent the parked one. Ours is
+        # then a genuine second event and dispatches on its own.
+        return {"merged": False, "ctx": ctx, "kinds": [kind]}
+
+    prior_ctx = dict(existing.get("ctx") or {})
+    prior_kind = existing.get("kind")
+    # The later event's context wins on conflict — a rating arriving after a
+    # listen carries the star count, which is the more informative of the two.
+    merged_ctx = {**prior_ctx, **ctx}
+    return {
+        "merged": True,
+        "ctx": merged_ctx,
+        "kinds": [k for k in (prior_kind, kind) if k],
+    }
+
+
+def take_expired(limit: int = 200) -> list[dict[str, Any]]:
+    """
+    Claim pending rows whose window has lapsed, for the sweeper to dispatch.
+
+    Each row is deleted as it is taken, so two overlapping sweeper runs cannot
+    both send the same notification.
+    """
+    table = _table()
+    if table is None:
+        return []
+
+    now = int(time.time())
+    taken: list[dict[str, Any]] = []
+
+    try:
+        scan_kwargs: dict[str, Any] = {"Limit": limit}
+        response = table.scan(**scan_kwargs)
+        candidates = [
+            item for item in response.get("Items", [])
+            if int(item.get("expiresAt", 0)) <= now
+        ]
+    except ClientError as err:
+        log.error(f"pending scan failed: {err}")
+        return []
+
+    for item in candidates:
+        try:
+            claimed = table.delete_item(
+                Key={"coalesceKey": item["coalesceKey"]},
+                ConditionExpression="attribute_exists(coalesceKey)",
+                ReturnValues="ALL_OLD",
+            ).get("Attributes")
+        except ClientError:
+            # Lost the race to another sweeper run — fine, it will send it.
+            continue
+        if claimed:
+            taken.append(claimed)
+
+    return taken

--- a/lambdas/common/notifications_dynamo.py
+++ b/lambdas/common/notifications_dynamo.py
@@ -1,0 +1,255 @@
+"""
+XOMIFY Notifications Inbox
+==========================
+Per-user notification feed with read state.
+
+Table: xomify-notifications
+- PK  `email` [S]
+- SK  `tsId`  [S]  — "<iso8601 ts>#<rand8>"
+- attrs: kind, title, body, route, actorEmail, actorName, imageUrl,
+         read (bool), createdAt (ISO), ttl (epoch, 90 days)
+
+WHY NOT REUSE xomify-notification-log: that table is PK `day`, read by full
+scan, and exists to answer "what did we send yesterday?" for the admin view. A
+per-user inbox needs the opposite access pattern — one user's items, newest
+first, cheaply, with mutable read state. Bolting a GSA on `toEmail` onto a
+send-log would give a send-log with an index, not an inbox. Both tables stay.
+
+The SK sorts lexicographically, and ISO8601 sorts chronologically, so a
+descending query IS newest-first with no sort key gymnastics. The `#<rand8>`
+suffix only exists to keep two notifications written in the same millisecond
+from colliding.
+
+FAIL-OPEN, like everything else on this path: a failed inbox write must not
+stop the push going out. Callers get False, not an exception.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+from lambdas.common.constants import AWS_DEFAULT_REGION
+from lambdas.common.logger import get_logger
+
+log = get_logger(__file__)
+
+NOTIFICATIONS_TABLE_NAME = os.environ.get("NOTIFICATIONS_TABLE_NAME", "")
+
+RETENTION_DAYS = 90
+#: Hard ceiling on one page. Guards against a client asking for everything.
+MAX_PAGE = 50
+DEFAULT_PAGE = 25
+#: Cap on a mark-all sweep. Beyond this the client should page and re-call —
+#: an unbounded update loop in a lambda is how you find the 15-minute timeout.
+MAX_MARK_ALL = 300
+
+_dynamodb = boto3.resource("dynamodb", region_name=AWS_DEFAULT_REGION)
+
+
+def _table():
+    if not NOTIFICATIONS_TABLE_NAME:
+        return None
+    return _dynamodb.Table(NOTIFICATIONS_TABLE_NAME)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ttl_epoch() -> int:
+    return int((datetime.now(timezone.utc) + timedelta(days=RETENTION_DAYS)).timestamp())
+
+
+def build_ts_id(created_at: Optional[str] = None) -> str:
+    return f"{created_at or _now_iso()}#{uuid.uuid4().hex[:8]}"
+
+
+def put_notification(
+    *,
+    email: str,
+    kind: str,
+    title: str,
+    body: str,
+    route: Optional[str] = None,
+    actor_email: Optional[str] = None,
+    actor_name: Optional[str] = None,
+    image_url: Optional[str] = None,
+) -> bool:
+    """Write one inbox row. Returns False on failure rather than raising."""
+    table = _table()
+    if table is None:
+        log.warning("NOTIFICATIONS_TABLE_NAME unset — inbox write skipped")
+        return False
+    if not email:
+        return False
+
+    created_at = _now_iso()
+    item: dict[str, Any] = {
+        "email": email,
+        "tsId": build_ts_id(created_at),
+        "kind": kind,
+        "title": title,
+        "body": body,
+        "read": False,
+        "createdAt": created_at,
+        "ttl": _ttl_epoch(),
+    }
+    for key, value in (
+        ("route", route),
+        ("actorEmail", actor_email),
+        ("actorName", actor_name),
+        ("imageUrl", image_url),
+    ):
+        if value:
+            item[key] = value
+
+    try:
+        table.put_item(Item=item)
+        return True
+    except Exception as err:  # noqa: BLE001 — fail-open
+        log.error(f"inbox write failed for {email}: {err}")
+        return False
+
+
+def list_notifications(
+    email: str,
+    limit: int = DEFAULT_PAGE,
+    cursor: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    One page of a user's inbox, newest first.
+
+    `cursor` is the `tsId` of the last item the client already has. Because the
+    SK is the sort key and it is time-ordered, paging is a plain
+    `ExclusiveStartKey` — no filtering, no scanning past what was returned.
+    """
+    table = _table()
+    if table is None:
+        return {"items": [], "nextCursor": None}
+
+    limit = max(1, min(int(limit or DEFAULT_PAGE), MAX_PAGE))
+
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("email").eq(email),
+        "ScanIndexForward": False,   # newest first
+        "Limit": limit,
+    }
+    if cursor:
+        kwargs["ExclusiveStartKey"] = {"email": email, "tsId": cursor}
+
+    try:
+        response = table.query(**kwargs)
+    except Exception as err:  # noqa: BLE001
+        log.error(f"inbox query failed for {email}: {err}")
+        return {"items": [], "nextCursor": None}
+
+    items = response.get("Items", [])
+    last_key = response.get("LastEvaluatedKey")
+    return {
+        "items": items,
+        "nextCursor": last_key.get("tsId") if last_key else None,
+    }
+
+
+def count_unread(email: str) -> int:
+    """
+    Unread count for the badge.
+
+    Uses `Select=COUNT` with a filter, so nothing is transferred back — but note
+    a filter is applied AFTER the read, so this still reads the partition. At
+    90-day retention and one user's traffic that is cheap; if it ever stops
+    being cheap, the fix is a sparse GSI keyed on unread items, not a bigger
+    page size.
+    """
+    table = _table()
+    if table is None:
+        return 0
+
+    total = 0
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("email").eq(email),
+        "FilterExpression": "#r = :false",
+        "ExpressionAttributeNames": {"#r": "read"},
+        "ExpressionAttributeValues": {":false": False},
+        "Select": "COUNT",
+    }
+
+    try:
+        while True:
+            response = table.query(**kwargs)
+            total += int(response.get("Count", 0))
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            kwargs["ExclusiveStartKey"] = last_key
+    except Exception as err:  # noqa: BLE001
+        log.error(f"unread count failed for {email}: {err}")
+        return total
+
+    return total
+
+
+def mark_read(email: str, ts_id: str) -> bool:
+    """Mark one item read. Idempotent."""
+    table = _table()
+    if table is None or not ts_id:
+        return False
+    try:
+        table.update_item(
+            Key={"email": email, "tsId": ts_id},
+            UpdateExpression="SET #r = :true",
+            ExpressionAttributeNames={"#r": "read"},
+            ExpressionAttributeValues={":true": True},
+            # Do not resurrect a row that TTL already reaped.
+            ConditionExpression="attribute_exists(tsId)",
+        )
+        return True
+    except Exception as err:  # noqa: BLE001
+        log.warning(f"mark_read failed for {email}/{ts_id}: {err}")
+        return False
+
+
+def mark_all_read(email: str) -> int:
+    """
+    Mark every unread item read. Returns how many were updated.
+
+    Bounded by MAX_MARK_ALL: an unbounded update loop is how a lambda finds its
+    timeout. A user with more than that many unread items marks the rest on a
+    second call, which is a far better failure mode than a half-finished sweep
+    that reports success.
+    """
+    table = _table()
+    if table is None:
+        return 0
+
+    updated = 0
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("email").eq(email),
+        "FilterExpression": "#r = :false",
+        "ExpressionAttributeNames": {"#r": "read"},
+        "ExpressionAttributeValues": {":false": False},
+        "ProjectionExpression": "tsId",
+    }
+
+    try:
+        while updated < MAX_MARK_ALL:
+            response = table.query(**kwargs)
+            for row in response.get("Items", []):
+                if updated >= MAX_MARK_ALL:
+                    break
+                if mark_read(email, row.get("tsId", "")):
+                    updated += 1
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            kwargs["ExclusiveStartKey"] = last_key
+    except Exception as err:  # noqa: BLE001
+        log.error(f"mark_all_read failed for {email}: {err}")
+
+    return updated

--- a/lambdas/common/notify.py
+++ b/lambdas/common/notify.py
@@ -269,3 +269,30 @@ def notify_friends_of(
     for recipient in emails:
         notify(kind_key, recipient, actor_email=actor_email, **ctx)
     return len(emails)
+
+
+def sneak_peek(raw_track: Optional[dict]) -> dict[str, Any]:
+    """
+    Pull the human-facing bits out of a raw Spotify track object.
+
+    This is what makes a playlist-drop push worth reading. "Your March Wrapped
+    is ready" is an announcement; "Starting with Midnight City — M83" is a
+    reason to tap. Returns empty strings rather than None so the templates
+    render something rather than the literal placeholder.
+    """
+    if not isinstance(raw_track, dict):
+        return {"track_name": "", "artist_name": "", "image_url": None}
+
+    artists = raw_track.get("artists") or []
+    artist_name = ""
+    if artists and isinstance(artists[0], dict):
+        artist_name = artists[0].get("name") or ""
+
+    images = ((raw_track.get("album") or {}).get("images")) or []
+    image_url = images[0].get("url") if images and isinstance(images[0], dict) else None
+
+    return {
+        "track_name": raw_track.get("name") or "",
+        "artist_name": artist_name,
+        "image_url": image_url,
+    }

--- a/lambdas/common/notify.py
+++ b/lambdas/common/notify.py
@@ -6,8 +6,14 @@ The single entry point every producer uses:
     from lambdas.common.notify import notify
     notify("share_received", recipient_email, actor_email=sender, share_id=..., ...)
 
-It resolves the kind from the registry, renders title/body/route, applies
-coalescing where the kind asks for it, and async-invokes `notifications_send`.
+It resolves the kind from the registry, renders title/body/route, writes the
+inbox row, applies coalescing where the kind asks for it, and async-invokes
+`notifications_send`.
+
+INBOX AND PUSH ARE INDEPENDENT. The inbox row is written even when the device
+has that kind muted, and even when the user has no device at all — muting a
+push means "do not interrupt me", not "hide this from my history". Web has no
+APNs token at all and would otherwise have an permanently empty inbox.
 
 TWO RULES, both non-negotiable:
 
@@ -40,6 +46,7 @@ from lambdas.common.notification_pending_dynamo import (
     claim_or_merge,
     coalesce_key,
 )
+from lambdas.common.notifications_dynamo import put_notification
 
 log = get_logger(__file__)
 
@@ -126,22 +133,39 @@ def _dispatch(
     *,
     merged: bool,
 ) -> None:
-    """Render and async-invoke notifications_send."""
+    """Write the inbox row, then async-invoke notifications_send."""
+    title_tpl = (kind.merged_title if merged and kind.merged_title else kind.title)
+    body_tpl = (kind.merged_body if merged and kind.merged_body else kind.body)
+
+    title = render(title_tpl, ctx)
+    body_text = render(body_tpl, ctx)
+    route = render(kind.route, ctx) if kind.route else None
+
+    # Inbox first, and unconditionally — see the module docstring. A user with
+    # this kind muted, or on web with no APNs token at all, still gets history.
+    put_notification(
+        email=recipient_email,
+        kind=kind.key,
+        title=title,
+        body=body_text,
+        route=route,
+        actor_email=ctx.get("actor_email"),
+        actor_name=ctx.get("actor_name"),
+        image_url=ctx.get("image_url"),
+    )
+
     if not NOTIFICATIONS_SEND_FUNCTION_NAME:
         log.warning("NOTIFICATIONS_SEND_FUNCTION_NAME unset — skipping push")
         return
 
-    title_tpl = (kind.merged_title if merged and kind.merged_title else kind.title)
-    body_tpl = (kind.merged_body if merged and kind.merged_body else kind.body)
-
     event: dict[str, Any] = {
         "kind": kind.key,
         "email": recipient_email,
-        "title": render(title_tpl, ctx),
-        "body": render(body_tpl, ctx),
+        "title": title,
+        "body": body_text,
         "customData": {
             **{k: v for k, v in ctx.items() if v is not None},
-            "route": render(kind.route, ctx) if kind.route else None,
+            "route": route,
             "pushType": kind.key,
         },
     }

--- a/lambdas/common/notify.py
+++ b/lambdas/common/notify.py
@@ -195,3 +195,77 @@ def dispatch_pending(row: dict[str, Any]) -> None:
         log.error(f"dispatch_pending: unusable row {row!r}")
         return
     _dispatch(kind, recipient, dict(row.get("ctx") or {}), merged=False)
+
+
+# ── Producer helpers ────────────────────────────────────────────────────
+
+#: Ceiling on a single share's fan-out. Shares are broadcast to the author's
+#: friends graph rather than addressed to one person, so one share is N pushes.
+#: This is a personal app with small graphs, but an unbounded fan-out inside a
+#: request handler is a latency cliff waiting to happen.
+MAX_FANOUT = 100
+
+
+def display_name_for(email: str) -> str:
+    """
+    Human name for a notification's actor.
+
+    Falls back to the email's local part rather than the full address —
+    "sam sent you a song" beats leaking someone's address onto a lock screen.
+    Import is local so `notify` stays cheap for producers that never need it.
+    """
+    if not email:
+        return "Someone"
+    try:
+        from lambdas.common.dynamo_helpers import batch_get_users
+
+        profile = (batch_get_users([email]) or {}).get(email) or {}
+        name = (profile.get("displayName") or "").strip()
+        if name:
+            return name
+    except Exception as err:  # noqa: BLE001
+        log.warning(f"display_name_for({email}) failed: {err}")
+    return email.split("@")[0]
+
+
+def notify_friends_of(
+    actor_email: str,
+    kind_key: str,
+    **ctx: Any,
+) -> int:
+    """
+    Fan one notification out to the actor's accepted friends.
+
+    Returns how many recipients were notified. Fail-open like everything else
+    on this path — a friends-graph read that falls over must not fail the write
+    that triggered it.
+    """
+    try:
+        from lambdas.common.friendships_dynamo import list_all_friends_for_user
+
+        friends = list_all_friends_for_user(actor_email) or []
+    except Exception as err:  # noqa: BLE001
+        log.error(f"fan-out friends lookup failed for {actor_email}: {err}")
+        return 0
+
+    # `status` MUST be checked. list_all_friends_for_user returns every row in
+    # the partition — pending requests and blocks included — so an unfiltered
+    # fan-out would push to people who declined you or blocked you outright.
+    emails: list[str] = []
+    for row in friends:
+        if not isinstance(row, dict) or row.get("status") != "accepted":
+            continue
+        candidate = row.get("friendEmail")
+        if candidate and candidate != actor_email and candidate not in emails:
+            emails.append(candidate)
+
+    if len(emails) > MAX_FANOUT:
+        log.warning(
+            f"fan-out for {actor_email} capped at {MAX_FANOUT} "
+            f"(graph has {len(emails)})"
+        )
+        emails = emails[:MAX_FANOUT]
+
+    for recipient in emails:
+        notify(kind_key, recipient, actor_email=actor_email, **ctx)
+    return len(emails)

--- a/lambdas/common/notify.py
+++ b/lambdas/common/notify.py
@@ -1,0 +1,173 @@
+"""
+XOMIFY Notification Dispatch Helper
+===================================
+The single entry point every producer uses:
+
+    from lambdas.common.notify import notify
+    notify("share_received", recipient_email, actor_email=sender, share_id=..., ...)
+
+It resolves the kind from the registry, renders title/body/route, applies
+coalescing where the kind asks for it, and async-invokes `notifications_send`.
+
+TWO RULES, both non-negotiable:
+
+1. FAIL-OPEN. A notification must never take down the interaction that
+   triggered it. Every path here swallows its own exceptions and logs, exactly
+   like `record_notification` already does for the send log. Nobody's comment
+   should fail to post because APNs had a bad afternoon.
+
+2. NEVER NOTIFY YOURSELF. Commenting on your own share, rating a song you sent
+   yourself, accepting your own invite — all reachable, all pointless as a
+   push. `actor_email == recipient_email` short-circuits before anything else.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import boto3
+
+from lambdas.common.constants import NOTIFICATIONS_SEND_FUNCTION_NAME
+from lambdas.common.logger import get_logger
+from lambdas.common.notification_kinds import (
+    COALESCE_WINDOW_S,
+    NotificationKind,
+    get_kind,
+    render,
+)
+from lambdas.common.notification_pending_dynamo import (
+    claim_or_merge,
+    coalesce_key,
+)
+
+log = get_logger(__file__)
+
+_lambda_client = boto3.client("lambda")
+
+
+def notify(
+    kind_key: str,
+    recipient_email: str,
+    *,
+    actor_email: Optional[str] = None,
+    subject_id: Optional[str] = None,
+    **ctx: Any,
+) -> None:
+    """
+    Send one notification. Fire-and-forget; never raises.
+
+    Args:
+        kind_key:        registry key, e.g. "share_received".
+        recipient_email: who is being notified.
+        actor_email:     who caused it, when there is a person behind it. Used
+                         both to suppress self-notification and to key the
+                         coalescing window.
+        subject_id:      the thing being acted on (usually a shareId). Required
+                         for coalescing kinds; ignored otherwise.
+        **ctx:           template context for title/body/route.
+    """
+    try:
+        _notify(kind_key, recipient_email, actor_email, subject_id, ctx)
+    except Exception as err:  # noqa: BLE001 — fail-open is the contract
+        log.error(f"notify({kind_key}) failed for {recipient_email}: {err}")
+
+
+def _notify(
+    kind_key: str,
+    recipient_email: str,
+    actor_email: Optional[str],
+    subject_id: Optional[str],
+    ctx: dict[str, Any],
+) -> None:
+    kind = get_kind(kind_key)
+    if kind is None:
+        log.error(f"notify called with unknown kind '{kind_key}' — dropping")
+        return
+
+    if not recipient_email:
+        log.warning(f"notify({kind_key}) with no recipient — dropping")
+        return
+
+    if actor_email and actor_email == recipient_email:
+        log.info(f"notify({kind_key}) suppressed — actor is the recipient")
+        return
+
+    full_ctx = dict(ctx)
+    if actor_email:
+        full_ctx.setdefault("actor_email", actor_email)
+
+    # ── Coalescing ──────────────────────────────────────────────────────
+    if kind.coalesce_group and subject_id and actor_email:
+        key = coalesce_key(recipient_email, kind.coalesce_group, f"{actor_email}#{subject_id}")
+        outcome = claim_or_merge(
+            key=key,
+            kind=kind.key,
+            recipient_email=recipient_email,
+            ctx=full_ctx,
+            window_s=COALESCE_WINDOW_S,
+        )
+        if outcome is None:
+            # Parked. The sibling event merges with it, or the sweeper sends it.
+            log.info(f"notify({kind_key}) parked for coalescing: {key}")
+            return
+        if outcome.get("merged"):
+            _dispatch(kind, recipient_email, outcome["ctx"], merged=True)
+            return
+        full_ctx = outcome.get("ctx", full_ctx)
+
+    _dispatch(kind, recipient_email, full_ctx, merged=False)
+
+
+def _dispatch(
+    kind: NotificationKind,
+    recipient_email: str,
+    ctx: dict[str, Any],
+    *,
+    merged: bool,
+) -> None:
+    """Render and async-invoke notifications_send."""
+    if not NOTIFICATIONS_SEND_FUNCTION_NAME:
+        log.warning("NOTIFICATIONS_SEND_FUNCTION_NAME unset — skipping push")
+        return
+
+    title_tpl = (kind.merged_title if merged and kind.merged_title else kind.title)
+    body_tpl = (kind.merged_body if merged and kind.merged_body else kind.body)
+
+    event: dict[str, Any] = {
+        "kind": kind.key,
+        "email": recipient_email,
+        "title": render(title_tpl, ctx),
+        "body": render(body_tpl, ctx),
+        "customData": {
+            **{k: v for k, v in ctx.items() if v is not None},
+            "route": render(kind.route, ctx) if kind.route else None,
+            "pushType": kind.key,
+        },
+    }
+
+    try:
+        _lambda_client.invoke(
+            FunctionName=NOTIFICATIONS_SEND_FUNCTION_NAME,
+            InvocationType="Event",  # async — never block the interaction
+            Payload=json.dumps(event, default=str).encode("utf-8"),
+        )
+        log.info(f"notify({kind.key}) dispatched to {recipient_email} (merged={merged})")
+    except Exception as err:  # noqa: BLE001
+        log.error(f"Failed to invoke notifications_send for {kind.key}: {err}")
+
+
+def dispatch_pending(row: dict[str, Any]) -> None:
+    """
+    Send a coalesced notification whose window lapsed with no sibling.
+
+    Called by the sweeper (see cron_notification_sweeper). Rendered with the
+    kind's OWN wording, not the merged wording — a listen with no rating is
+    just a listen.
+    """
+    kind = get_kind(row.get("kind", ""))
+    recipient = row.get("recipientEmail")
+    if kind is None or not recipient:
+        log.error(f"dispatch_pending: unusable row {row!r}")
+        return
+    _dispatch(kind, recipient, dict(row.get("ctx") or {}), merged=False)

--- a/lambdas/common/share_reactions_dynamo.py
+++ b/lambdas/common/share_reactions_dynamo.py
@@ -47,6 +47,19 @@ VALID_REACTIONS: set[str] = {
     "thumbs_up",
 }
 
+#: Display glyph for each slug. Reactions are stored as SLUGS, not emoji, so
+#: anything rendering one for a human — a push body especially — has to map it.
+#: "Sam reacted fire" is not a sentence.
+REACTION_EMOJI: dict[str, str] = {
+    "fire": "🔥",
+    "heart": "❤️",
+    "laugh": "😂",
+    "mind_blown": "🤯",
+    "sad": "😢",
+    "thumbs_up": "👍",
+}
+
+
 
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat()

--- a/lambdas/common/shares_dynamo.py
+++ b/lambdas/common/shares_dynamo.py
@@ -322,6 +322,35 @@ def scan_all_shares(page_size: int = 100):
 # ============================================
 # Threshold Notification Latch (idempotent)
 # ============================================
+def mark_rate_reminded(share_id: str) -> bool:
+    """
+    Atomically latch a share as having fired its rate reminder.
+
+    Same conditional-write trick as `mark_threshold_notified`: only one caller
+    can acquire the latch, so an overlapping cron run cannot double-remind. The
+    reminder is once per share EVER (epic decision 9) — if 24 hours did not get
+    someone to listen, a second nudge only teaches them to ignore the app.
+    """
+    try:
+        table = dynamodb.Table(SHARES_TABLE_NAME)
+        table.update_item(
+            Key={"shareId": share_id},
+            UpdateExpression="SET #a = :now",
+            ExpressionAttributeNames={"#a": "rateRemindedAt"},
+            ExpressionAttributeValues={":now": _iso_now()},
+            ConditionExpression="attribute_not_exists(#a)",
+        )
+        return True
+    except ClientError as err:
+        if err.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        log.error(f"mark_rate_reminded failed: {err}")
+        return False
+    except Exception as err:  # noqa: BLE001
+        log.error(f"mark_rate_reminded failed: {err}")
+        return False
+
+
 def mark_threshold_notified(share_id: str, threshold: int) -> bool:
     """
     Atomically mark a share as having fired its queue-threshold notification.

--- a/lambdas/cron_favorites_reminder/handler.py
+++ b/lambdas/cron_favorites_reminder/handler.py
@@ -53,6 +53,18 @@ def _run():
 
         try:
             send_favorites_reminder_email(email, user.get("displayName") or "", year)
+
+            # Push alongside the email. Best-effort and AFTER the email, so a
+            # push failure can never cost someone the reminder they'd have got
+            # anyway — and it stays outside the try/except that counts a
+            # failure, because the email is what "sent" means here.
+            try:
+                from lambdas.common.notify import notify
+
+                notify("favorites_reminder", email, year=year)
+            except Exception as push_err:  # noqa: BLE001
+                log.warning(f"favorites_reminder push failed for {email}: {push_err}")
+
             put_reminder_marker(email, year)
             successful += 1
         except Exception as err:  # noqa: BLE001 - isolate per-user send failures

--- a/lambdas/cron_notification_sweeper/handler.py
+++ b/lambdas/cron_notification_sweeper/handler.py
@@ -1,0 +1,65 @@
+"""
+Cron: Notification Coalescing Sweeper
+
+Scheduled via EventBridge every 5 minutes.
+
+Coalescing (relaunch epic, decision 11) parks the first of a pair of sibling
+notifications — share_listened / share_rated — for up to 10 minutes, hoping its
+partner arrives so the two can go out as one push. When the partner never comes,
+something has to send the parked one on its own. That is this.
+
+WHY IT CANNOT RIDE THE DAILY cron_rate_reminder SCHEDULE: the coalesce window is
+ten minutes. A daily sweeper would hold a lone "Sam listened to your song" for
+up to twenty-four hours, which is worse than never sending it.
+
+Flow:
+    1. Claim every pending row whose window has lapsed (delete-on-take, so two
+       overlapping runs cannot both send the same one).
+    2. Dispatch each with its own wording — a listen with no rating is just a
+       listen, not "listened and rated".
+
+Returns: {"swept": n, "failed": m}
+"""
+
+from __future__ import annotations
+
+from lambdas.common.cron_runs_dynamo import record_cron_run
+from lambdas.common.errors import handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.notification_pending_dynamo import take_expired
+from lambdas.common.notify import dispatch_pending
+from lambdas.common.utility_helpers import success_response
+
+log = get_logger(__file__)
+
+HANDLER = "cron_notification_sweeper"
+CRON_NAME = "notification-sweeper"
+
+#: One run's ceiling. At a 5-minute cadence this is far above any realistic
+#: backlog; it exists so a pathological pile-up degrades into several runs
+#: rather than one timing out and sending nothing at all.
+MAX_PER_RUN = 200
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    rows = take_expired(limit=MAX_PER_RUN)
+
+    swept = 0
+    failed = 0
+
+    for row in rows:
+        try:
+            dispatch_pending(row)
+            swept += 1
+        except Exception as err:  # noqa: BLE001
+            # dispatch_pending is already fail-open; this is belt-and-braces so
+            # one bad row cannot strand the rest of the batch.
+            log.error(f"sweeper failed to dispatch {row.get('coalesceKey')}: {err}")
+            failed += 1
+
+    stats = {"swept": swept, "failed": failed}
+    log.info(f"notification sweeper: {stats}")
+
+    record_cron_run(CRON_NAME, stats)
+    return success_response(stats, is_api=False)

--- a/lambdas/cron_rate_reminder/handler.py
+++ b/lambdas/cron_rate_reminder/handler.py
@@ -1,0 +1,161 @@
+"""
+Cron: Rate Reminder
+
+Runs daily. One nudge, roughly 24 hours after a share lands, to people who have
+neither played it nor rated it.
+
+ONCE PER SHARE, EVER (relaunch epic, decision 9). Latched via `rateRemindedAt`
+on the share row using the same conditional write `mark_threshold_notified`
+uses, so an overlapping run cannot double-remind. If 24 hours did not get
+someone to listen, a second nudge only teaches them to ignore the app.
+
+Flow:
+    1. Scan shares whose createdAt falls in the [24h, 48h) window. The lower
+       bound gives the share a day to land; the upper bound keeps a daily run
+       from re-examining the entire table forever.
+    2. Skip anything already latched.
+    3. For each of the author's accepted friends who has not listened and has
+       not rated, send `rate_reminder`.
+    4. Latch the share.
+
+Returns: {"examined": n, "reminded": m, "skipped": s}
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from lambdas.common.cron_runs_dynamo import record_cron_run
+from lambdas.common.errors import handle_errors
+from lambdas.common.interactions_dynamo import list_interactions_for_share
+from lambdas.common.logger import get_logger
+from lambdas.common.notify import display_name_for, notify
+from lambdas.common.share_listeners_dynamo import list_listeners_for_share
+from lambdas.common.shares_dynamo import mark_rate_reminded, scan_all_shares
+from lambdas.common.utility_helpers import success_response
+
+log = get_logger(__file__)
+
+HANDLER = "cron_rate_reminder"
+CRON_NAME = "rate-reminder"
+
+REMIND_AFTER_HOURS = 24
+#: Upper bound on the window. A share older than this was either already
+#: reminded or missed its moment; re-examining it every day forever is a scan
+#: that only grows.
+WINDOW_CLOSES_HOURS = 48
+
+#: Ceiling per run, so one pathological day degrades into several runs rather
+#: than one timeout that sends nothing.
+MAX_REMINDERS_PER_RUN = 200
+
+
+def _in_window(created_at: str, now: datetime) -> bool:
+    if not created_at:
+        return False
+    try:
+        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return False
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    age = now - created
+    return timedelta(hours=REMIND_AFTER_HOURS) <= age < timedelta(hours=WINDOW_CLOSES_HOURS)
+
+
+def _engaged_emails(share_id: str) -> set[str]:
+    """Everyone who has already played or rated this share."""
+    engaged: set[str] = set()
+    try:
+        for row in list_listeners_for_share(share_id) or []:
+            if row.get("email"):
+                engaged.add(row["email"])
+    except Exception as err:  # noqa: BLE001
+        log.warning(f"listeners lookup failed for {share_id}: {err}")
+    try:
+        for row in list_interactions_for_share(share_id) or []:
+            # Either signal counts — a rating without a recorded listen still
+            # means they engaged, and nudging them would be plainly wrong.
+            if row.get("email") and (row.get("queued") or row.get("rated")):
+                engaged.add(row["email"])
+    except Exception as err:  # noqa: BLE001
+        log.warning(f"interactions lookup failed for {share_id}: {err}")
+    return engaged
+
+
+def _audience(author_email: str) -> list[str]:
+    from lambdas.common.friendships_dynamo import list_all_friends_for_user
+
+    try:
+        rows = list_all_friends_for_user(author_email) or []
+    except Exception as err:  # noqa: BLE001
+        log.warning(f"friends lookup failed for {author_email}: {err}")
+        return []
+    return [
+        r["friendEmail"]
+        for r in rows
+        if isinstance(r, dict)
+        and r.get("status") == "accepted"
+        and r.get("friendEmail")
+        and r["friendEmail"] != author_email
+    ]
+
+
+def _run() -> dict:
+    now = datetime.now(timezone.utc)
+    examined = 0
+    reminded = 0
+    skipped = 0
+
+    for page in scan_all_shares(page_size=100):
+        for share in page:
+            if reminded >= MAX_REMINDERS_PER_RUN:
+                log.warning(f"rate reminder run capped at {MAX_REMINDERS_PER_RUN}")
+                return {"examined": examined, "reminded": reminded, "skipped": skipped}
+
+            if not _in_window(share.get("createdAt", ""), now):
+                continue
+            examined += 1
+
+            share_id = share.get("shareId")
+            author = share.get("email") or share.get("sharedBy")
+            if not share_id or not author:
+                skipped += 1
+                continue
+
+            # Latch FIRST. Losing the race means another run owns this share;
+            # doing the work and then discovering that would waste the reads.
+            if not mark_rate_reminded(share_id):
+                skipped += 1
+                continue
+
+            engaged = _engaged_emails(share_id)
+            actor_name = display_name_for(author)
+
+            for recipient in _audience(author):
+                if recipient in engaged:
+                    continue
+                notify(
+                    "rate_reminder",
+                    recipient,
+                    actor_email=author,
+                    actor_name=actor_name,
+                    track_name=share.get("trackName") or "that track",
+                    artist_name=share.get("artistName"),
+                    share_id=share_id,
+                )
+                reminded += 1
+
+    return {"examined": examined, "reminded": reminded, "skipped": skipped}
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    stats: dict = {}
+
+    def _wrapped():
+        stats.update(_run())
+        log.info(f"rate reminder: {stats}")
+        return success_response(stats, is_api=False)
+
+    return record_cron_run(CRON_NAME, _wrapped, items=lambda: stats.get("reminded"))

--- a/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
+++ b/lambdas/cron_release_radar/weekly_release_radar_aiohttp.py
@@ -194,6 +194,28 @@ async def process_user(
             playlist_id=playlist_id
         )
 
+        # Drop notification with a SNEAK PEEK, naming the release it leads with.
+        #
+        # An empty week is NOT notified — cron_shares_digest already set that
+        # precedent ("don't spam empty weeks"), and "0 new releases" is a push
+        # that only teaches people to swipe them away.
+        if releases:
+            try:
+                from lambdas.common.notify import notify
+
+                lead = releases[0]
+                notify(
+                    "release_radar_drop",
+                    email,
+                    release_count=len(releases),
+                    playlist_id=playlist_id,
+                    track_name=lead.get("albumName") or "",
+                    artist_name=lead.get("artistName") or "",
+                    image_url=lead.get("imageUrl"),
+                )
+            except Exception as err:
+                log.warning(f"[{email}] release_radar_drop notification failed: {err}")
+
         log.info(f"[{email}] Complete!")
 
         return {

--- a/lambdas/cron_wrapped/monthly_wrapped_aiohttp.py
+++ b/lambdas/cron_wrapped/monthly_wrapped_aiohttp.py
@@ -86,6 +86,15 @@ async def aiohttp_wrapped_chron_job(event) -> list:
     return successes, failures
 
 
+def _month_label(month_key: str) -> str:
+    """"2026-03" -> "March". A month key is a storage detail, not push copy."""
+    try:
+        year, month = month_key.split("-")
+        return datetime(int(year), int(month), 1).strftime("%B")
+    except Exception:
+        return "monthly"
+
+
 async def process_wrapped_user(user: dict, session: aiohttp.ClientSession, month_key: str) -> str:
     """
     Process a single user's monthly wrapped data.
@@ -178,7 +187,28 @@ async def process_wrapped_user(user: dict, session: aiohttp.ClientSession, month
         
         # Update user timestamp
         _update_user_timestamp(user)
-        
+
+        # Drop notification with a SNEAK PEEK. "Your March Wrapped is ready" is
+        # an announcement; naming the track it opens with is a reason to tap.
+        # The route deep-links straight into the playlist.
+        #
+        # Best-effort, like every other notification: a user whose Wrapped was
+        # generated must never see it fail because a push could not be built.
+        try:
+            from lambdas.common.notify import notify, sneak_peek
+
+            top = (spotify.top_tracks_short.track_list or [None])[0]
+            peek = sneak_peek(top)
+            notify(
+                "wrapped_drop",
+                email,
+                month=_month_label(month_key),
+                playlist_id=spotify.monthly_spotify_playlist.id,
+                **peek,
+            )
+        except Exception as err:
+            log.warning(f"[{email}] wrapped_drop notification failed: {err}")
+
         log.info(f"[{email}] ✅ Wrapped complete!")
         return email
         

--- a/lambdas/friends_accept/handler.py
+++ b/lambdas/friends_accept/handler.py
@@ -6,6 +6,7 @@ from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response, parse_body, require_fields, get_caller_email
 from lambdas.common.friendships_dynamo import accept_friend_request
+from lambdas.common.notify import display_name_for, notify
 
 log = get_logger(__file__)
 
@@ -23,5 +24,14 @@ def handler(event, context):
     log.info(f"User {email} is accepting friend request from {request_email}.")
     success = accept_friend_request(email, request_email)
     log.info(f"Friend Request Accepted {'Success!' if success else 'Failure!'}")
+
+    # The notification goes to whoever SENT the request, not the accepter.
+    if success:
+        notify(
+            'friend_accepted',
+            request_email,
+            actor_email=email,
+            actor_name=display_name_for(email),
+        )
 
     return success_response({'success': success})

--- a/lambdas/friends_request/handler.py
+++ b/lambdas/friends_request/handler.py
@@ -6,6 +6,7 @@ from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response, parse_body, require_fields, get_caller_email
 from lambdas.common.friendships_dynamo import send_friend_request
+from lambdas.common.notify import display_name_for, notify
 
 log = get_logger(__file__)
 
@@ -23,5 +24,15 @@ def handler(event, context):
     log.info(f"User {email} is sending request to {request_email} to be a friend.")
     success = send_friend_request(email, request_email)
     log.info(f"Friend Request {'Success!' if success else 'Failure!'}")
+
+    # Only on a successful write — a failed request must not tell the target
+    # someone tried.
+    if success:
+        notify(
+            'friend_request',
+            request_email,
+            actor_email=email,
+            actor_name=display_name_for(email),
+        )
 
     return success_response({'success': success})

--- a/lambdas/invites_accept/handler.py
+++ b/lambdas/invites_accept/handler.py
@@ -146,6 +146,16 @@ def handler(event, context):
 
     log.info(f"Invite {invite_code} accepted; {sender_email} <-> {email} now friends")
 
+    # Goes to the inviter — the accepter already knows they accepted.
+    from lambdas.common.notify import display_name_for, notify
+
+    notify(
+        'invite_accepted',
+        sender_email,
+        actor_email=email,
+        actor_name=display_name_for(email),
+    )
+
     return success_response({
         'ok': True,
         'senderEmail': sender_email,

--- a/lambdas/notifications_feed/handler.py
+++ b/lambdas/notifications_feed/handler.py
@@ -1,0 +1,45 @@
+"""
+GET /notifications?limit=&cursor= — one page of the caller's inbox.
+
+Newest first. `cursor` is the `tsId` of the last item the client already holds;
+pass back `nextCursor` from the previous response. `nextCursor` is null on the
+last page.
+
+Caller identity comes from the authorizer context via `get_caller_email` — the
+inbox is strictly self-scoped and takes no email parameter, so there is nothing
+to spoof.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.errors import handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.notifications_dynamo import list_notifications
+from lambdas.common.utility_helpers import get_caller_email, success_response
+
+log = get_logger(__file__)
+
+HANDLER = "notifications_feed"
+
+
+@handle_errors(HANDLER)
+def handler(event: dict, context: Any) -> dict:
+    email = get_caller_email(event)
+    params = event.get("queryStringParameters") or {}
+
+    raw_limit = params.get("limit")
+    try:
+        limit = int(raw_limit) if raw_limit else 25
+    except (TypeError, ValueError):
+        # A junk limit is not worth a 400 — fall back to the default page.
+        limit = 25
+
+    page = list_notifications(email, limit=limit, cursor=params.get("cursor"))
+    log.info(f"inbox page for {email}: {len(page['items'])} items")
+
+    return success_response({
+        "items": page["items"],
+        "nextCursor": page["nextCursor"],
+    })

--- a/lambdas/notifications_read/handler.py
+++ b/lambdas/notifications_read/handler.py
@@ -1,0 +1,53 @@
+"""
+POST /notifications/read — mark inbox items read.
+
+Body:
+    { "tsId": "<iso>#<rand8>" }   mark one
+    { "all": true }               mark every unread item
+
+Idempotent either way. Marking an already-read item is a no-op, and marking one
+that TTL has already reaped fails the condition check and returns updated=0
+rather than resurrecting a ghost row.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.errors import handle_errors, ValidationError
+from lambdas.common.logger import get_logger
+from lambdas.common.notifications_dynamo import mark_all_read, mark_read
+from lambdas.common.utility_helpers import (
+    get_caller_email,
+    parse_body,
+    success_response,
+)
+
+log = get_logger(__file__)
+
+HANDLER = "notifications_read"
+
+
+@handle_errors(HANDLER)
+def handler(event: dict, context: Any) -> dict:
+    email = get_caller_email(event)
+    body = parse_body(event)
+
+    mark_everything = bool(body.get("all"))
+    ts_id = body.get("tsId")
+
+    if not mark_everything and not ts_id:
+        raise ValidationError(
+            message="Provide either tsId or all=true",
+            handler=HANDLER,
+            function="handler",
+            field="tsId",
+        )
+
+    if mark_everything:
+        updated = mark_all_read(email)
+    else:
+        updated = 1 if mark_read(email, ts_id) else 0
+
+    log.info(f"marked {updated} notification(s) read for {email}")
+    return success_response({"ok": True, "updated": updated})

--- a/lambdas/notifications_register/handler.py
+++ b/lambdas/notifications_register/handler.py
@@ -8,14 +8,27 @@ preference flags.
 Body:
     {
         "deviceToken": "<hex>",
-        "digestEnabled": true,               # optional, default true
-        "queueNotificationsEnabled": true    # optional, default true
+
+        # NEW — the full per-kind map. Only the flags present are written;
+        # anything omitted keeps whatever the row already had (or the registry
+        # default, if the row has never carried it).
+        "preferences": { "shareReceivedEnabled": true, ... },
+
+        # LEGACY — the two flags that existed before the registry. Still
+        # honoured so an older client build keeps working; they fold into
+        # `preferences`.
+        "digestEnabled": true,
+        "queueNotificationsEnabled": true
     }
+
+Returns the EFFECTIVE preference map — every kind, defaults filled in — so a
+Settings screen can render all sixteen toggles from one response rather than
+having to know the defaults itself.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors, ValidationError
@@ -26,13 +39,23 @@ from lambdas.common.utility_helpers import (
     success_response,
 )
 from lambdas.common.device_tokens_dynamo import upsert_token
+from lambdas.common.notification_kinds import (
+    effective_preferences,
+    sanitize_preferences,
+)
 
 log = get_logger(__file__)
 
 HANDLER = "notifications_register"
 
 
-def _as_bool(value: Any, default: bool) -> bool:
+def _as_bool(value: Any, default: Optional[bool]) -> Optional[bool]:
+    """
+    None in, None out — the caller distinguishes "client said false" from
+    "client did not mention this flag". Collapsing the two would make every
+    registration write every flag, which is exactly what the sparse upsert
+    exists to avoid.
+    """
     if value is None:
         return default
     if isinstance(value, bool):
@@ -58,24 +81,33 @@ def handler(event: dict, context: Any) -> dict:
             field="deviceToken",
         )
 
-    digest_enabled = _as_bool(body.get("digestEnabled"), True)
-    queue_notifications_enabled = _as_bool(body.get("queueNotificationsEnabled"), True)
+    preferences = sanitize_preferences(body.get("preferences") or {})
+
+    # Legacy top-level flags, from client builds that predate the registry.
+    digest_enabled = _as_bool(body.get("digestEnabled"), None)
+    queue_notifications_enabled = _as_bool(body.get("queueNotificationsEnabled"), None)
 
     log.info(
         f"Registering device token for {email} "
-        f"(digestEnabled={digest_enabled}, queueEnabled={queue_notifications_enabled})"
+        f"(explicit flags: {sorted(preferences)}, "
+        f"legacy digest={digest_enabled}, legacy queue={queue_notifications_enabled})"
     )
 
-    upsert_token(
+    row = upsert_token(
         email=email,
         device_token=device_token,
+        preferences=preferences,
         digest_enabled=digest_enabled,
         queue_notifications_enabled=queue_notifications_enabled,
     )
 
+    effective = effective_preferences(row)
+
     return success_response({
         "ok": True,
         "email": email,
-        "digestEnabled": digest_enabled,
-        "queueNotificationsEnabled": queue_notifications_enabled,
+        "preferences": effective,
+        # Kept at the top level for older clients that read them there.
+        "digestEnabled": effective["digestEnabled"],
+        "queueNotificationsEnabled": effective["queueNotificationsEnabled"],
     })

--- a/lambdas/notifications_send/handler.py
+++ b/lambdas/notifications_send/handler.py
@@ -30,16 +30,16 @@ from lambdas.common.utility_helpers import success_response
 from lambdas.common.device_tokens_dynamo import delete_token, list_tokens_for_user
 from lambdas.common.apns_client import get_client
 from lambdas.common.notification_log_dynamo import record_notification
+from lambdas.common.notification_kinds import VALID_KINDS, get_kind, is_opted_in
 
 log = get_logger(__file__)
 
 HANDLER = "notifications_send"
 
-VALID_KINDS = {"queue_threshold", "digest"}
-OPT_IN_FLAG_BY_KIND = {
-    "queue_threshold": "queueNotificationsEnabled",
-    "digest": "digestEnabled",
-}
+# Kinds and their opt-in flags now come from the shared registry
+# (lambdas/common/notification_kinds.py) rather than being duplicated here.
+# This module used to hardcode the two-kind world; there are sixteen now, and a
+# second copy of that mapping is a second place to get it wrong.
 
 
 def _coerce_event(event: dict) -> dict:
@@ -70,6 +70,8 @@ def handler(event, context):
             function="handler",
             field="kind",
         )
+
+    kind_spec = get_kind(kind)
     if not email:
         raise ValidationError(
             message="email is required",
@@ -86,7 +88,6 @@ def handler(event, context):
         )
 
     tokens = list_tokens_for_user(email)
-    opt_in_flag = OPT_IN_FLAG_BY_KIND[kind]
 
     sent = 0
     failed = 0
@@ -96,8 +97,11 @@ def handler(event, context):
     client = get_client()
 
     for row in tokens:
-        # Default to True if the flag is absent (legacy rows).
-        if not bool(row.get(opt_in_flag, True)):
+        # An absent flag falls back to the KIND'S OWN default rather than a
+        # blanket True — see notification_kinds.is_opted_in. That is what lets
+        # fourteen new kinds ship without backfilling every device row, and it
+        # is also what stops `digest` reaching devices that never asked for it.
+        if not is_opted_in(row, kind_spec):
             skipped += 1
             continue
 

--- a/lambdas/notifications_unread_count/handler.py
+++ b/lambdas/notifications_unread_count/handler.py
@@ -1,0 +1,26 @@
+"""
+GET /notifications/unread-count — badge count for the caller.
+
+Split from the feed endpoint on purpose: a client polls this far more often
+than it opens the inbox, and it should not have to transfer a page of items to
+render a number.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.errors import handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.notifications_dynamo import count_unread
+from lambdas.common.utility_helpers import get_caller_email, success_response
+
+log = get_logger(__file__)
+
+HANDLER = "notifications_unread_count"
+
+
+@handle_errors(HANDLER)
+def handler(event: dict, context: Any) -> dict:
+    email = get_caller_email(event)
+    return success_response({"unread": count_unread(email)})

--- a/lambdas/shares_comments_create/handler.py
+++ b/lambdas/shares_comments_create/handler.py
@@ -33,6 +33,7 @@ from lambdas.common.shares_dynamo import get_share
 from lambdas.common.share_comments_dynamo import create_comment
 from lambdas.common.share_visibility import viewer_can_see_share
 from lambdas.common.dynamo_helpers import batch_get_users
+from lambdas.common.notify import notify
 
 log = get_logger(__file__)
 
@@ -104,6 +105,19 @@ def handler(event, context):
         log.warning(f"Profile hydrate failed for {email}: {err}")
 
     profile = profile_map.get(email) or {}
+
+    # notify() suppresses the self-case, so commenting on your own share is a
+    # no-op here rather than something this handler has to special-case.
+    notify(
+        "share_comment",
+        share.get("email") or share.get("sharedBy") or "",
+        actor_email=email,
+        actor_name=(profile.get("displayName") or "").strip() or email.split("@")[0],
+        comment_preview=(text[:120] + "…") if len(text) > 120 else text,
+        share_id=share_id,
+        track_name=share.get("trackName"),
+    )
+
     payload = {
         "commentId": comment.get("commentId"),
         "shareId": comment.get("shareId"),

--- a/lambdas/shares_create/handler.py
+++ b/lambdas/shares_create/handler.py
@@ -30,6 +30,7 @@ from lambdas.common.shares_dynamo import create_share
 from lambdas.common.group_members_dynamo import is_member_of_group
 from lambdas.common.track_ratings_dynamo import upsert_track_rating
 from lambdas.common.share_listeners_dynamo import mark_listened
+from lambdas.common.notify import display_name_for, notify_friends_of
 
 log = get_logger(__file__)
 
@@ -229,5 +230,24 @@ def handler(event, context):
             log.warning(
                 f"Rate-on-share: failed to write rating for share {result['shareId']}: {exc}"
             )
+
+    # Notify the author's friends. A share is a friends-graph broadcast rather
+    # than an addressed message, so this fans out; notify_friends_of caps it and
+    # filters to ACCEPTED friendships only.
+    #
+    # Group-only shares are skipped deliberately: `share_received` says "someone
+    # sent you a song", and a group post is not that. Group notifications would
+    # need their own kind, and Groups has no client UI any more.
+    if public:
+        notify_friends_of(
+            email,
+            "share_received",
+            subject_id=result['shareId'],
+            actor_name=display_name_for(email),
+            track_name=track_name,
+            artist_name=artist_name,
+            share_id=result['shareId'],
+            image_url=album_art_url or None,
+        )
 
     return success_response(result)

--- a/lambdas/shares_listened/handler.py
+++ b/lambdas/shares_listened/handler.py
@@ -106,8 +106,13 @@ def handler(event, context):
             field="source",
         )
 
+    from lambdas.common.notify import display_name_for, notify
+
     listened: list[str] = []
     skipped: list[str] = []
+    # Resolved once, not per share — a 25-share batch should not be 25 profile
+    # reads for the same person.
+    actor_name = None
 
     for share_id in share_ids:
         share = get_share(share_id)
@@ -120,6 +125,24 @@ def handler(event, context):
         try:
             mark_listened(share_id, email, source=raw_source)
             listened.append(share_id)
+
+            # `author_create` is shares_create marking its own author as a
+            # listener — notifying them that they listened to their own share
+            # would be absurd. notify() would suppress it anyway, but skipping
+            # here avoids a pointless profile read.
+            if raw_source != "author_create":
+                if actor_name is None:
+                    actor_name = display_name_for(email)
+                notify(
+                    "share_listened",
+                    share.get("email") or share.get("sharedBy") or "",
+                    actor_email=email,
+                    subject_id=share_id,
+                    actor_name=actor_name,
+                    track_name=share.get("trackName"),
+                    artist_name=share.get("artistName"),
+                    share_id=share_id,
+                )
         except Exception as err:
             # Don't 500 the whole batch on a single row's DDB hiccup.
             log.error(

--- a/lambdas/shares_react/handler.py
+++ b/lambdas/shares_react/handler.py
@@ -188,6 +188,25 @@ def handler(event, context):
             rating = _coerce_rating(raw_rating)
         set_reaction(share_id, email, shared_by=shared_by, action=action, rating=rating)
 
+    # Rating notification. Coalesces with `share_listened` from the same person
+    # on the same share inside a 10-minute window — queueing then rating is one
+    # act of engagement and should be one interruption.
+    if action == "rated":
+        from lambdas.common.notify import display_name_for, notify
+
+        stars = int(raw_rating) if isinstance(raw_rating, (int, float)) else 0
+        notify(
+            "share_rated",
+            shared_by or "",
+            actor_email=email,
+            subject_id=share_id,
+            actor_name=display_name_for(email),
+            stars="★" * max(0, min(stars, 5)),
+            track_name=share.get("trackName") if share else None,
+            artist_name=share.get("artistName") if share else None,
+            share_id=share_id,
+        )
+
     # Threshold push — only on `queued`, only when not self-react, only at or above 3.
     if action == "queued" and email != shared_by:
         reactor_count = count_distinct_reactors(share_id)

--- a/lambdas/shares_reactions_toggle/handler.py
+++ b/lambdas/shares_reactions_toggle/handler.py
@@ -46,6 +46,7 @@ from lambdas.common.utility_helpers import (
 )
 from lambdas.common.shares_dynamo import get_share
 from lambdas.common.share_reactions_dynamo import (
+    REACTION_EMOJI,
     VALID_REACTIONS,
     add_reaction,
     build_reaction_summary,
@@ -106,6 +107,21 @@ def handler(event, context):
     else:
         add_reaction(share_id, email, reaction)
         active = True
+
+    # Only on ADD. Un-reacting is not an event worth a push, and pushing on
+    # both edges turns a toggle into a notification machine gun.
+    if active:
+        from lambdas.common.notify import display_name_for, notify
+
+        notify(
+            "share_reaction",
+            share.get("email") or share.get("sharedBy") or "",
+            actor_email=email,
+            actor_name=display_name_for(email),
+            emoji=REACTION_EMOJI.get(reaction, reaction),
+            track_name=share.get("trackName"),
+            share_id=share_id,
+        )
 
     summary = build_reaction_summary(share_id, email)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ _TEST_ENV_VARS = {
     "DEVICE_TOKENS_TABLE_NAME": "xomify-device-tokens-test",
     "NOTIFICATION_LOG_TABLE_NAME": "xomify-notification-log-test",
     "NOTIFICATION_PENDING_TABLE_NAME": "xomify-notification-pending-test",
+    "NOTIFICATIONS_TABLE_NAME": "xomify-notifications-test",
     "NOTIFICATIONS_SEND_FUNCTION_NAME": "xomify-notifications-send-test",
 }
 for key, value in _TEST_ENV_VARS.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,10 @@ _TEST_ENV_VARS = {
     "FAVORITES_TABLE_NAME": "xomify-favorites-test",
     "BROADCASTS_TABLE_NAME": "xomify-broadcasts-test",
     "ADMIN_EMAIL": "admin@example.com",
+    "DEVICE_TOKENS_TABLE_NAME": "xomify-device-tokens-test",
+    "NOTIFICATION_LOG_TABLE_NAME": "xomify-notification-log-test",
+    "NOTIFICATION_PENDING_TABLE_NAME": "xomify-notification-pending-test",
+    "NOTIFICATIONS_SEND_FUNCTION_NAME": "xomify-notifications-send-test",
 }
 for key, value in _TEST_ENV_VARS.items():
     os.environ.setdefault(key, value)

--- a/tests/test_cron_rate_reminder.py
+++ b/tests/test_cron_rate_reminder.py
@@ -1,0 +1,137 @@
+"""
+Tests for the rate-reminder cron (B5).
+
+Decision 9 is "one reminder per share, EVER". The two ways to violate that are
+reminding twice and reminding someone who already engaged, so both get a test.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+
+def _share(share_id="s1", hours_old=30, author="author@e.com"):
+    created = datetime.now(timezone.utc) - timedelta(hours=hours_old)
+    return {
+        "shareId": share_id,
+        "email": author,
+        "createdAt": created.isoformat(),
+        "trackName": "Midnight City",
+        "artistName": "M83",
+    }
+
+
+def _friends(*emails):
+    return [{"friendEmail": e, "status": "accepted"} for e in emails]
+
+
+@pytest.fixture
+def wired():
+    with patch("lambdas.cron_rate_reminder.handler.notify") as notify, \
+         patch("lambdas.cron_rate_reminder.handler.display_name_for", return_value="Author"), \
+         patch("lambdas.cron_rate_reminder.handler.mark_rate_reminded", return_value=True) as latch, \
+         patch("lambdas.cron_rate_reminder.handler.list_listeners_for_share", return_value=[]), \
+         patch("lambdas.cron_rate_reminder.handler.list_interactions_for_share", return_value=[]), \
+         patch("lambdas.common.friendships_dynamo.list_all_friends_for_user",
+               return_value=_friends("a@e.com", "b@e.com")):
+        yield {"notify": notify, "latch": latch}
+
+
+def test_reminds_the_unengaged_audience(wired):
+    from lambdas.cron_rate_reminder.handler import _run
+
+    with patch("lambdas.cron_rate_reminder.handler.scan_all_shares", return_value=[[_share()]]):
+        stats = _run()
+
+    assert stats["reminded"] == 2
+    assert {c.args[1] for c in wired["notify"].call_args_list} == {"a@e.com", "b@e.com"}
+    assert wired["notify"].call_args.args[0] == "rate_reminder"
+
+
+def test_skips_a_share_that_is_too_young(wired):
+    """A share needs a day to land before nagging anyone about it."""
+    from lambdas.cron_rate_reminder.handler import _run
+
+    with patch("lambdas.cron_rate_reminder.handler.scan_all_shares",
+               return_value=[[_share(hours_old=2)]]):
+        stats = _run()
+
+    assert stats["examined"] == 0
+    wired["notify"].assert_not_called()
+
+
+def test_skips_a_share_past_the_window(wired):
+    """
+    Without an upper bound the daily scan re-examines the whole table forever.
+    """
+    from lambdas.cron_rate_reminder.handler import _run
+
+    with patch("lambdas.cron_rate_reminder.handler.scan_all_shares",
+               return_value=[[_share(hours_old=200)]]):
+        stats = _run()
+
+    assert stats["examined"] == 0
+    wired["notify"].assert_not_called()
+
+
+def test_a_lost_latch_means_another_run_owns_it(wired):
+    """Once per share, ever — an overlapping run must not double-remind."""
+    from lambdas.cron_rate_reminder.handler import _run
+
+    wired["latch"].return_value = False
+    with patch("lambdas.cron_rate_reminder.handler.scan_all_shares", return_value=[[_share()]]):
+        stats = _run()
+
+    assert stats["reminded"] == 0
+    assert stats["skipped"] == 1
+    wired["notify"].assert_not_called()
+
+
+def test_does_not_nag_someone_who_already_listened():
+    from lambdas.cron_rate_reminder.handler import _run
+
+    with patch("lambdas.cron_rate_reminder.handler.notify") as notify, \
+         patch("lambdas.cron_rate_reminder.handler.display_name_for", return_value="Author"), \
+         patch("lambdas.cron_rate_reminder.handler.mark_rate_reminded", return_value=True), \
+         patch("lambdas.cron_rate_reminder.handler.list_listeners_for_share",
+               return_value=[{"email": "a@e.com"}]), \
+         patch("lambdas.cron_rate_reminder.handler.list_interactions_for_share", return_value=[]), \
+         patch("lambdas.common.friendships_dynamo.list_all_friends_for_user",
+               return_value=_friends("a@e.com", "b@e.com")), \
+         patch("lambdas.cron_rate_reminder.handler.scan_all_shares", return_value=[[_share()]]):
+        stats = _run()
+
+    assert stats["reminded"] == 1
+    assert notify.call_args.args[1] == "b@e.com"
+
+
+def test_a_rating_without_a_listen_still_counts_as_engaged():
+    """Rating a track you never 'played' in-app is still engagement."""
+    from lambdas.cron_rate_reminder.handler import _run
+
+    with patch("lambdas.cron_rate_reminder.handler.notify") as notify, \
+         patch("lambdas.cron_rate_reminder.handler.display_name_for", return_value="Author"), \
+         patch("lambdas.cron_rate_reminder.handler.mark_rate_reminded", return_value=True), \
+         patch("lambdas.cron_rate_reminder.handler.list_listeners_for_share", return_value=[]), \
+         patch("lambdas.cron_rate_reminder.handler.list_interactions_for_share",
+               return_value=[{"email": "a@e.com", "rated": True}]), \
+         patch("lambdas.common.friendships_dynamo.list_all_friends_for_user",
+               return_value=_friends("a@e.com", "b@e.com")), \
+         patch("lambdas.cron_rate_reminder.handler.scan_all_shares", return_value=[[_share()]]):
+        stats = _run()
+
+    assert stats["reminded"] == 1
+    assert notify.call_args.args[1] == "b@e.com"
+
+
+def test_the_author_never_reminds_themselves(wired):
+    from lambdas.cron_rate_reminder.handler import _run
+
+    with patch("lambdas.common.friendships_dynamo.list_all_friends_for_user",
+               return_value=_friends("author@e.com", "b@e.com")), \
+         patch("lambdas.cron_rate_reminder.handler.scan_all_shares", return_value=[[_share()]]):
+        stats = _run()
+
+    assert stats["reminded"] == 1
+    assert wired["notify"].call_args.args[1] == "b@e.com"

--- a/tests/test_notification_kinds.py
+++ b/tests/test_notification_kinds.py
@@ -1,0 +1,108 @@
+"""
+Tests for the notification kind registry.
+
+The registry is the contract every producer and both clients read from, so the
+invariants worth guarding are structural: no duplicate wire keys, no duplicate
+opt-in flags (two kinds sharing a flag means one toggle silently controls two
+notifications), and no drift in the two pre-existing kinds.
+"""
+
+import pytest
+
+from lambdas.common.notification_kinds import (
+    ALL_KINDS,
+    BY_KEY,
+    SECTION_ORDER,
+    default_preferences,
+    get_kind,
+    is_opted_in,
+    render,
+)
+
+
+def test_keys_are_unique():
+    keys = [k.key for k in ALL_KINDS]
+    assert len(keys) == len(set(keys))
+
+
+def test_opt_in_flags_are_unique():
+    """Two kinds sharing a flag would make one Settings toggle mute both."""
+    flags = [k.opt_in_flag for k in ALL_KINDS]
+    assert len(flags) == len(set(flags))
+
+
+def test_every_kind_has_a_known_section():
+    for kind in ALL_KINDS:
+        assert kind.section in SECTION_ORDER
+
+
+def test_every_kind_has_label_and_copy():
+    for kind in ALL_KINDS:
+        assert kind.label, f"{kind.key} has no Settings label"
+        assert kind.title and kind.body, f"{kind.key} has no copy"
+
+
+@pytest.mark.parametrize(
+    "key,flag",
+    [("queue_threshold", "queueNotificationsEnabled"), ("digest", "digestEnabled")],
+)
+def test_preexisting_kinds_keep_their_wire_contract(key, flag):
+    """
+    Renaming either of these silently opts every existing device out of
+    something it had already chosen.
+    """
+    kind = get_kind(key)
+    assert kind is not None
+    assert kind.opt_in_flag == flag
+
+
+def test_default_preferences_cover_every_kind():
+    prefs = default_preferences()
+    assert len(prefs) == len(ALL_KINDS)
+    for kind in ALL_KINDS:
+        assert kind.opt_in_flag in prefs
+
+
+def test_digest_is_the_only_kind_off_by_default():
+    """
+    Deliberate change from the old blanket `row.get(flag, True)`: a device row
+    with no digestEnabled was receiving a weekly push nobody opted into.
+    """
+    off = [f for f, v in default_preferences().items() if not v]
+    assert off == ["digestEnabled"]
+
+
+def test_absent_flag_falls_back_to_kind_default_not_false():
+    """This is the whole no-backfill migration story."""
+    kind = get_kind("share_received")
+    assert is_opted_in({}, kind) is True
+
+    digest = get_kind("digest")
+    assert is_opted_in({}, digest) is False
+
+
+def test_explicit_flag_beats_the_default():
+    kind = get_kind("share_received")
+    assert is_opted_in({"shareReceivedEnabled": False}, kind) is False
+
+    digest = get_kind("digest")
+    assert is_opted_in({"digestEnabled": True}, digest) is True
+
+
+def test_coalescing_pair_shares_a_group_and_merged_copy():
+    listened = get_kind("share_listened")
+    rated = get_kind("share_rated")
+    assert listened.coalesce_group == rated.coalesce_group
+    assert listened.coalesce_group is not None
+    assert listened.merged_title == rated.merged_title
+
+
+def test_render_is_forgiving_of_missing_context():
+    """Notification copy is never worth failing the interaction over."""
+    assert render("{a} and {b}", {"a": "x"}) == "{a} and {b}"
+    assert render("{a} only", {"a": "x"}) == "x only"
+
+
+def test_unknown_kind_returns_none():
+    assert get_kind("no_such_kind") is None
+    assert "no_such_kind" not in BY_KEY

--- a/tests/test_notification_preferences.py
+++ b/tests/test_notification_preferences.py
@@ -1,0 +1,163 @@
+"""
+Tests for per-type notification preferences (B2).
+
+The invariant worth defending hardest: registration must write ONLY the flags
+the client actually sent. A blanket write of all sixteen booleans would freeze
+today's defaults onto every device row and permanently destroy the
+absent-means-default migration path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from lambdas.common.notification_kinds import (
+    ALL_KINDS,
+    effective_preferences,
+    sanitize_preferences,
+)
+
+
+# ── Registry helpers ────────────────────────────────────────────────────
+
+def test_effective_preferences_fills_every_kind_from_an_empty_row():
+    prefs = effective_preferences({})
+    assert len(prefs) == len(ALL_KINDS)
+    assert prefs["shareReceivedEnabled"] is True
+    assert prefs["digestEnabled"] is False
+
+
+def test_effective_preferences_lets_a_stored_flag_win():
+    prefs = effective_preferences({"shareReceivedEnabled": False, "digestEnabled": True})
+    assert prefs["shareReceivedEnabled"] is False
+    assert prefs["digestEnabled"] is True
+    # Untouched kinds still resolve to their defaults.
+    assert prefs["shareCommentEnabled"] is True
+
+
+def test_sanitize_drops_unknown_flags():
+    """A client typo must not persist forever as a meaningless attribute."""
+    out = sanitize_preferences({"digestEnabled": True, "notARealFlag": True})
+    assert out == {"digestEnabled": True}
+
+
+def test_sanitize_coerces_string_booleans():
+    out = sanitize_preferences({"digestEnabled": "true", "shareRatedEnabled": "false"})
+    assert out == {"digestEnabled": True, "shareRatedEnabled": False}
+
+
+# ── Sparse upsert ───────────────────────────────────────────────────────
+
+def _captured_update(mock_table):
+    return mock_table.update_item.call_args.kwargs
+
+
+@patch("lambdas.common.device_tokens_dynamo.dynamodb")
+def test_upsert_writes_only_the_supplied_flags(mock_dynamo):
+    from lambdas.common.device_tokens_dynamo import upsert_token
+
+    table = MagicMock()
+    table.update_item.return_value = {"Attributes": {}}
+    mock_dynamo.Table.return_value = table
+
+    upsert_token("e@x.com", "tok", preferences={"shareRatedEnabled": False})
+
+    names = _captured_update(table)["ExpressionAttributeNames"]
+    written = [v for v in names.values() if v.endswith("Enabled")]
+    assert written == ["shareRatedEnabled"]
+
+
+@patch("lambdas.common.device_tokens_dynamo.dynamodb")
+def test_upsert_with_no_preferences_touches_no_flags(mock_dynamo):
+    """A plain token refresh must not silently rewrite the user's choices."""
+    from lambdas.common.device_tokens_dynamo import upsert_token
+
+    table = MagicMock()
+    table.update_item.return_value = {"Attributes": {}}
+    mock_dynamo.Table.return_value = table
+
+    upsert_token("e@x.com", "tok")
+
+    names = _captured_update(table)["ExpressionAttributeNames"]
+    assert not [v for v in names.values() if v.endswith("Enabled")]
+
+
+@patch("lambdas.common.device_tokens_dynamo.dynamodb")
+def test_legacy_kwargs_still_write_their_flags(mock_dynamo):
+    """Older client builds send exactly these two and must keep working."""
+    from lambdas.common.device_tokens_dynamo import upsert_token
+
+    table = MagicMock()
+    table.update_item.return_value = {"Attributes": {}}
+    mock_dynamo.Table.return_value = table
+
+    upsert_token("e@x.com", "tok", digest_enabled=True, queue_notifications_enabled=False)
+
+    kwargs = _captured_update(table)
+    written = {v for v in kwargs["ExpressionAttributeNames"].values() if v.endswith("Enabled")}
+    assert written == {"digestEnabled", "queueNotificationsEnabled"}
+
+
+@patch("lambdas.common.device_tokens_dynamo.dynamodb")
+def test_flag_placeholders_are_unique(mock_dynamo):
+    """
+    Several flags share a prefix; deriving placeholders from the name would
+    collide and DynamoDB would reject the expression.
+    """
+    from lambdas.common.device_tokens_dynamo import upsert_token
+
+    table = MagicMock()
+    table.update_item.return_value = {"Attributes": {}}
+    mock_dynamo.Table.return_value = table
+
+    upsert_token("e@x.com", "tok", preferences={
+        "shareReceivedEnabled": True,
+        "shareRatedEnabled": False,
+        "shareReactionEnabled": True,
+    })
+
+    kwargs = _captured_update(table)
+    names = kwargs["ExpressionAttributeNames"]
+    assert len(set(names.keys())) == len(names)
+    assert len(set(kwargs["ExpressionAttributeValues"].keys())) == len(kwargs["ExpressionAttributeValues"])
+
+
+# ── Register handler ────────────────────────────────────────────────────
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_returns_the_full_effective_map(mock_upsert, mock_context):
+    """One response should be enough to render all sixteen Settings toggles."""
+    import json
+    from lambdas.notifications_register.handler import handler
+
+    mock_upsert.return_value = {"digestEnabled": True, "shareRatedEnabled": False}
+
+    event = {
+        "body": json.dumps({"deviceToken": "a" * 16, "preferences": {"shareRatedEnabled": False}}),
+        "requestContext": {"authorizer": {"email": "e@x.com"}},
+    }
+    response = handler(event, mock_context)
+    payload = json.loads(response["body"])
+    prefs = payload.get("data", payload).get("preferences")
+
+    assert len(prefs) == len(ALL_KINDS)
+    assert prefs["shareRatedEnabled"] is False
+    assert prefs["digestEnabled"] is True
+    assert prefs["shareCommentEnabled"] is True   # untouched -> default
+
+
+@patch("lambdas.notifications_register.handler.upsert_token")
+def test_register_passes_only_explicit_flags_through(mock_upsert, mock_context):
+    import json
+    from lambdas.notifications_register.handler import handler
+
+    mock_upsert.return_value = {}
+    event = {
+        "body": json.dumps({"deviceToken": "a" * 16}),
+        "requestContext": {"authorizer": {"email": "e@x.com"}},
+    }
+    handler(event, mock_context)
+
+    kwargs = mock_upsert.call_args.kwargs
+    assert kwargs["preferences"] == {}
+    # None, not True — "client did not mention it" is not "client said yes".
+    assert kwargs["digest_enabled"] is None
+    assert kwargs["queue_notifications_enabled"] is None

--- a/tests/test_notification_producers.py
+++ b/tests/test_notification_producers.py
@@ -1,0 +1,188 @@
+"""
+Tests for the interaction producers (B4).
+
+These guard the wiring, not the dispatch — notify() itself is covered in
+test_notify.py. What matters here is that each producer picks the RIGHT
+RECIPIENT (several of them are easy to get backwards) and fires on the right
+edge.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _authed(email, body=None):
+    event = {"requestContext": {"authorizer": {"email": email}}}
+    if body is not None:
+        event["body"] = json.dumps(body)
+    return event
+
+
+# ── friends: the recipient is the easy thing to get backwards ────────────
+
+@patch("lambdas.friends_request.handler.display_name_for", return_value="Sam")
+@patch("lambdas.friends_request.handler.notify")
+@patch("lambdas.friends_request.handler.send_friend_request", return_value=True)
+def test_friend_request_notifies_the_target(mock_send, mock_notify, _name, mock_context):
+    from lambdas.friends_request.handler import handler
+
+    handler(_authed("sam@e.com", {"requestEmail": "target@e.com"}), mock_context)
+
+    args, kwargs = mock_notify.call_args
+    assert args[0] == "friend_request"
+    assert args[1] == "target@e.com"          # the target, not the sender
+    assert kwargs["actor_email"] == "sam@e.com"
+
+
+@patch("lambdas.friends_request.handler.display_name_for", return_value="Sam")
+@patch("lambdas.friends_request.handler.notify")
+@patch("lambdas.friends_request.handler.send_friend_request", return_value=False)
+def test_failed_friend_request_notifies_nobody(mock_send, mock_notify, _n, mock_context):
+    """A failed write must not tell the target someone tried."""
+    from lambdas.friends_request.handler import handler
+
+    handler(_authed("sam@e.com", {"requestEmail": "target@e.com"}), mock_context)
+    mock_notify.assert_not_called()
+
+
+@patch("lambdas.friends_accept.handler.display_name_for", return_value="Target")
+@patch("lambdas.friends_accept.handler.notify")
+@patch("lambdas.friends_accept.handler.accept_friend_request", return_value=True)
+def test_friend_accept_notifies_the_original_sender(mock_accept, mock_notify, _n, mock_context):
+    """
+    The accepter already knows they accepted. The notification goes to whoever
+    SENT the request — the reverse of friends_request.
+    """
+    from lambdas.friends_accept.handler import handler
+
+    handler(_authed("target@e.com", {"requestEmail": "sam@e.com"}), mock_context)
+
+    args, kwargs = mock_notify.call_args
+    assert args[0] == "friend_accepted"
+    assert args[1] == "sam@e.com"             # the requester
+    assert kwargs["actor_email"] == "target@e.com"
+
+
+# ── shares_create fan-out ────────────────────────────────────────────────
+
+@patch("lambdas.shares_create.handler.display_name_for", return_value="Sam")
+@patch("lambdas.shares_create.handler.notify_friends_of")
+def test_public_share_fans_out_to_friends(mock_fanout, _name):
+    """A share is a friends-graph broadcast, not an addressed message."""
+    import lambdas.shares_create.handler as mod
+
+    with patch.object(mod, "create_share", return_value={"shareId": "s1", "public": True}), \
+         patch.object(mod, "mark_listened"), \
+         patch.object(mod, "upsert_track_rating"):
+        mod.handler(_authed("sam@e.com", {
+            "trackId": "t1", "trackUri": "spotify:track:t1",
+            "trackName": "Midnight City", "artistName": "M83",
+            "albumName": "Hurry Up", "albumArtUrl": "http://img",
+            "public": True,
+        }), MagicMock())
+
+    assert mock_fanout.call_count == 1
+    args, kwargs = mock_fanout.call_args
+    assert args[0] == "sam@e.com"
+    assert args[1] == "share_received"
+    assert kwargs["track_name"] == "Midnight City"
+
+
+# ── fan-out helper ───────────────────────────────────────────────────────
+
+@patch("lambdas.common.notify.notify")
+def test_fanout_only_reaches_accepted_friendships(mock_notify):
+    """
+    list_all_friends_for_user returns the whole partition — pending and blocked
+    included. An unfiltered fan-out would push to people who declined or
+    blocked you.
+    """
+    import lambdas.common.notify as mod
+
+    rows = [
+        {"friendEmail": "ok@e.com", "status": "accepted"},
+        {"friendEmail": "pending@e.com", "status": "pending"},
+        {"friendEmail": "blocked@e.com", "status": "blocked"},
+    ]
+    with patch("lambdas.common.friendships_dynamo.list_all_friends_for_user", return_value=rows):
+        count = mod.notify_friends_of("sam@e.com", "share_received", share_id="s1")
+
+    assert count == 1
+    assert mock_notify.call_args.args[1] == "ok@e.com"
+
+
+@patch("lambdas.common.notify.notify")
+def test_fanout_is_capped(mock_notify):
+    import lambdas.common.notify as mod
+
+    rows = [
+        {"friendEmail": f"f{i}@e.com", "status": "accepted"}
+        for i in range(mod.MAX_FANOUT + 25)
+    ]
+    with patch("lambdas.common.friendships_dynamo.list_all_friends_for_user", return_value=rows):
+        assert mod.notify_friends_of("sam@e.com", "share_received") == mod.MAX_FANOUT
+
+
+@patch("lambdas.common.notify.notify")
+def test_fanout_survives_a_friends_lookup_failure(mock_notify):
+    """Fail-open: a broken graph read must not fail the share that triggered it."""
+    import lambdas.common.notify as mod
+
+    with patch("lambdas.common.friendships_dynamo.list_all_friends_for_user",
+               side_effect=RuntimeError("dynamo down")):
+        assert mod.notify_friends_of("sam@e.com", "share_received") == 0
+    mock_notify.assert_not_called()
+
+
+def test_display_name_falls_back_to_the_local_part():
+    """Never leak a full email address onto someone's lock screen."""
+    import lambdas.common.notify as mod
+
+    with patch("lambdas.common.dynamo_helpers.batch_get_users", return_value={}):
+        assert mod.display_name_for("dominick@example.com") == "dominick"
+    with patch("lambdas.common.dynamo_helpers.batch_get_users",
+               side_effect=RuntimeError("boom")):
+        assert mod.display_name_for("dominick@example.com") == "dominick"
+    assert mod.display_name_for("") == "Someone"
+
+
+def test_display_name_prefers_the_stored_display_name():
+    import lambdas.common.notify as mod
+
+    with patch("lambdas.common.dynamo_helpers.batch_get_users",
+               return_value={"d@e.com": {"displayName": "Dom G"}}):
+        assert mod.display_name_for("d@e.com") == "Dom G"
+
+
+# ── reactions fire on one edge only ──────────────────────────────────────
+
+@patch("lambdas.common.notify.notify")
+def test_reaction_notifies_on_add_but_not_on_remove(mock_notify):
+    """Pushing on both edges turns a toggle into a notification machine gun."""
+    import lambdas.shares_reactions_toggle.handler as mod
+
+    share = {"shareId": "s1", "email": "author@e.com", "trackName": "Midnight City"}
+    common = dict(
+        get_share=MagicMock(return_value=share),
+        viewer_can_see_share=MagicMock(return_value=True),
+        build_reaction_summary=MagicMock(return_value={"counts": {}, "viewerReactions": []}),
+        add_reaction=MagicMock(),
+        remove_reaction=MagicMock(),
+    )
+
+    # ADD -> notified
+    with patch.multiple(mod, get_reaction=MagicMock(return_value=None), **common):
+        mod.handler(_authed("fan@e.com", {"shareId": "s1", "reaction": "fire"}), MagicMock())
+    assert mock_notify.call_count == 1
+    assert mock_notify.call_args.args[0] == "share_reaction"
+    # Slug in, glyph out — "Sam reacted fire" is not a sentence.
+    assert mock_notify.call_args.kwargs["emoji"] == "🔥"
+
+    mock_notify.reset_mock()
+
+    # REMOVE -> silent
+    with patch.multiple(mod, get_reaction=MagicMock(return_value={"x": 1}), **common):
+        mod.handler(_authed("fan@e.com", {"shareId": "s1", "reaction": "fire"}), MagicMock())
+    mock_notify.assert_not_called()

--- a/tests/test_notifications_inbox.py
+++ b/tests/test_notifications_inbox.py
@@ -1,0 +1,287 @@
+"""
+Tests for the notifications inbox (B3).
+
+Two behaviours carry most of the risk: paging (an off-by-one in the cursor
+either loses items or repeats them forever) and the inbox/push independence
+rule — a muted kind must still land in history.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+# ── Store ───────────────────────────────────────────────────────────────
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_put_notification_writes_the_expected_shape(mock_table_fn):
+    from lambdas.common.notifications_dynamo import put_notification
+
+    table = MagicMock()
+    mock_table_fn.return_value = table
+
+    assert put_notification(
+        email="r@e.com", kind="share_received",
+        title="Sam sent you a song", body="Midnight City — M83",
+        route="share:abc", actor_email="s@e.com", actor_name="Sam",
+    ) is True
+
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["email"] == "r@e.com"
+    assert item["read"] is False
+    assert item["kind"] == "share_received"
+    assert item["route"] == "share:abc"
+    assert "ttl" in item
+    # SK must be time-ordered so a descending query is newest-first for free.
+    assert item["tsId"].startswith(item["createdAt"])
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_put_notification_omits_empty_optional_fields(mock_table_fn):
+    """Empty strings persisted as attributes are noise the clients must guard."""
+    from lambdas.common.notifications_dynamo import put_notification
+
+    table = MagicMock()
+    mock_table_fn.return_value = table
+    put_notification(email="r@e.com", kind="digest", title="t", body="b")
+
+    item = table.put_item.call_args.kwargs["Item"]
+    for absent in ("route", "actorEmail", "actorName", "imageUrl"):
+        assert absent not in item
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_put_notification_is_fail_open(mock_table_fn):
+    """A failed inbox write must not stop the push."""
+    from lambdas.common.notifications_dynamo import put_notification
+
+    table = MagicMock()
+    table.put_item.side_effect = RuntimeError("dynamo down")
+    mock_table_fn.return_value = table
+
+    assert put_notification(email="r@e.com", kind="digest", title="t", body="b") is False
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_list_returns_newest_first_and_a_cursor(mock_table_fn):
+    from lambdas.common.notifications_dynamo import list_notifications
+
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [{"tsId": "2026-08-25T00:00:00+00:00#aaaaaaaa"}],
+        "LastEvaluatedKey": {"email": "r@e.com", "tsId": "2026-08-24T00:00:00+00:00#bbbbbbbb"},
+    }
+    mock_table_fn.return_value = table
+
+    page = list_notifications("r@e.com")
+
+    assert table.query.call_args.kwargs["ScanIndexForward"] is False
+    assert len(page["items"]) == 1
+    assert page["nextCursor"] == "2026-08-24T00:00:00+00:00#bbbbbbbb"
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_list_last_page_has_no_cursor(mock_table_fn):
+    """A non-null cursor on the last page makes clients page forever."""
+    from lambdas.common.notifications_dynamo import list_notifications
+
+    table = MagicMock()
+    table.query.return_value = {"Items": []}
+    mock_table_fn.return_value = table
+
+    assert list_notifications("r@e.com")["nextCursor"] is None
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_list_clamps_the_page_size(mock_table_fn):
+    from lambdas.common.notifications_dynamo import list_notifications, MAX_PAGE
+
+    table = MagicMock()
+    table.query.return_value = {"Items": []}
+    mock_table_fn.return_value = table
+
+    list_notifications("r@e.com", limit=9999)
+    assert table.query.call_args.kwargs["Limit"] == MAX_PAGE
+
+    list_notifications("r@e.com", limit=0)
+    assert table.query.call_args.kwargs["Limit"] >= 1
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_cursor_becomes_an_exclusive_start_key(mock_table_fn):
+    from lambdas.common.notifications_dynamo import list_notifications
+
+    table = MagicMock()
+    table.query.return_value = {"Items": []}
+    mock_table_fn.return_value = table
+
+    list_notifications("r@e.com", cursor="2026-08-24T00:00:00+00:00#bbbbbbbb")
+    assert table.query.call_args.kwargs["ExclusiveStartKey"] == {
+        "email": "r@e.com",
+        "tsId": "2026-08-24T00:00:00+00:00#bbbbbbbb",
+    }
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_count_unread_follows_pagination(mock_table_fn):
+    """A single query's Count is only this page — stopping early undercounts."""
+    from lambdas.common.notifications_dynamo import count_unread
+
+    table = MagicMock()
+    table.query.side_effect = [
+        {"Count": 3, "LastEvaluatedKey": {"email": "r@e.com", "tsId": "x"}},
+        {"Count": 2},
+    ]
+    mock_table_fn.return_value = table
+
+    assert count_unread("r@e.com") == 5
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_mark_all_read_is_bounded(mock_table_fn):
+    """An unbounded update loop is how a lambda finds its timeout."""
+    from lambdas.common.notifications_dynamo import mark_all_read, MAX_MARK_ALL
+
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [{"tsId": f"t{i}"} for i in range(MAX_MARK_ALL + 50)],
+    }
+    mock_table_fn.return_value = table
+
+    assert mark_all_read("r@e.com") == MAX_MARK_ALL
+
+
+@patch("lambdas.common.notifications_dynamo._table")
+def test_mark_read_will_not_resurrect_a_reaped_row(mock_table_fn):
+    from lambdas.common.notifications_dynamo import mark_read
+
+    table = MagicMock()
+    mock_table_fn.return_value = table
+    mark_read("r@e.com", "t1")
+
+    assert "attribute_exists" in table.update_item.call_args.kwargs["ConditionExpression"]
+
+
+# ── notify() integration ────────────────────────────────────────────────
+
+@patch("lambdas.common.notify.put_notification")
+@patch("lambdas.common.notify._lambda_client")
+def test_notify_writes_the_inbox_row(mock_client, mock_put):
+    from lambdas.common.notify import notify
+
+    notify("share_received", "r@e.com", actor_email="s@e.com",
+           actor_name="Sam", track_name="Midnight City",
+           artist_name="M83", share_id="abc")
+
+    kwargs = mock_put.call_args.kwargs
+    assert kwargs["email"] == "r@e.com"
+    assert kwargs["kind"] == "share_received"
+    assert kwargs["title"] == "Sam sent you a song"
+    assert kwargs["route"] == "share:abc"
+    assert kwargs["actor_name"] == "Sam"
+
+
+@patch("lambdas.common.notify.put_notification")
+@patch("lambdas.common.notify._lambda_client")
+def test_inbox_row_is_written_even_when_push_dispatch_is_impossible(mock_client, mock_put):
+    """
+    Muting a push means 'do not interrupt me', not 'hide this from my history'.
+    Web has no APNs token at all and would otherwise have an empty inbox forever.
+    """
+    import lambdas.common.notify as notify_mod
+    from lambdas.common.notify import notify
+
+    original = notify_mod.NOTIFICATIONS_SEND_FUNCTION_NAME
+    notify_mod.NOTIFICATIONS_SEND_FUNCTION_NAME = ""
+    try:
+        notify("friend_request", "r@e.com", actor_email="s@e.com", actor_name="Sam")
+    finally:
+        notify_mod.NOTIFICATIONS_SEND_FUNCTION_NAME = original
+
+    mock_put.assert_called_once()
+    mock_client.invoke.assert_not_called()
+
+
+@patch("lambdas.common.notify.put_notification")
+@patch("lambdas.common.notify._lambda_client")
+def test_self_notification_writes_no_inbox_row_either(mock_client, mock_put):
+    from lambdas.common.notify import notify
+
+    notify("share_comment", "same@e.com", actor_email="same@e.com")
+    mock_put.assert_not_called()
+
+
+# ── Handlers ────────────────────────────────────────────────────────────
+
+def _authed(body=None, params=None):
+    event = {"requestContext": {"authorizer": {"email": "r@e.com"}}}
+    if body is not None:
+        event["body"] = json.dumps(body)
+    if params is not None:
+        event["queryStringParameters"] = params
+    return event
+
+
+@patch("lambdas.notifications_feed.handler.list_notifications")
+def test_feed_handler_returns_items_and_cursor(mock_list, mock_context):
+    from lambdas.notifications_feed.handler import handler
+
+    mock_list.return_value = {"items": [{"tsId": "a"}], "nextCursor": "b"}
+    response = handler(_authed(params={"limit": "10", "cursor": "z"}), mock_context)
+
+    assert response["statusCode"] == 200
+    payload = json.loads(response["body"])
+    data = payload.get("data", payload)
+    assert data["nextCursor"] == "b"
+    assert mock_list.call_args.kwargs["limit"] == 10
+    assert mock_list.call_args.kwargs["cursor"] == "z"
+
+
+@patch("lambdas.notifications_feed.handler.list_notifications")
+def test_feed_handler_tolerates_a_junk_limit(mock_list, mock_context):
+    """Not worth a 400 — fall back to the default page."""
+    from lambdas.notifications_feed.handler import handler
+
+    mock_list.return_value = {"items": [], "nextCursor": None}
+    handler(_authed(params={"limit": "banana"}), mock_context)
+    assert mock_list.call_args.kwargs["limit"] == 25
+
+
+@patch("lambdas.notifications_read.handler.mark_read")
+def test_read_handler_marks_one(mock_mark, mock_context):
+    from lambdas.notifications_read.handler import handler
+
+    mock_mark.return_value = True
+    response = handler(_authed(body={"tsId": "t1"}), mock_context)
+
+    data = json.loads(response["body"])
+    assert data.get("data", data)["updated"] == 1
+    mock_mark.assert_called_once_with("r@e.com", "t1")
+
+
+@patch("lambdas.notifications_read.handler.mark_all_read")
+def test_read_handler_marks_all(mock_mark_all, mock_context):
+    from lambdas.notifications_read.handler import handler
+
+    mock_mark_all.return_value = 7
+    response = handler(_authed(body={"all": True}), mock_context)
+
+    data = json.loads(response["body"])
+    assert data.get("data", data)["updated"] == 7
+
+
+def test_read_handler_requires_a_target(mock_context):
+    from lambdas.notifications_read.handler import handler
+
+    response = handler(_authed(body={}), mock_context)
+    assert response["statusCode"] == 400
+
+
+@patch("lambdas.notifications_unread_count.handler.count_unread")
+def test_unread_count_handler(mock_count, mock_context):
+    from lambdas.notifications_unread_count.handler import handler
+
+    mock_count.return_value = 4
+    response = handler(_authed(), mock_context)
+
+    data = json.loads(response["body"])
+    assert data.get("data", data)["unread"] == 4

--- a/tests/test_notifications_register.py
+++ b/tests/test_notifications_register.py
@@ -32,6 +32,14 @@ def _post_event(base: dict, body: dict) -> dict:
 def test_register_happy_path_uses_caller_email_from_context(
     mock_upsert: Any, mock_context: Any, authorized_event: Any
 ) -> None:
+    """
+    CONTRACT CHANGE (per-type preferences, B2): a registration that mentions no
+    flags now writes no flags. It used to coerce both legacy flags to True and
+    persist them, which would freeze today's defaults onto the row and destroy
+    the absent-means-registry-default fallback every new kind depends on.
+    """
+    mock_upsert.return_value = {"email": "alice@example.com"}
+
     event = _post_event(
         authorized_event(email="alice@example.com"),
         {"deviceToken": "abcdef0123456789"},
@@ -43,14 +51,18 @@ def test_register_happy_path_uses_caller_email_from_context(
     body = json.loads(response["body"])
     assert body["ok"] is True
     assert body["email"] == "alice@example.com"
-    assert body["digestEnabled"] is True
+
+    # Effective map is returned, resolved against the registry defaults.
+    assert body["preferences"]["queueNotificationsEnabled"] is True
+    assert body["preferences"]["digestEnabled"] is False
     assert body["queueNotificationsEnabled"] is True
 
     mock_upsert.assert_called_once_with(
         email="alice@example.com",
         device_token="abcdef0123456789",
-        digest_enabled=True,
-        queue_notifications_enabled=True,
+        preferences={},
+        digest_enabled=None,
+        queue_notifications_enabled=None,
     )
 
 
@@ -59,6 +71,7 @@ def test_register_ignores_email_in_body_prefers_context(
     mock_upsert: Any, mock_context: Any, authorized_event: Any
 ) -> None:
     """Spoofed body email must NOT win over the trusted authorizer context."""
+    mock_upsert.return_value = {"email": "trusted@example.com"}
     event = _post_event(
         authorized_event(email="trusted@example.com"),
         {"email": "spoofed@evil.com", "deviceToken": "abcdef0123456789"},
@@ -86,6 +99,14 @@ def test_register_honors_optional_flags(
         },
     )
 
+    # The response echoes what is STORED, not what was asked for, so the
+    # stubbed row has to look like the row DynamoDB would return.
+    mock_upsert.return_value = {
+        "email": "alice@example.com",
+        "digestEnabled": False,
+        "queueNotificationsEnabled": False,
+    }
+
     response = handler(event, mock_context)
 
     assert response["statusCode"] == 200
@@ -95,6 +116,7 @@ def test_register_honors_optional_flags(
     mock_upsert.assert_called_once_with(
         email="alice@example.com",
         device_token="abcdef0123456789",
+        preferences={},
         digest_enabled=False,
         queue_notifications_enabled=False,
     )

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,195 @@
+"""
+Tests for the notify() dispatch helper.
+
+The two contracts that matter here are the two the module docstring states:
+fail-open (a notification must never break the interaction that caused it) and
+never-notify-yourself. Coalescing is the third, and the fiddliest.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _payload(mock_invoke, call_index=0):
+    kwargs = mock_invoke.call_args_list[call_index].kwargs
+    return json.loads(kwargs["Payload"].decode("utf-8"))
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_dispatches_rendered_copy_and_route(mock_client):
+    from lambdas.common.notify import notify
+
+    notify(
+        "share_received",
+        "recipient@e.com",
+        actor_email="sam@e.com",
+        actor_name="Sam",
+        track_name="Midnight City",
+        artist_name="M83",
+        share_id="abc123",
+    )
+
+    assert mock_client.invoke.call_count == 1
+    payload = _payload(mock_client.invoke)
+    assert payload["kind"] == "share_received"
+    assert payload["email"] == "recipient@e.com"
+    assert payload["title"] == "Sam sent you a song"
+    assert payload["body"] == "Midnight City — M83"
+    assert payload["customData"]["route"] == "share:abc123"
+    assert payload["customData"]["pushType"] == "share_received"
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_invoked_asynchronously(mock_client):
+    """A push must never block the write that triggered it."""
+    from lambdas.common.notify import notify
+
+    notify("friend_request", "r@e.com", actor_email="a@e.com", actor_name="A")
+    assert mock_client.invoke.call_args.kwargs["InvocationType"] == "Event"
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_never_notifies_the_actor_about_their_own_action(mock_client):
+    from lambdas.common.notify import notify
+
+    notify("share_comment", "same@e.com", actor_email="same@e.com", actor_name="Same")
+    mock_client.invoke.assert_not_called()
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_unknown_kind_is_dropped_not_raised(mock_client):
+    from lambdas.common.notify import notify
+
+    notify("not_a_real_kind", "r@e.com")   # must not raise
+    mock_client.invoke.assert_not_called()
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_missing_recipient_is_dropped_not_raised(mock_client):
+    from lambdas.common.notify import notify
+
+    notify("share_received", "")
+    mock_client.invoke.assert_not_called()
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_invoke_failure_is_swallowed(mock_client):
+    """Fail-open: APNs having a bad afternoon must not fail someone's comment."""
+    from lambdas.common.notify import notify
+
+    mock_client.invoke.side_effect = RuntimeError("lambda unavailable")
+    notify("share_received", "r@e.com", actor_email="a@e.com")   # must not raise
+
+
+# ── Coalescing ──────────────────────────────────────────────────────────
+
+@patch("lambdas.common.notify.claim_or_merge")
+@patch("lambdas.common.notify._lambda_client")
+def test_first_of_a_coalescing_pair_is_parked_not_sent(mock_client, mock_claim):
+    from lambdas.common.notify import notify
+
+    mock_claim.return_value = None   # parked
+
+    notify(
+        "share_listened",
+        "r@e.com",
+        actor_email="sam@e.com",
+        subject_id="share1",
+        actor_name="Sam",
+        track_name="Midnight City",
+    )
+
+    mock_client.invoke.assert_not_called()
+
+
+@patch("lambdas.common.notify.claim_or_merge")
+@patch("lambdas.common.notify._lambda_client")
+def test_second_of_a_pair_sends_one_merged_push(mock_client, mock_claim):
+    """One act of engagement, one interruption — the point of decision 11."""
+    from lambdas.common.notify import notify
+
+    mock_claim.return_value = {
+        "merged": True,
+        "ctx": {
+            "actor_name": "Sam",
+            "track_name": "Midnight City",
+            "artist_name": "M83",
+            "stars": "****",
+        },
+        "kinds": ["share_listened", "share_rated"],
+    }
+
+    notify(
+        "share_rated",
+        "r@e.com",
+        actor_email="sam@e.com",
+        subject_id="share1",
+        actor_name="Sam",
+        stars="****",
+    )
+
+    assert mock_client.invoke.call_count == 1
+    payload = _payload(mock_client.invoke)
+    assert payload["title"] == "Sam listened and rated ****"
+    assert payload["body"] == "Midnight City — M83"
+
+
+@patch("lambdas.common.notify.claim_or_merge")
+@patch("lambdas.common.notify._lambda_client")
+def test_coalescing_unavailable_falls_through_to_immediate_send(mock_client, mock_claim):
+    """
+    B1 ships before B6 provisions the table. Losing coalescing is cosmetic;
+    losing the notification is not.
+    """
+    from lambdas.common.notify import notify
+
+    mock_claim.return_value = {"merged": False, "ctx": {"actor_name": "Sam", "track_name": "T"}, "kinds": ["share_listened"]}
+
+    notify(
+        "share_listened",
+        "r@e.com",
+        actor_email="sam@e.com",
+        subject_id="share1",
+        actor_name="Sam",
+        track_name="T",
+    )
+
+    assert mock_client.invoke.call_count == 1
+    assert _payload(mock_client.invoke)["title"] == "Sam listened"
+
+
+@patch("lambdas.common.notify.claim_or_merge")
+@patch("lambdas.common.notify._lambda_client")
+def test_coalescing_kind_without_a_subject_sends_immediately(mock_client, mock_claim):
+    """No subject means nothing to coalesce ON — don't park it forever."""
+    from lambdas.common.notify import notify
+
+    notify("share_listened", "r@e.com", actor_email="sam@e.com", actor_name="Sam", track_name="T")
+
+    mock_claim.assert_not_called()
+    assert mock_client.invoke.call_count == 1
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_sweeper_dispatch_uses_solo_copy_not_merged(mock_client):
+    """A listen with no rating is just a listen."""
+    from lambdas.common.notify import dispatch_pending
+
+    dispatch_pending({
+        "kind": "share_listened",
+        "recipientEmail": "r@e.com",
+        "ctx": {"actor_name": "Sam", "track_name": "Midnight City"},
+    })
+
+    payload = _payload(mock_client.invoke)
+    assert payload["title"] == "Sam listened"
+    assert payload["body"] == "to Midnight City"
+
+
+@patch("lambdas.common.notify._lambda_client")
+def test_sweeper_dispatch_tolerates_an_unusable_row(mock_client):
+    from lambdas.common.notify import dispatch_pending
+
+    dispatch_pending({"kind": "nope", "recipientEmail": "r@e.com"})
+    dispatch_pending({"kind": "share_listened"})
+    mock_client.invoke.assert_not_called()


### PR DESCRIPTION
Track B (B1–B5) of the **xomify-relaunch** epic. Takes the product from **one** working notification producer to **fifteen**.

## Before

`notifications_send` knew two kinds (`queue_threshold`, `digest`) gated on two flags. Exactly one producer existed in the entire codebase — a latch in `shares_react`. Of ~16 notifiable events, one pushed.

## After

| | |
|---|---|
| **B1** | 16-kind registry, fail-open `notify()`, coalescing, 5-min sweeper |
| **B2** | One opt-in flag per kind, written sparsely |
| **B3** | Per-user inbox table + 3 endpoints |
| **B4** | Nine interaction producers wired |
| **B5** | Four cron producers, incl. new `cron_rate_reminder` |

## Design calls worth reviewing

- **Coalescing uses a pending table, not APNs `collapse_id`.** Collapse-id replaces the tray entry but the second push *still alerts* — it fixes clutter, not the buzz. One interruption per act of engagement means holding the first event back, which needs somewhere to hold it. A conditional write claims the slot so two simultaneous events can't both park with neither ever sending.
- **Inbox and push are independent.** The row is written even when the kind is muted and even when the user has no device. Muting means "don't interrupt me", not "hide this from my history" — and **web has no APNs token at all**, so gating the inbox on delivery would leave every web user with a permanently empty inbox.
- **The fan-out `status` filter is load-bearing.** `list_all_friends_for_user` returns the whole partition — pending *and blocked*. My first version didn't filter, which would have pushed every share to people who'd blocked the author. Now directly tested.
- **Registration writes only the flags the client sent.** Writing all sixteen booleans would stamp today's defaults onto every row and kill the absent-means-default fallback — the whole no-backfill migration — the moment any client registered.
- **The sneak peek** is what makes a drop worth tapping: *"Starting with Midnight City — M83"*, not *"Your Wrapped is ready"*, deep-linked into the playlist.

## Behaviour changes

- **`digest` now defaults OFF.** The old code read *every* absent flag as `True`, so device rows without `digestEnabled` were getting a weekly push nobody opted into.
- **Absent is no longer coerced to `True`** in `notifications_register`. Three existing tests asserted the old coercion and were updated.

## Gaps, stated plainly

- **`admin_broadcasts_create` is unwired** — the one kind in the registry with no producer. Fan-out to every user needs a users-table scan; inside the admin's request handler that's a silent timeout risk. Needs an async invoke.
- **`invites_create` can't be wired** — an invite goes to someone with no account yet.
- **Nothing here runs until the infra PR lands** (`xomify-infrastructure#feature/notification-infra`). Everything degrades gracefully by design, but the inbox writes nothing and coalescing is off until those tables exist.

## Verification

**14 failed / 646 passed** — the 14 are pre-existing favorites failures, identical on clean `master`. 60 new tests.

⚠️ **The suite does not run under the default `python3` here (3.9.6)** — the repo uses `X | Y` unions. It runs fine on 3.13:

```
uv run --python 3.13 --with pytest --with boto3 --with requests \
       --with aiohttp --with pyjwt --with cryptography python -m pytest -q
```

`--with-requirements requirements.txt` fails (pinned `cffi` won't compile against 3.13 headers). **Worth adding this to the README** — running `pytest` directly makes the suite look broken.

Note: no issue number, so no `Closes #N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)