### PR TITLE
feat(notifications): broadcast fan-out — and fix a live send bug

### DIFF
--- a/docs/features/notification-kind-registry/PLAN.md
+++ b/docs/features/notification-kind-registry/PLAN.md
@@ -84,20 +84,25 @@ Landed on `feature/notification-kind-registry`.
 
 ### Test environment finding (pre-existing, not caused by this work)
 
-The default `python3` on this machine is 3.9.6, and the repo uses `X | Y` unions
-(3.10+) — `lambdas/common/errors.py:261` among others. Under 3.9 the suite collapses to
-50 failures and 74 collection errors on clean `master`.
-
-**It does run**, via the already-installed `uv` and Homebrew `python3.13`:
+The default `python3` here is 3.9.6 and the repo uses `X | Y` unions (3.10+), so a plain
+`pytest` collapses into dozens of collection errors. It runs fine via the already-installed
+`uv` and Homebrew `python3.13`:
 
 ```
-uv run --python 3.13 --with pytest --with boto3 --with requests \
-       --with aiohttp --with pyjwt --with cryptography python -m pytest -q
+uv run --python 3.13 --with pytest --with boto3 --with requests --with aiohttp \
+       --with pyjwt --with cryptography --with pydantic python -m pytest -q
 ```
 
-`--with-requirements requirements.txt` does NOT work — the pinned `cffi` fails to
-compile against Python 3.13 headers here. The explicit `--with` list above avoids it.
+`--with-requirements requirements.txt` does NOT work — the pinned `cffi` fails to compile
+against 3.13 headers.
 
-**True baseline on 3.13: 14 failed, 600 passed.** All 14 are pre-existing favorites
-failures, unrelated to this track. Worth adding the uv invocation to the repo README so
-the next person doesn't conclude the suite is broken.
+**TRUE BASELINE: 660 passed, 0 failed.** Two earlier figures recorded here were wrong, both
+because of this environment rather than the code:
+
+| Reported | Cause | Actual |
+|----------|-------|--------|
+| "50 failed / 74 errors" | Python 3.9 vs 3.12 union syntax | not real |
+| "14 failed / 600 passed" | `pydantic` missing from the ephemeral env | **660 passed, 0 failed** |
+
+The suite is fully green. Worth putting that invocation in the README so nobody else
+concludes otherwise.

--- a/lambdas/admin_broadcasts_create/handler.py
+++ b/lambdas/admin_broadcasts_create/handler.py
@@ -15,6 +15,40 @@ from lambdas.common.errors import handle_errors
 from lambdas.common.logger import get_logger
 from lambdas.common.model_helpers import parse_model
 from lambdas.common.utility_helpers import parse_body, success_response
+import json
+import boto3
+from lambdas.common.constants import BROADCAST_FANOUT_FUNCTION_NAME
+
+_lambda_client = boto3.client("lambda")
+
+
+def _dispatch_broadcast_push(broadcast_id: str, title: str, body_text: str) -> None:
+    """
+    Hand the fan-out to a dedicated lambda, asynchronously.
+
+    Deliberately NOT done inline: reaching every user means a full users-table
+    scan plus one dispatch each. Inside this request handler the admin would
+    wait on all of it, and it would get quietly slower until it hit the
+    gateway timeout with no feedback. Fire-and-forget — the broadcast row is
+    already persisted, so a failed push never costs the broadcast itself.
+    """
+    if not BROADCAST_FANOUT_FUNCTION_NAME:
+        log.warning("BROADCAST_FANOUT_FUNCTION_NAME unset — skipping broadcast push")
+        return
+    try:
+        _lambda_client.invoke(
+            FunctionName=BROADCAST_FANOUT_FUNCTION_NAME,
+            InvocationType="Event",
+            Payload=json.dumps({
+                "broadcastId": broadcast_id,
+                "title": title,
+                "body": body_text,
+            }).encode("utf-8"),
+        )
+        log.info(f"broadcast fan-out dispatched for {broadcast_id}")
+    except Exception as err:  # noqa: BLE001
+        log.error(f"Failed to dispatch broadcast fan-out: {err}")
+
 
 log = get_logger(__file__)
 
@@ -58,6 +92,8 @@ def handler(event, context):
 
     log.info(f"admin_broadcasts_create by={admin_email} id={broadcast_id}")
     put_broadcast(item)
+
+    _dispatch_broadcast_push(broadcast_id, request.title, request.body)
 
     return success_response({
         "id": broadcast_id,

--- a/lambdas/common/constants.py
+++ b/lambdas/common/constants.py
@@ -51,6 +51,7 @@ USER_LIKES_EMAIL_ADDED_INDEX = os.environ.get("USER_LIKES_EMAIL_ADDED_INDEX", "e
 
 # Cross-lambda invocation (backend-interactions-and-notifications sub-feature)
 NOTIFICATIONS_SEND_FUNCTION_NAME = os.environ.get('NOTIFICATIONS_SEND_FUNCTION_NAME', '')
+BROADCAST_FANOUT_FUNCTION_NAME = os.environ.get('BROADCAST_FANOUT_FUNCTION_NAME', '')
 
 # APNs SSM parameter paths (populated by infra PR-A)
 APNS_AUTH_KEY_PARAM = os.environ.get('APNS_AUTH_KEY_PARAM', '/xomify/apns/AUTH_KEY')

--- a/lambdas/notifications_broadcast_fanout/handler.py
+++ b/lambdas/notifications_broadcast_fanout/handler.py
@@ -1,0 +1,120 @@
+"""
+Internal-invoke lambda — notifications_broadcast_fanout
+
+Sends one admin broadcast to every active user.
+
+WHY THIS IS ITS OWN LAMBDA AND NOT INLINE IN admin_broadcasts_create:
+fanning out to every user means a full scan of the users table plus one
+dispatch per user. Doing that inside the admin's request handler means the
+admin waits on it, and — worse — it silently gets slower as the user base
+grows until one day it hits the API Gateway timeout with no feedback at all.
+Async invoke moves it off the request path entirely; the admin's broadcast is
+persisted and returned immediately either way.
+
+Event shape:
+    {
+        "broadcastId": "<uuid>",
+        "title": "...",
+        "body":  "..."
+    }
+
+Returns: {"notified": n, "skipped": s}
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.constants import USERS_TABLE_NAME
+from lambdas.common.dynamo_helpers import full_table_scan
+from lambdas.common.errors import handle_errors, ValidationError
+from lambdas.common.logger import get_logger
+from lambdas.common.notify import notify
+from lambdas.common.utility_helpers import success_response
+
+log = get_logger(__file__)
+
+HANDLER = "notifications_broadcast_fanout"
+
+#: Ceiling per invocation. Far above any realistic user count for this app; it
+#: exists so a runaway scan degrades into a truncated send with a loud log
+#: rather than a timeout that delivers nothing.
+MAX_RECIPIENTS = 5000
+
+
+def _coerce_event(event: dict) -> dict:
+    """
+    Accept both the API Gateway shape and a direct-invoke payload.
+
+    THE SUBTLETY THAT BIT THIS BEFORE: the direct-invoke payload has its OWN
+    `body` key — the notification's body text — which collides with API
+    Gateway's `body` envelope. The previous version saw a string under `body`,
+    tried to `json.loads` it, failed on ordinary prose like
+    "2 friends have queued Midnight City", and returned `{}`. Every direct
+    invoke was then rejected as missing its required fields, so nothing ever
+    sent.
+
+    Only unwrap when the string actually parses to a dict. Prose does not.
+    """
+    if not isinstance(event, dict):
+        return {}
+    raw = event.get("body")
+    if isinstance(raw, str):
+        import json
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            return event
+        # A parsed scalar means `body` was the notification text, not an
+        # envelope — keep the original event.
+        return parsed if isinstance(parsed, dict) else event
+    return event
+
+
+@handle_errors(HANDLER)
+def handler(event, context):
+    payload = _coerce_event(event)
+
+    title = payload.get("title")
+    body_text = payload.get("body")
+    broadcast_id = payload.get("broadcastId")
+
+    if not title or not body_text:
+        raise ValidationError(
+            message="title and body are required",
+            handler=HANDLER,
+            function="handler",
+            field="title",
+        )
+
+    users: list[dict[str, Any]] = full_table_scan(USERS_TABLE_NAME) or []
+
+    notified = 0
+    skipped = 0
+
+    for user in users:
+        email = user.get("email")
+        # Same `active` gate cron_favorites_reminder uses — there is no separate
+        # broadcast enrolment flag, and inventing one here would diverge.
+        if not email or not user.get("active"):
+            skipped += 1
+            continue
+
+        if notified >= MAX_RECIPIENTS:
+            log.warning(f"broadcast fan-out capped at {MAX_RECIPIENTS}")
+            break
+
+        # notify() is fail-open per recipient, so one bad row cannot strand the
+        # rest of the broadcast.
+        notify(
+            "broadcast",
+            email,
+            broadcast_title=title,
+            broadcast_body=body_text,
+            broadcast_id=broadcast_id,
+        )
+        notified += 1
+
+    stats = {"notified": notified, "skipped": skipped}
+    log.info(f"broadcast fan-out {broadcast_id}: {stats}")
+    return success_response(stats, is_api=False)

--- a/lambdas/notifications_send/handler.py
+++ b/lambdas/notifications_send/handler.py
@@ -43,14 +43,32 @@ HANDLER = "notifications_send"
 
 
 def _coerce_event(event: dict) -> dict:
-    """Accept both API Gateway shape and direct-invoke payload shape."""
-    if isinstance(event, dict) and isinstance(event.get("body"), str):
+    """
+    Accept both the API Gateway shape and a direct-invoke payload.
+
+    THE SUBTLETY THAT BIT THIS BEFORE: the direct-invoke payload has its OWN
+    `body` key — the notification's body text — which collides with API
+    Gateway's `body` envelope. The previous version saw a string under `body`,
+    tried to `json.loads` it, failed on ordinary prose like
+    "2 friends have queued Midnight City", and returned `{}`. Every direct
+    invoke was then rejected as missing its required fields, so nothing ever
+    sent.
+
+    Only unwrap when the string actually parses to a dict. Prose does not.
+    """
+    if not isinstance(event, dict):
+        return {}
+    raw = event.get("body")
+    if isinstance(raw, str):
         import json
         try:
-            return json.loads(event["body"])
+            parsed = json.loads(raw)
         except Exception:
-            return {}
-    return event or {}
+            return event
+        # A parsed scalar means `body` was the notification text, not an
+        # envelope — keep the original event.
+        return parsed if isinstance(parsed, dict) else event
+    return event
 
 
 @handle_errors(HANDLER)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ _TEST_ENV_VARS = {
     "NOTIFICATION_PENDING_TABLE_NAME": "xomify-notification-pending-test",
     "NOTIFICATIONS_TABLE_NAME": "xomify-notifications-test",
     "NOTIFICATIONS_SEND_FUNCTION_NAME": "xomify-notifications-send-test",
+    "BROADCAST_FANOUT_FUNCTION_NAME": "xomify-notifications-broadcast-fanout-test",
 }
 for key, value in _TEST_ENV_VARS.items():
     os.environ.setdefault(key, value)

--- a/tests/test_broadcast_fanout.py
+++ b/tests/test_broadcast_fanout.py
@@ -1,0 +1,132 @@
+"""
+Tests for the admin-broadcast fan-out (B4 leftover).
+
+The point of this lambda is that the work happens OFF the admin's request
+path, so the two things worth guarding are: the request handler dispatches
+asynchronously and never blocks, and the fan-out itself respects the same
+`active` gate every other user-wide send uses.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _admin_event(body):
+    return {
+        "body": json.dumps(body),
+        "requestContext": {"authorizer": {"email": "admin@example.com"}},
+    }
+
+
+# ── Fan-out lambda ──────────────────────────────────────────────────────
+
+@patch("lambdas.notifications_broadcast_fanout.handler.notify")
+@patch("lambdas.notifications_broadcast_fanout.handler.full_table_scan")
+def test_fanout_notifies_only_active_users(mock_scan, mock_notify, mock_context):
+    from lambdas.notifications_broadcast_fanout.handler import handler
+
+    mock_scan.return_value = [
+        {"email": "a@e.com", "active": True},
+        {"email": "b@e.com", "active": False},   # inactive -> skipped
+        {"active": True},                         # no email -> skipped
+        {"email": "c@e.com", "active": True},
+    ]
+
+    response = handler({"broadcastId": "b1", "title": "T", "body": "B"}, mock_context)
+    # is_api=False, so `body` is the raw dict rather than a JSON string.
+    data = response["body"]
+
+    assert data["notified"] == 2
+    assert data["skipped"] == 2
+    assert {c.args[1] for c in mock_notify.call_args_list} == {"a@e.com", "c@e.com"}
+    assert mock_notify.call_args.args[0] == "broadcast"
+
+
+@patch("lambdas.notifications_broadcast_fanout.handler.notify")
+@patch("lambdas.notifications_broadcast_fanout.handler.full_table_scan")
+def test_fanout_is_capped(mock_scan, mock_notify, mock_context):
+    """A runaway scan should truncate loudly, not time out delivering nothing."""
+    from lambdas.notifications_broadcast_fanout.handler import handler, MAX_RECIPIENTS
+
+    mock_scan.return_value = [
+        {"email": f"u{i}@e.com", "active": True} for i in range(MAX_RECIPIENTS + 20)
+    ]
+    handler({"broadcastId": "b1", "title": "T", "body": "B"}, mock_context)
+    assert mock_notify.call_count == MAX_RECIPIENTS
+
+
+@patch("lambdas.notifications_broadcast_fanout.handler.full_table_scan")
+def test_fanout_requires_title_and_body(mock_scan, mock_context):
+    from lambdas.notifications_broadcast_fanout.handler import handler
+
+    response = handler({"broadcastId": "b1"}, mock_context)
+    assert response["statusCode"] == 400
+
+
+# ── Request handler dispatches, never blocks ────────────────────────────
+
+@patch("lambdas.admin_broadcasts_create.handler._lambda_client")
+@patch("lambdas.admin_broadcasts_create.handler.put_broadcast")
+@patch("lambdas.admin_broadcasts_create.handler.require_admin")
+def test_create_dispatches_fanout_asynchronously(mock_admin, mock_put, mock_client, mock_context):
+    from lambdas.admin_broadcasts_create.handler import handler
+
+    mock_admin.return_value = "admin@example.com"
+    handler(_admin_event({"title": "Heads up", "body": "New release", "activeUntil": None}), mock_context)
+
+    assert mock_client.invoke.call_count == 1
+    kwargs = mock_client.invoke.call_args.kwargs
+    # Event, not RequestResponse — the admin must not wait on a users-table scan.
+    assert kwargs["InvocationType"] == "Event"
+    payload = json.loads(kwargs["Payload"].decode("utf-8"))
+    assert payload["title"] == "Heads up"
+
+
+@patch("lambdas.admin_broadcasts_create.handler._lambda_client")
+@patch("lambdas.admin_broadcasts_create.handler.put_broadcast")
+@patch("lambdas.admin_broadcasts_create.handler.require_admin")
+def test_create_survives_a_failed_dispatch(mock_admin, mock_put, mock_client, mock_context):
+    """The broadcast row is already persisted — a failed push must not 500 it."""
+    from lambdas.admin_broadcasts_create.handler import handler
+
+    mock_admin.return_value = "admin@example.com"
+    mock_client.invoke.side_effect = RuntimeError("lambda unavailable")
+
+    response = handler(_admin_event({"title": "T", "body": "B", "activeUntil": None}), mock_context)
+    assert response["statusCode"] == 200
+
+
+# ── Envelope-collision regression ───────────────────────────────────────
+
+def test_coerce_event_does_not_eat_a_prose_body(mock_context):
+    """
+    REGRESSION. The direct-invoke payload has its own `body` key — the
+    notification's text — which collides with API Gateway's `body` envelope.
+    The original `_coerce_event` saw a string, tried `json.loads` on ordinary
+    prose, failed, and returned `{}`. Every direct invoke was then rejected as
+    missing required fields, so NOTHING EVER SENT.
+    """
+    from lambdas.notifications_send.handler import _coerce_event
+
+    event = {
+        "kind": "queue_threshold",
+        "email": "r@e.com",
+        "title": "Your share is heating up",
+        "body": "3 friends have queued Midnight City",
+    }
+    assert _coerce_event(event) == event
+
+
+def test_coerce_event_still_unwraps_a_real_api_gateway_envelope(mock_context):
+    from lambdas.notifications_send.handler import _coerce_event
+
+    inner = {"kind": "digest", "email": "r@e.com", "title": "T", "body": "B"}
+    assert _coerce_event({"body": json.dumps(inner)}) == inner
+
+
+def test_coerce_event_ignores_a_json_scalar_body(mock_context):
+    """`body: "42"` parses as JSON but is text, not an envelope."""
+    from lambdas.notifications_send.handler import _coerce_event
+
+    event = {"kind": "digest", "email": "r@e.com", "title": "T", "body": "42"}
+    assert _coerce_event(event) == event


### PR DESCRIPTION
Completes the registry: `broadcast` was the one notification kind with no producer.

## The fan-out is its own lambda

Reaching every user means a full users-table scan plus one dispatch each. Inside the admin's request handler the admin waits on all of it — and it gets quietly slower as the user base grows until it hits the gateway timeout with no feedback at all.

Async invoke moves it off the request path. The broadcast row is persisted and returned either way, so a failed push never costs the broadcast itself.

---

## 🐛 Live bug fixed — pre-existing, and it means pushes have never sent

`notifications_send._coerce_event` saw a string under `body` and tried `json.loads` on it:

```python
if isinstance(event.get("body"), str):
    try: return json.loads(event["body"])
    except Exception: return {}
```

But the direct-invoke payload's **own `body` key is the notification text**, which collides with API Gateway's `body` envelope. Parsing `"3 friends have queued Midnight City"` as JSON throws, the handler returns `{}`, and every direct invoke is rejected as missing its required fields.

**Queue-threshold pushes and the weekly digest have never actually sent.** And every one of the 16 new kinds would have failed identically, since `notify()` sends the same shape.

Now it only unwraps when the string parses to a **dict** — prose and JSON scalars keep the original event. Three regression tests cover it.

---

## ⚠️ Baseline correction

I reported this repo's test baseline twice and was wrong both times, in both cases because of my own environment rather than your code:

| I said | Actual cause | Reality |
|--------|-------------|---------|
| "50 failed / 74 errors" | local Python 3.9 vs the repo's 3.10+ union syntax | not real |
| "14 failed / 600 passed" | `pydantic` missing from my ephemeral env | **660 passed, 0 failed** |

**Your backend suite is fully green.** The working invocation, worth adding to the README:

```
uv run --python 3.13 --with pytest --with boto3 --with requests --with aiohttp \
       --with pyjwt --with cryptography --with pydantic python -m pytest -q
```

(`--with-requirements requirements.txt` fails — the pinned `cffi` won't compile against 3.13 headers.)

**668 passed with the 8 tests added here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)